### PR TITLE
Expand Meta to Span over the Entire HTML

### DIFF
--- a/src/parser/html_parser/utility.py
+++ b/src/parser/html_parser/utility.py
@@ -92,7 +92,7 @@ def extract_article_body_with_selector(
 
 
 def get_meta_content(tree: lxml.html.HtmlElement) -> Dict[str, str]:
-    meta_node_selector = "head > meta[name], head > meta[property]"
+    meta_node_selector = "meta[name], meta[property]"
     meta_nodes = tree.cssselect(meta_node_selector)
     meta: Dict[str, str] = {}
     for node in meta_nodes:


### PR DESCRIPTION
This PR expands the meta css selector of the `get_meta_content` function to no longer be restricted to the head but cover the entire HTML. Some articles from publishers, e.g. CNBC, contain meta information, e.g. the topics, in the HTML body. Without this change the information would be harder to access.

Example:

```python
import lxml.html
import requests

from src.parser.html_parser.utility import get_meta_content

url: str = "https://www.cnbc.com/2023/03/28/salt-paradox-why-its-essential-and-a-threat-to-the-environment.html"
html: str = requests.get(url).text

tree: lxml.html.HtmlElement = lxml.html.document_fromstring(html)

# Old: None
# New: Climate,Morningstar Inc,Business,U.S. Economy,Economy,Politics,Markets,Compass Minerals International Inc,United States,Water treatment,Video First,business news
print(get_meta_content(tree).get("keywords"))
```

