### PR TITLE
Rework parser utils

### DIFF
--- a/src/library/de_de/faz_parser.py
+++ b/src/library/de_de/faz_parser.py
@@ -2,8 +2,8 @@ import datetime
 from typing import Optional, List
 
 from src.parser.html_parser import BaseParser, register_attribute
-from src.parser.html_parser.utility import generic_plaintext_extraction_with_css, generic_date_extraction, \
-    generic_author_extraction, generic_topic_extraction
+from src.parser.html_parser.utility import generic_plaintext_extraction_with_css, generic_date_parsing, \
+    generic_author_parsing, generic_topic_parsing
 
 
 class FAZParser(BaseParser):
@@ -14,16 +14,16 @@ class FAZParser(BaseParser):
 
     @register_attribute
     def topics(self) -> Optional[List[str]]:
-        return generic_topic_extraction(self.precomputed.meta)
+        return generic_topic_parsing(self.precomputed.meta.get('keywords'))
 
     @register_attribute
     def publishing_date(self) -> Optional[datetime.datetime]:
-        return generic_date_extraction(self.precomputed.ld, "datePublished")
+        return generic_date_parsing(self.precomputed.ld.get('datePublished'))
 
     @register_attribute
     def authors(self) -> List[str]:
-        return generic_author_extraction(self.precomputed.meta, ['author'])
+        return generic_author_parsing(self.precomputed.meta.get('author'))
 
     @register_attribute
     def title(self) -> Optional[str]:
-        return self.meta().get('og:title')
+        return self.precomputed.meta.get('og:title')

--- a/src/library/de_de/focus_parser.py
+++ b/src/library/de_de/focus_parser.py
@@ -3,8 +3,8 @@ import re
 from typing import Optional, List, Match
 
 from src.parser.html_parser import BaseParser, register_attribute
-from src.parser.html_parser.utility import generic_plaintext_extraction_with_css, generic_author_extraction, \
-    generic_date_extraction
+from src.parser.html_parser.utility import generic_plaintext_extraction_with_css, generic_author_parsing, \
+    generic_date_parsing
 
 
 class FocusParser(BaseParser):
@@ -21,14 +21,14 @@ class FocusParser(BaseParser):
 
     @register_attribute
     def authors(self) -> List[str]:
-        author_names = generic_author_extraction(self.precomputed.ld, ["author"])
+        author_names = generic_author_parsing(self.precomputed.ld.get("author"))
         for i, name in enumerate(author_names):
             author_names[i] = re.sub(self._author_substitution_pattern, '', name)
         return author_names
 
     @register_attribute
     def publishing_date(self) -> Optional[datetime.datetime]:
-        return generic_date_extraction(self.precomputed.ld)
+        return generic_date_parsing(self.precomputed.ld.get('datePublished'))
 
     @register_attribute
     def title(self):

--- a/src/parser/html_parser/utility.py
+++ b/src/parser/html_parser/utility.py
@@ -1,7 +1,6 @@
 import re
 from datetime import datetime
-from typing import Dict, List, Optional, Any
-from datetime import datetime
+from typing import Any, Union
 from typing import Dict, List, Optional
 
 import dateutil
@@ -35,26 +34,24 @@ def strip_nodes_to_text(text_nodes: List) -> Optional[str]:
     return "\n\n".join(([re.sub(r'\n+', ' ', node.text_content()) for node in text_nodes])).strip()
 
 
-def generic_author_extraction(source: HasGet, key_list: List[str]) -> List[str]:
-    authors = _get_nested_value_with_key_path_as_list(source, key_list)
-
-    if not authors:
+def generic_author_parsing(value: Union[str, dict, List[dict]]) -> List[str]:
+    if not value:
         return []
 
-    if isinstance(authors, str):
-        authors = [authors]
+    if isinstance(value, str):
+        authors = [value]
 
-    elif isinstance(authors, list):
-        authors = [name for author in authors if (name := author.get('name'))]
+    elif isinstance(value, list):
+        authors = [name for author in value if (name := author.get('name'))]
 
-    elif isinstance(authors, dict):
-        authors = [name] if (name := authors.get('name')) else []
+    elif isinstance(value, dict):
+        authors = [name] if (name := value.get('name')) else []
 
     else:
-        raise TypeError(f"Value '{authors}' in 'source' dict with key path '{' -> '.join(key_list)}' has an unsupported"
-                        f"type. Supported types are 'str, list, dict'")
+        raise TypeError(f"<value> '{value}' has an unsupported type {type(value)}. "
+                        f"Supported types are 'str, dict, List[dict]'")
 
-    return authors
+    return [name.strip() for name in authors]
 
 
 def generic_plaintext_extraction_with_css(doc, selector: str) -> Optional[str]:
@@ -62,13 +59,9 @@ def generic_plaintext_extraction_with_css(doc, selector: str) -> Optional[str]:
     return strip_nodes_to_text(nodes)
 
 
-def generic_topic_extraction(meta: Dict[str, any], key_word: str = "keywords", delimiter: str = ',') -> List[str]:
-    if keyword_str := meta.get(key_word):
-        return [keyword.strip() for keyword in keyword_str.split(delimiter)]
-    return []
+def generic_topic_parsing(keyword_str: str, delimiter: str = ',') -> List[str]:
+    return [keyword.strip() for keyword in keyword_str.split(delimiter)] if keyword_str else []
 
 
-def generic_date_extraction(meta, key_word: str = "datePublished") -> Optional[datetime]:
-    if date_str := meta.get(key_word):
-        return dateutil.parser.parse(date_str)
-    return None
+def generic_date_parsing(date_str: str) -> Optional[datetime]:
+    return dateutil.parser.parse(date_str) if date_str else None


### PR DESCRIPTION
While working on some parsers i noticed that the `key` or `key_list` parameter in most extraction functions leeds to some weird lines of code. Since the structure of the JSON-LD differs for most parsers, we have to specify the value location as well as the key, because the previous methods tried to extract and parse at the same time. Imo it's much cleaner if the user takes care of the key or value part himself, and the utility functions solely purpose is to parse the provided value.

``` python
# before
@register_attribute
    def publishing_date(self) -> Optional[datetime.datetime]:
        return generic_date_extraction(self.precomputed.ld.get("mainEntity"), "date_Published")

# after
@register_attribute
    def publishing_date(self) -> Optional[datetime.datetime]:
        return generic_date_parsing(self.precomputed.ld.breadth_first_search("date_published"))
        #alternative
        return generic_date_parsing(self.precomputed.ld.get_value_by_key_path(["mainEntity", "date_Published"]))
```

Of course the above example is artificial and the benefits will only be shown after #40 gets greenlighted, but i think it shows the purpose of this PR. 

This PR also addresses some issues in the MDR parser as well as introducing parsing utility functions to the same.