### PR TITLE
[GH-195] Changes the default of param <only_complete> to True

### DIFF
--- a/src/fundus/scraping/pipeline.py
+++ b/src/fundus/scraping/pipeline.py
@@ -56,7 +56,7 @@ class Crawler:
         max_articles: Optional[int] = None,
         restrict_sources_to: Optional[Literal["rss", "sitemap", "news"]] = None,
         error_handling: Literal["suppress", "catch", "raise"] = "suppress",
-        only_complete: Union[bool, ExtractionFilter] = False,
+        only_complete: Union[bool, ExtractionFilter] = True,
         batch_size: int = 10,
     ) -> Iterator[Article]:
         extraction_filter: Optional[ExtractionFilter]


### PR DESCRIPTION
This is done in order to de-noise extraction for the user at first sight. You can still set your desired level of article "noise" with `Requires`.

Closes #195

This also closes #181 for now since #195 decided on abandoning article classification based on HTML.