### PR TITLE
Fix Incorrect Article Variable Name `author` -> `authors`

### DIFF
--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -17,7 +17,7 @@ class Article:
 
     # supported attributes as defined in the guidelines
     title: Optional[str] = None
-    author: List[str] = field(default_factory=list)
+    authors: List[str] = field(default_factory=list)
     body: Optional[ArticleBody] = None
     publishing_date: Optional[datetime] = None
     topics: List[str] = field(default_factory=list)


### PR DESCRIPTION
Before this change, the autocompleting for articles incorrectly displayed the `author` attribute which does not conform with our attribute guidelines. Now, its changed back to authors. This is a leftover from #155.