### PR TITLE
Reworked cache for BaseParser

### DIFF
--- a/examples/example_crawler.py
+++ b/examples/example_crawler.py
@@ -20,5 +20,5 @@ if __name__ == '__main__':
         
     """
 
-    for article in crawler.crawl(max_articles=100):
+    for article in crawler.crawl(max_articles=100, error_handling='raise'):
         print(article.pprint(exclude=['html']))

--- a/src/library/de_de/die_welt_parser.py
+++ b/src/library/de_de/die_welt_parser.py
@@ -13,7 +13,7 @@ class DieWeltParser(BaseParser):
 
     @register_attribute
     def plaintext(self) -> Optional[str]:
-        doc: lxml.html.HtmlElement = self.cache['doc']
+        doc: lxml.html.HtmlElement = self.precomputed.doc
         selector: str = (
             "body .c-summary > div, "
             "body .c-article-text > p"
@@ -23,21 +23,21 @@ class DieWeltParser(BaseParser):
 
     @register_attribute
     def authors(self) -> List[str]:
-        if author_entries := self.ld().get('author'):
+        if author_entries := self.precomputed.ld.get('author'):
             return [entry['name'] for entry in listify(author_entries) if entry.get('name')]
         else:
             return []
 
     @register_attribute
     def publishing_date(self) -> Optional[datetime.datetime]:
-        if iso_date_str := self.ld().get('datePublished'):
+        if iso_date_str := self.precomputed.ld.get('datePublished'):
             return dateutil.parser.parse(iso_date_str)
 
     @register_attribute
     def title(self):
-        return self.ld().get('headline')
+        return self.precomputed.ld.get('headline')
 
     @register_attribute
     def topics(self) -> List[str]:
-        if keyword_str := self.meta().get('keywords'):
+        if keyword_str := self.precomputed.meta.get('keywords'):
             return keyword_str.split(', ')

--- a/src/library/de_de/mdr_parser.py
+++ b/src/library/de_de/mdr_parser.py
@@ -11,25 +11,25 @@ class MDRParser(BaseParser):
 
     @register_attribute
     def plaintext(self) -> Optional[str]:
-        doc = self.cache['doc']
+        doc = self.precomputed.doc
         if nodes := doc.cssselect('div.paragraph'):
             return strip_nodes_to_text(nodes)
 
     @register_attribute
     def topics(self) -> Optional[str]:
-        if topics := self.meta().get('news_keywords'):
+        if topics := self.precomputed.meta.get('news_keywords'):
             return topics.split(', ')
 
     @register_attribute
     def publishing_date(self) -> Optional[datetime.datetime]:
-        if date_string := self.ld().get('datePublished'):
+        if date_string := self.precomputed.ld.get('datePublished'):
             return dateutil.parser.parse(date_string)
 
     @register_attribute
     def authors(self) -> str:
-        if author_dict := self.ld().get('author'):
+        if author_dict := self.precomputed.ld.get('author'):
             return author_dict.get('name')
 
     @register_attribute
     def title(self) -> Optional[str]:
-        return self.ld().get('headline')
+        return self.precomputed.ld.get('headline')


### PR DESCRIPTION
Hey @Weyaaron, i finally managed to implement your [suggestions ](https://github.com/MaxDall/CCNewsCrawler/pull/11)

This incorporates the former `cache` into a dataclass called `Precomputed` present in the `BaseParser` under attribute `precomputed` based on @Weyaaron's suggestions.