### PR TITLE
Add an assertion if the JSON covers all required attributes

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -57,7 +57,7 @@ class TestParser:
         parser = publisher.parser()
 
         # enforce test coverage
-        attrs_required_to_cover = {"title", 'authors', 'topics'}
+        attrs_required_to_cover = {"title", "authors", "topics"}
         supported_attrs = set(parser.attributes().names)
         missing_attrs = attrs_required_to_cover & supported_attrs - set(comparative_data.keys())
         assert not missing_attrs, f"Test JSON does not cover the following attribute(s): {missing_attrs}"


### PR DESCRIPTION
This adds an assertion to `test_parsing` which checks if the required attributes - set with `attrs_required_to_cover` - are covered by the JSON. This also makes the message of the annotation test more readable.