### PR TITLE
[Proposal] Adds very basic feedback wrapper

### DIFF
--- a/src/fundus/user_feedback.py
+++ b/src/fundus/user_feedback.py
@@ -1,32 +1,33 @@
-from typing import Iterator
+from typing import Iterator, Optional, Set
 
 from fundus.scraping.article import Article
 
 
 class StatusDisplay(Iterator[Article]):
-
     def __init__(self, stepsize: int = 500):
         self.counter = 0
-        self.iterator = None
-        self.unique_sources = set()
+        self.iterator: Optional[Iterator[Article]] = None
+        self.unique_sources: Set[str] = set()
         self.stepsize: int = stepsize
 
     def __next__(self) -> Article:
-        current_article = next(self.iterator)
+        assert self.iterator is not None
+        current_article: Article = next(self.iterator)
         self.counter += 1
-        self.unique_sources.add(current_article.source.publisher)
+        if current_article.source.publisher:
+            self.unique_sources.add(current_article.source.publisher)
         if self.counter % self.stepsize == 0:
-            print(f'{self.counter} articles from {len(self.unique_sources)} Sources processed')
+            print(f"{self.counter} articles from {len(self.unique_sources)} Sources processed")
         return current_article
 
     def summary(self):
-        return f'{self.counter} articles from {len(self.unique_sources)} Sources processed'
+        return f"{self.counter} articles from {len(self.unique_sources)} Sources processed"
 
     def __call__(self, article_iterator: Iterator[Article]) -> Iterator[Article]:
         self.iterator = article_iterator
         return self
 
-    def __enter__(self) -> 'StatusDisplay':
+    def __enter__(self) -> "StatusDisplay":
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/src/fundus/user_feedback.py
+++ b/src/fundus/user_feedback.py
@@ -1,0 +1,33 @@
+from typing import Iterator
+
+from fundus.scraping.article import Article
+
+
+class StatusDisplay(Iterator[Article]):
+
+    def __init__(self, stepsize: int = 500):
+        self.counter = 0
+        self.iterator = None
+        self.unique_sources = set()
+        self.stepsize: int = stepsize
+
+    def __next__(self) -> Article:
+        current_article = next(self.iterator)
+        self.counter += 1
+        self.unique_sources.add(current_article.source.publisher)
+        if self.counter % self.stepsize == 0:
+            print(f'{self.counter} articles from {len(self.unique_sources)} Sources processed')
+        return current_article
+
+    def summary(self):
+        return f'{self.counter} articles from {len(self.unique_sources)} Sources processed'
+
+    def __call__(self, article_iterator: Iterator[Article]) -> Iterator[Article]:
+        self.iterator = article_iterator
+        return self
+
+    def __enter__(self) -> 'StatusDisplay':
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        print("exit")


### PR DESCRIPTION
This is an idea I just cooked up: I was missing some feedback from during the execution(#194). One solution might be a feature like this: A wrapper that provides optional feedback to the users. It could be easily expanded and maintained without clogging the main code. An obvious addition could be some sort of final summary after a run of the pipeline has finished. 
Edit: I forgot how to use it:

```python
de_de = PublisherCollection.at
crawler = Crawler(de_de)

with StatusDisplay(stepsize=50) as status:
     for article in status(crawler.crawl(max_articles=25, error_handling="suppress", only_complete=False)):
           print(article.source.url)
```
This will print a quick summary after each 500 Articles processed. 
