### PR TITLE
Add redirect log massage

### DIFF
--- a/src/scraping/source.py
+++ b/src/scraping/source.py
@@ -47,7 +47,7 @@ class Source(Iterable[str], ABC):
                     basic_logger.info(f"Skipped {url} because of {error}")
                     return None
                 if history := response.history:
-                    basic_logger.info(f"Got redirected {len(history)} times from {url} -> {response.url}")
+                    basic_logger.info(f"Got redirected {len(history)} time(s) from {url} -> {response.url}")
                 article_source = ArticleSource(
                     url=response.url,
                     html=response.text,


### PR DESCRIPTION
This adds a log message to `INFO` level when the requested URL got redirected:
``` console
2023-03-31 00:31:44,909 - root - INFO - Got redirected 1 time(s) from https://www.zeit.de/news/2023-03/31/tagessieg-fuer-clayton-darts-serie-von-price-endet-in-berlin -> https://www.zeit.de/zustimmung?url=https%3A%2F%2Fwww.zeit.de%2Fnews%2F2023-03%2F31%2Ftagessieg-fuer-clayton-darts-serie-von-price-endet-in-berlin
```