### PR TITLE
Fix a bug in Article __str__ method

### DIFF
--- a/src/pipeline/articles.py
+++ b/src/pipeline/articles.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from textwrap import TextWrapper, dedent
 from typing import Any, Callable, List, Dict, Optional
+from colorama import Fore, Style
 
 
 @dataclass(frozen=True)
@@ -65,12 +66,12 @@ class Article(BaseArticle):
         # the subsequent indent here is a bit wacky, but textwrapper.dedent won't work with tabs, so we have to use
         # whitespaces instead.
         text_wrapper = TextWrapper(width=100, max_lines=5, initial_indent='"', subsequent_indent='             ')
-        wrapped_title = text_wrapper.fill(self.title)
-        wrapped_plaintext = text_wrapper.fill(self.plaintext)
+        wrapped_title = text_wrapper.fill(self.title or f"{Fore.RED}--missing title--{Style.RESET_ALL}")
+        wrapped_plaintext = text_wrapper.fill(self.plaintext or f"{Fore.RED}--missing plaintext--{Style.RESET_ALL}")
 
         text = f"""
             {wrapped_title}"
-                - by {', '.join(self.authors) if self.authors else 'unknown'}
+                - by {', '.join(self.authors) if self.authors else f"{Fore.RED}--missing authors--{Style.RESET_ALL}"}
             
             {wrapped_plaintext}"
             


### PR DESCRIPTION
This fixes a bug with missing members in the `Article.__str__` method as well as adds coloured error messages if something is missing.

![image](https://user-images.githubusercontent.com/46926170/211164039-443fc370-b67e-479d-bcad-c26124efde8b.png)
