### PR TITLE
Discourage the use of LinkedData.get()

### DIFF
--- a/src/parser/html_parser/data.py
+++ b/src/parser/html_parser/data.py
@@ -48,8 +48,10 @@ class LinkedData:
 
         if not _displayed_deprecation_info:
             _displayed_deprecation_info = True
-            basic_logger.warning("LinkedDate.get() will be deprecated in the future. Use .get_value_by_key_path() "
-                                 "or .bf_search() instead")
+            basic_logger.warning(
+                "LinkedDate.get() will be deprecated in the future. Use .get_value_by_key_path() "
+                "or .bf_search() instead"
+            )
         for name, ld in sorted(self._ld_by_type.items(), key=lambda t: t[0]):
             if not name:
                 raise NotImplementedError("Currently this function does not support lds without types")


### PR DESCRIPTION
For now this will display a one time warning if `LinkedData.get()` is used. In the future the function will raise an error and will be removed at some point.