### PR TITLE
Add delimiter detection for `generic_author_parsing`

### DIFF
--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -71,10 +71,10 @@ class ParagraphNode(Node):
 
 
 def extract_article_body_with_selector(
-        doc: lxml.html.HtmlElement,
-        paragraph_selector: XPath,
-        summary_selector: Optional[XPath] = None,
-        subheadline_selector: Optional[XPath] = None,
+    doc: lxml.html.HtmlElement,
+    paragraph_selector: XPath,
+    summary_selector: Optional[XPath] = None,
+    subheadline_selector: Optional[XPath] = None,
 ) -> ArticleBody:
     # depth first index for each element in tree
     df_idx_by_ref = {element: i for i, element in enumerate(doc.iter())}
@@ -134,19 +134,19 @@ def strip_nodes_to_text(text_nodes: List[lxml.html.HtmlElement]) -> Optional[str
 
 
 def apply_substitution_pattern_over_list(
-        input_list: List[str], pattern: Pattern[str], replacement: Union[str, Callable[[Match[str]], str]] = ""
+    input_list: List[str], pattern: Pattern[str], replacement: Union[str, Callable[[Match[str]], str]] = ""
 ) -> List[str]:
     return [subbed for text in input_list if (subbed := re.sub(pattern, replacement, text).strip())]
 
 
 def generic_author_parsing(
-        value: Union[
-            Optional[str],
-            Dict[str, str],
-            List[str],
-            List[Dict[str, str]],
-        ],
-        split_on: Optional[List[str]] = None,
+    value: Union[
+        Optional[str],
+        Dict[str, str],
+        List[str],
+        List[Dict[str, str]],
+    ],
+    split_on: Optional[List[str]] = None,
 ) -> List[str]:
     """This function tries to parse the given <value> to a list of authors (List[str]) based on the type of value.
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from fundus.parser.base_parser import Attribute, BaseParser
+from fundus.parser.base_parser import Attribute, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import generic_author_parsing
 from fundus.publishers import PublisherCollection
 from fundus.publishers.base_objects import PublisherEnum


### PR DESCRIPTION
This adds a function to the `generic_author_parsing` that detects if a delimiter is used and if so splits the given author string.
This is only used while parsing authors given as a single string value.