### PR TITLE
Add `typing-extensions` to Dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     cssselect~=1.1.0
     feedparser~=6.0.10
     colorama~=0.4.4
+    typing-extensions >= 4.0, < 5.0
 python_requires = >=3.8
 zip_safe = no
 


### PR DESCRIPTION
When installing fundus in a production environment with `pip install .`, importing fundus with `import fundus` fails because the `typing-extensions` dependency is missing.

```console
ModuleNotFoundError: No module named 'typing_extensions'
```

On master, the only time `typing-extensions` is used is for a `TypeAlias` type-hint that is not required. Nevertheless, in #183 we rely on the `Self` type only available from `typing-extensions` for our supported Python versions. Therefore, I think is it better to include it as a dependency.

I've fixed the version according to the recommendation in their readme.

> Starting with version 4.0.0, typing_extensions uses [Semantic Versioning](https://semver.org/). The major version is incremented for all backwards-incompatible changes. Therefore, it's safe to depend on typing_extensions like this: typing_extensions >=x.y, <(x+1), where x.y is the first version that includes all features you need.