### PR TITLE
Fix a bug in bf_search

### DIFF
--- a/src/parser/html_parser/base_parser.py
+++ b/src/parser/html_parser/base_parser.py
@@ -196,7 +196,7 @@ class LinkedData:
                     if isinstance(node, dict) and (value := node.get(key)):
                         return value
                     new.extend(v for v in node.values() if isinstance(v, dict))
-                return search_recursive(new, current_depth + 1)
+                return search_recursive(new, current_depth + 1) if new else None
 
         return search_recursive(self._ld_by_type.values(), 0)
 


### PR DESCRIPTION
This fixes a crucial buf in the newly added `bf_search` were the programm runs into an endless recursion if the searched key is not present.