### PR TITLE
Makes `HTMLSource` non blocking

### DIFF
--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -208,35 +208,33 @@ class HTMLSource:
 
             session = await session_handler.get_session()
 
-            async with session.get(url, headers=self.request_header) as response:
-                if self._filter(str(response.url)):
-                    basic_logger.debug(f"Skipped responded URL '{url}' because of URL filter")
-                    yield None
-                    continue
+            try:
+                async with session.get(url, headers=self.request_header) as response:
+                    if self._filter(str(response.url)):
+                        basic_logger.debug(f"Skipped responded URL '{url}' because of URL filter")
+                        yield None
+                        continue
 
-                try:
                     html = await response.text()
                     response.raise_for_status()
 
-                except (HTTPError, ClientError, HttpProcessingError, UnicodeError) as error:
-                    basic_logger.info(f"Skipped requested URL '{url}' because of '{error}'")
-                    yield None
-                    continue
+            except (HTTPError, ClientError, HttpProcessingError, UnicodeError) as error:
+                basic_logger.info(f"Skipped requested URL '{url}' because of '{error}'")
+                yield None
+                continue
 
-                except Exception as error:
-                    basic_logger.warning(
-                        f"Warning! Skipped  requested URL '{url}' because of an unexpected error {error}"
-                    )
-                    yield None
-                    continue
+            except Exception as error:
+                basic_logger.warning(f"Warning! Skipped  requested URL '{url}' because of an unexpected error {error}")
+                yield None
+                continue
 
-                if response.history:
-                    basic_logger.debug(f"Got redirected {len(response.history)} time(s) from {url} -> {response.url}")
+            if response.history:
+                basic_logger.debug(f"Got redirected {len(response.history)} time(s) from {url} -> {response.url}")
 
-                yield HTML(
-                    requested_url=url,
-                    responded_url=str(response.url),
-                    content=html,
-                    crawl_date=datetime.now(),
-                    source=self,
-                )
+            yield HTML(
+                requested_url=url,
+                responded_url=str(response.url),
+                content=html,
+                crawl_date=datetime.now(),
+                source=self,
+            )

--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -44,6 +44,9 @@ class Scraper:
 
         for html_source in self.sources:
             async for html in html_source.fetch():
+                if html is None:
+                    yield None
+                    continue
                 try:
                     extraction = self.parser(html.crawl_date).parse(html.content, error_handling)
 


### PR DESCRIPTION
This makes the `HTMLSource` non-blocking alongside the also non-blocking scraper. We do so in order to be able to distribute load across publishers when using extensive URL filters. Before, when having a strict filter in place, and because of the blocking nature of `HTMLSource`, the crawler would search through an entire publisher until getting a hit, rather than search through the publishers equally. 