### PR TITLE
Add BF traversal for LinkedData

### DIFF
--- a/src/parser/html_parser/base_parser.py
+++ b/src/parser/html_parser/base_parser.py
@@ -138,7 +138,7 @@ class LinkedData:
                 return default
         return tmp
 
-    def breadth_first_search(self, key: str, depth: int = None) -> Any:
+    def bf_search(self, key: str, depth: int = None) -> Any:
         """
         This is a classic BF search on the nested dicts representing the JSON-LD. <key> specifies the dict key to
         search, <depth> the depth level. If the depth level is set to None, this method will search through the whole


### PR DESCRIPTION
Since more and more parsers are added and the JSON-LD part of the html don't seem to follow a strict hierarchy other than structural defined by the JSON-LD specs, this PR aims to address issues that arise in the process.
It does so by introducing the following functions.

- `breadth_first_search` for `LinkedData`: This is a classic breadth first search through the LD with selectable depth on top.
- `get_value_by_key_path`: This aiims to be a more precise but error prone way to get specific values from the LD by defining a key path through a list of strings.