### PR TITLE
Use dummy `User-Agent` for requests

### DIFF
--- a/src/scraping/source.py
+++ b/src/scraping/source.py
@@ -19,7 +19,7 @@ class Source(Iterable[str], ABC):
     request_header = {"user-agent": "Mozilla/5.0"}
 
     def __init__(
-            self, publisher: Optional[str], delay: Optional[Callable[[], float]] = None, max_threads: Optional[int] = 10
+        self, publisher: Optional[str], delay: Optional[Callable[[], float]] = None, max_threads: Optional[int] = 10
     ):
         self.publisher = publisher
         self.delay = delay
@@ -124,11 +124,11 @@ class _ArchiveDecompressor:
 
 class SitemapSource(Source):
     def __init__(
-            self,
-            sitemap: str,
-            publisher: str,
-            recursive: bool = True,
-            reverse: bool = False,
+        self,
+        sitemap: str,
+        publisher: str,
+        recursive: bool = True,
+        reverse: bool = False,
     ):
         super().__init__(publisher)
 


### PR DESCRIPTION
Since some sites require the `User-Agent` to be send with the header, this adds an empty `User-Agent` to the request headers.

Update:

- fundus now logs when a sitemap/rss_feed/article is throws a http error
- fixed a bug with `_ArchiveDecompressor`