### PR TITLE
Fix Article Title and Plaintext Printout for Empty Titles

### DIFF
--- a/src/scraping/article.py
+++ b/src/scraping/article.py
@@ -93,7 +93,7 @@ class Article(BaseArticle):
         title_wrapper = TextWrapper(width=80, max_lines=1, initial_indent="")
         text_wrapper = TextWrapper(width=80, max_lines=2, initial_indent="", subsequent_indent="          ")
         wrapped_title = title_wrapper.fill(
-            f'{Fore.RED}--missing title--{Style.RESET_ALL}' if self.title is None else self.title.strip()
+            f"{Fore.RED}--missing title--{Style.RESET_ALL}" if self.title is None else self.title.strip()
         )
         wrapped_plaintext = text_wrapper.fill(
             f"{Fore.RED}--missing plaintext--{Style.RESET_ALL}" if self.plaintext is None else self.plaintext.strip()


### PR DESCRIPTION
Before this change, `"--missing title--"` would be displayed for the empty title. With this PR, the empty title `""` is valid. The same applies to the plaintext.