### PR TITLE
Change default value for pipeline and scraper

### DIFF
--- a/src/scraping/pipeline.py
+++ b/src/scraping/pipeline.py
@@ -29,7 +29,7 @@ class AutoPipeline:
     def run(self,
             max_articles: int = None,
             restrict_sources_to: Literal['rss', 'sitemap', 'news'] = None,
-            error_handling: Literal['suppress', 'catch', 'raise'] = 'raise') -> Generator[Article, None, None]:
+            error_handling: Literal['suppress', 'catch', 'raise'] = 'suppress') -> Generator[Article, None, None]:
 
         scraper: List[Scraper] = []
         for spec in self.publishers:

--- a/src/scraping/scraper.py
+++ b/src/scraping/scraper.py
@@ -14,7 +14,7 @@ class Scraper:
         self.crawler = list(sources)
         self.parser = parser
 
-    def scrape(self, error_handling: Literal['suppress', 'catch', 'raise'] = 'raise'):
+    def scrape(self, error_handling: Literal['suppress', 'catch', 'raise']):
         for crawler in self.crawler:
             for article_source in crawler.crawl():
 


### PR DESCRIPTION
This changes the default `error_handling` parameter value for Autopipeline tu `suppress` and removes it for the scraper.

closes #63 