### PR TITLE
Adds some more mypy settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ module = "feedparser.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-# missing type stubs for feedparser
 module = "tests.*"
 disallow_untyped_defs = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,31 @@ requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]
-check_untyped_defs = true
+disallow_untyped_defs = true
+disallow_any_unimported = true
 disallow_any_generics = true
-ignore_missing_imports = true
-no_implicit_optional = true
-show_error_codes = true
-strict_equality = true
+check_untyped_defs = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
+warn_unused_ignores = true
 no_implicit_reexport = true
+no_implicit_optional = true
+show_error_codes = true
+strict_equality = true
+
+
+[[tool.mypy.overrides]]
+# missing type stubs for feedparser
+module = "feedparser.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# missing type stubs for feedparser
+module = "tests.*"
+disallow_untyped_defs = false
+
 
 [tool.black]
 line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ install_requires =
     colorama~=0.4.4
 python_requires = >=3.8
 zip_safe = no
+include_package_data = True
+
 
 [options.extras_require]
 dev =
@@ -38,3 +40,6 @@ dev =
     types-python-dateutil~=2.8.19.10
     types-requests~=2.28.11.15
     types-colorama~=0.4.15.8
+
+[options.package_data]
+fundus = py.typed

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -136,7 +136,7 @@ class LinkedDataMapping:
         :return: The content of the first matched key or None
         """
 
-        def search_recursive(nodes: Iterable[LDMappingValueT], current_depth: int):
+        def search_recursive(nodes: Iterable[LDMappingValueT], current_depth: int) -> Optional[Any]:
             if current_depth == depth:
                 return None
             else:
@@ -152,7 +152,7 @@ class LinkedDataMapping:
 
         return search_recursive(self.__dict__.values(), 0) or default
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"LD containing '{', '.join(content)}'" if (content := self.__dict__.keys()) else "Empty LD"
 
 
@@ -171,7 +171,7 @@ class TextSequence(Sequence[str]):
     def __getitem__(self, s: slice) -> "TextSequence":
         ...
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: Union[int, slice]) -> Union[str, "TextSequence"]:
         return self._data[i] if isinstance(i, int) else type(self)(self._data[i])
 
     def __len__(self) -> int:
@@ -194,23 +194,21 @@ class TextSequenceTree(ABC):
         return self.as_text_sequence().text(join_on)
 
     def df_traversal(self) -> Iterable[TextSequence]:
-        def recursion(o: object):
+        def recursion(o: object) -> Iterator[TextSequence]:
             if isinstance(o, TextSequence):
                 yield o
             elif isinstance(o, Collection):
                 for el in o:
                     yield from el
-            else:
-                yield o
 
         for value in self:
             yield from recursion(value)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         field_values = [getattr(self, f.name) for f in fields(self)]
         yield from field_values
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.text()
 
 

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -181,7 +181,7 @@ def generic_author_parsing(
     return [name.strip() for name in authors]
 
 
-def generic_text_extraction_with_css(doc, selector: XPath) -> Optional[str]:
+def generic_text_extraction_with_css(doc: lxml.html.HtmlElement, selector: XPath) -> Optional[str]:
     nodes = selector(doc)
     return strip_nodes_to_text(nodes)
 

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -13,14 +13,14 @@ class PublisherSpec:
     sitemaps: List[str] = field(default_factory=list)
     news_map: Optional[str] = field(default=None)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not (self.rss_feeds or self.sitemaps or self.news_map):
             raise ValueError("Publishers must at least define either an rss-feed, sitemap or news_map to crawl")
 
 
 @unique
 class PublisherEnum(Enum):
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> "PublisherEnum":
         value = len(cls.__members__) + 1
         obj = object.__new__(cls)
         obj._value_ = value
@@ -56,12 +56,9 @@ class PublisherEnum(Enum):
         attrs_set = set(attrs)
         spec: PublisherEnum
         for spec in list(cls):
-            if attrs_set.issubset(spec.parser.attributes().names) and spec.supports(source_type):
+            if attrs_set.issubset(spec.parser.get_attributes().names) and spec.supports(source_type):
                 matched.append(spec)
         return matched
-
-    def __get__(self, instance, owner):
-        return self
 
 
 class CollectionMeta(type):

--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -48,7 +48,7 @@ class Article:
     def __getattr__(self, item: object) -> Any:
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
 
-    def __str__(self):
+    def __str__(self) -> str:
         # the subsequent indent here is a bit wacky, but textwrapper.dedent won't work with tabs, so we have to use
         # whitespaces instead.
         title_wrapper = TextWrapper(width=80, max_lines=1, initial_indent="")

--- a/src/fundus/scraping/pipeline.py
+++ b/src/fundus/scraping/pipeline.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List, Literal, Optional, Set, Tuple, Type, Union
+from typing import Iterable, Iterator, List, Literal, Optional, Set, Tuple, Type, Union
 
 import more_itertools
 
@@ -34,7 +34,7 @@ class Pipeline:
 
 
 class Crawler:
-    def __init__(self, *publishers: Union[PublisherEnum, Type[PublisherEnum]]):
+    def __init__(self, *publishers: PublisherEnum):
         if not publishers:
             raise ValueError("param <publishers> of <Crawler.__init__> has to be non empty")
         nested_publisher = [listify(publisher) for publisher in publishers]

--- a/src/fundus/scraping/source.py
+++ b/src/fundus/scraping/source.py
@@ -97,7 +97,7 @@ class StaticSource(Source):
         super().__init__(publisher)
         self.links = links
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         yield from self.links
 
 
@@ -118,7 +118,7 @@ class RSSSource(Source):
 
 
 class _ArchiveDecompressor:
-    def __init__(self):
+    def __init__(self) -> None:
         self.archive_mapping: Dict[str, Callable[[bytes], bytes]] = {"application/x-gzip": self._decompress_gzip}
 
     @staticmethod
@@ -153,7 +153,7 @@ class SitemapSource(Source):
         self.reverse = reverse
         self._decompressor = _ArchiveDecompressor()
 
-    def config(self, recursive: bool, reverse: bool):
+    def config(self, recursive: bool, reverse: bool) -> None:
         self.recursive = recursive
         self.reverse = reverse
 
@@ -164,7 +164,7 @@ class SitemapSource(Source):
             return None
 
     def __iter__(self) -> Iterator[str]:
-        def yield_recursive(url: str):
+        def yield_recursive(url: str) -> Iterator[str]:
             try:
                 response = session.get(url=url, headers=self.request_header)
                 response.raise_for_status()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -39,7 +39,7 @@ class TestCollection:
     def test_search(self, publisher_enum_with_news_map, parser_with_attr_title):
         publisher_enum_with_news_map.value.parser = parser_with_attr_title
 
-        assert (attrs := publisher_enum_with_news_map.value.parser.attributes().names)
+        assert (attrs := publisher_enum_with_news_map.value.parser.get_attributes().names)
         assert attrs == ["title"]
         assert len(publisher_enum_with_news_map.search(attrs)) == 1
         assert len(publisher_enum_with_news_map.search(["this_is_a_test"])) == 0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -40,22 +40,22 @@ def load_data(publisher: PublisherEnum) -> Dict[str, Any]:
 
 class TestBaseParser:
     def test_functions_iter(self, parser_with_function_test, parser_with_static_method):
-        assert len(BaseParser.functions()) == 0
-        assert len(parser_with_static_method.functions()) == 0
-        assert len(parser_with_function_test.functions()) == 1
-        assert parser_with_function_test.functions().names == ["test"]
+        assert len(BaseParser.get_functions()) == 0
+        assert len(parser_with_static_method.get_functions()) == 0
+        assert len(parser_with_function_test.get_functions()) == 1
+        assert parser_with_function_test.get_functions().names == ["test"]
 
     def test_attributes_iter(self, parser_with_attr_title, parser_with_static_method):
-        assert len(BaseParser.attributes()) == 0
-        assert len(parser_with_static_method.attributes()) == 0
-        assert len(parser_with_attr_title.attributes()) == 1
-        assert parser_with_attr_title.attributes().names == ["title"]
+        assert len(BaseParser.get_attributes()) == 0
+        assert len(parser_with_static_method.get_attributes()) == 0
+        assert len(parser_with_attr_title.get_attributes()) == 1
+        assert parser_with_attr_title.get_attributes().names == ["title"]
 
     def test_supported_unsupported(self, parser_with_validated_and_unvalidated):
         parser = parser_with_validated_and_unvalidated
-        assert len(parser.attributes()) == 2
-        assert parser.attributes().validated == [parser.validated]
-        assert parser.attributes().unvalidated == [parser.unvalidated]
+        assert len(parser.get_attributes()) == 2
+        assert parser.get_attributes().validated == [parser.validated]
+        assert parser.get_attributes().unvalidated == [parser.unvalidated]
 
 
 @pytest.mark.parametrize(
@@ -64,7 +64,7 @@ class TestBaseParser:
 class TestParser:
     def test_annotations(self, publisher: PublisherEnum) -> None:
         parser = publisher.parser
-        for attr in parser.attributes().validated:
+        for attr in parser.get_attributes().validated:
             if annotation := attribute_annotations_mapping[attr.__name__]:
                 assert (
                     attr.__annotations__.get("return") == annotation
@@ -79,7 +79,7 @@ class TestParser:
 
         # enforce test coverage
         attrs_required_to_cover = {"title", "authors", "topics"}
-        supported_attrs = set(parser.attributes().names)
+        supported_attrs = set(parser.get_attributes().names)
         missing_attrs = attrs_required_to_cover & supported_attrs - set(comparative_data.keys())
         assert not missing_attrs, f"Test JSON does not cover the following attribute(s): {missing_attrs}"
 


### PR DESCRIPTION
**Notice**: This PR is based on #170 and should be merged afterwards.

This PR adds some more `mypy` settings according to this [post](https://careers.wolt.com/en/blog/tech/professional-grade-mypy-configuration) suggested by @dobbersc.

Especially `disallow_untyped_defs` changes a lot, so this PR addresses all those requirements. 

There is still a problem with the `attribute` decorator, where the only possible solution I found till now would be to excessively overload the decorator with typings `overload` decorator. To avoid this, in my opinion, redundant typing, I excluded the decorator temporarily from `mypy`. Maybe someone comes up with a better solution in the future.

This also does the following:
- adds a `py.typed` file so `mypy` wont complain about fundus not being type hinted
- renames `BaseParser.attributes()` -> `BaseParser.get_attributes()`
- adds `property` `attributes` to `BaseParser`