### PR TITLE
Fixes a design flaw in the method handling for RegisteredFunctions

### DIFF
--- a/examples/example_pasrer.py
+++ b/examples/example_pasrer.py
@@ -4,9 +4,8 @@ from typing import Optional
 import dateutil.parser
 import requests
 
-from src.parser.html_parser import BaseParser
-from src.parser.html_parser import register_attribute
-from src.parser.html_parser import strip_nodes_to_text
+from src.parser.html_parser import BaseParser, register_attribute
+from src.parser.html_parser.utility import strip_nodes_to_text
 
 
 class MDRParser(BaseParser):

--- a/src/library/de_de/die_welt_parser.py
+++ b/src/library/de_de/die_welt_parser.py
@@ -4,7 +4,7 @@ from typing import Optional, List
 import dateutil.parser
 import lxml.html
 
-from src.parser.html_parser.base_parser import BaseParser, register_attribute
+from src.parser.html_parser import BaseParser, register_attribute
 from src.parser.html_parser.utility import strip_nodes_to_text
 from stream.utils import listify
 

--- a/src/library/de_de/mdr_parser.py
+++ b/src/library/de_de/mdr_parser.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import dateutil.parser
 
-from src.parser.html_parser.base_parser import BaseParser, register_attribute
+from src.parser.html_parser import BaseParser, register_attribute
 from src.parser.html_parser.utility import strip_nodes_to_text
 
 

--- a/src/parser/html_parser/__init__.py
+++ b/src/parser/html_parser/__init__.py
@@ -1,1 +1,1 @@
-from .base_parser import BaseParser
+from .base_parser import BaseParser, register_attribute, register_function


### PR DESCRIPTION
This fixes a design flaw in the `__get__` method for `RegisteredFunstins`:

prev: 
The instance was attached to the original, unbound object in the class it was wrapped to thus one had to copy the object manually to keep a reference to the bound object. This contradicts methode behavior.

current:
`__get__` now returns a bound copy of the object once an instance is given and the object requested is unbound else we return the unbound object