### PR TITLE
Clarify `PublisherSpecification` Parameters

### DIFF
--- a/docs/how_to_contribute.md
+++ b/docs/how_to_contribute.md
@@ -144,7 +144,7 @@ Thus `https://www.latimes.com/news-sitemap.xml` is a Google News Index Map.
 
 #### Finishing the Publisher Specification
 
-To complete the publisher specification, specify at least
+To complete the publisher specification, specify at least one of the following parameters:
 - `sitemaps` spanning the entire website, 
 - `news_map` referring to a Google News Sitemap or Google News Index Map or
 - `rss_feeds` covering recently published articles.


### PR DESCRIPTION
This PR clarifies that at least one of the source parameters should be added. From our external reviewer we found that the current wording is confusing:

> The doc says to add at least 3 links To complete the publisher specification, specify at least `sitemaps`, `news_map`, `rss_feeds` but since I only found one for news_map, I will proceed anyway.