### PR TITLE
Adds additional message when crashing

### DIFF
--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -59,7 +59,8 @@ class Scraper:
                     if error_handling == "raise":
                         error_message = f"Run into an error processing '{article_source.url}'"
                         basic_logger.error(error_message)
-                        raise type(err)(str(err) + "\n\n" + error_message)
+                        err.args = (str(err) + "\n\n" + error_message,)
+                        raise err
                     elif error_handling == "catch":
                         yield Article(source=article_source, exception=err)
                         continue


### PR DESCRIPTION
This adds an additional message displaying the URL when crashing during parsing and `raise` is selected in front of the traceback.

```console
2023-05-23 17:47:26,883 - root - ERROR - Run into an error processing 'https://www.merkur.de/welt/fernstrasse-auto-italien-unwetter-steinschlag-stuerzt-suedtiroler-92291684.html'
Traceback (most recent call last):
  File "C:/Users/maxda/PycharmProjects/fundus/scratch.py", line 25, in <module>
    for article in scraper.scrape(error_handling='raise'):
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\scraping\scraper.py", line 63, in scrape
    raise err
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\scraping\scraper.py", line 54, in scrape
    extraction = self.parser(article_source.crawl_date).parse(article_source.html, error_handling)
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\parser\base_parser.py", line 209, in parse
    raise err
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\parser\base_parser.py", line 204, in parse
    parsed_data[attribute_name] = func()
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\parser\base_parser.py", line 59, in __call__
    return self.__func__(self.__self__)
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\publishers\de\merkur.py", line 31, in authors
    return generic_author_parsing(self.precomputed.ld.bf_search("author"))
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\parser\utility.py", line 202, in generic_author_parsing
    return [name.strip() for name in authors]
  File "C:\Users\maxda\PycharmProjects\fundus\src\fundus\parser\utility.py", line 202, in <listcomp>
    return [name.strip() for name in authors]
AttributeError: 'list' object has no attribute 'strip'

Run into an error processing 'https://www.merkur.de/welt/fernstrasse-auto-italien-unwetter-steinschlag-stuerzt-suedtiroler-92291684.html'

```