### PR TITLE
Use custom request header for `DieZeit`

### DIFF
--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -107,6 +107,7 @@ class DE(PublisherEnum):
                 f"https://www.zeit.de/gsitemaps/index.xml?date={datetime.now().strftime('%Y-%m-%d')}&unit=days&period=1"
             ),
         ],
+        request_header={"user-agent": "Googlebot"},
         parser=DieZeitParser,
     )
 


### PR DESCRIPTION
This fixes an error where Fundus got redirected crawling `DieZeit` by hiding as `Googlebot` user agent.