### PR TITLE
Add missing tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ We provide **quick tutorials** to get you started with the library:
 
 1. [**Tutorial 1: How to crawl news with Fundus**](docs/1_getting_started.md)
 2. [**Tutorial 2: The Article Class**](docs/2_the_article_class.md)
-3. [**Tutorial 2: How to filter articles**](docs/3_how_to_filter_articles.md)
+3. [**Tutorial 3: How to filter articles**](docs/3_how_to_filter_articles.md)
+4. [**Tutorial 4: How to search for publishers**](docs/4_how_to_search_for_publishers.md)
 
 If you wish to contribute check out these tutorials
 1. [**How to add a new news-source**](docs/how_to_contribute.md)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ Developed at [Humboldt University of Berlin](https://www.informatik.hu-berlin.de
 
 Fundus is:
 
-* A crawler for news ...
+* **A static news crawler.** 
+  Fundus lets you gather a ton of news articles already in shape from a huge variety of news sources in only a couple of lines of code.
+  Be it for your thesis about political bias or training your home-brewed stock prediction model, Fundus gets you covered with the data.
 
-* A Python ...
+* **An open-source Python package.**
+  Fundus is built around and based on the idea of building something together.
+  The more people want to be a part of this the better. So feel free to check out if you can help Fundus [growing](docs/how_to_contribute.md)
 
 ## Quick Start
 
@@ -28,15 +32,14 @@ pip install fundus
 
 Fundus requires Python 3.8+.
 
-### Example 1: Crawl a bunch of German-language news articles
+### Example 1: Crawl a bunch of English-language news articles
 
-Let's use Fundus to crawl 2 articles of English-language news publishers based in the US.
+Let's use Fundus to crawl 2 articles from publishers based in the US.
 
 ```python
-
 from fundus import PublisherCollection, Crawler
 
-# initialize the crawler for news publisher based in the us
+# initialize the crawler for news publishers based in the US
 crawler = Crawler(PublisherCollection.us)
 
 # crawl 2 articles and print
@@ -44,7 +47,7 @@ for article in crawler.crawl(max_articles=2):
     print(article)
 ```
 
-This should print something like:
+This should print something like this:
 
 ```console
 Fundus-Article:
@@ -63,9 +66,9 @@ Fundus-Article:
 
 This means that you crawled 2 articles from different US publishers.
 
-### Example 2: Crawl specific news source
+### Example 2: Crawl a specific news source
 
-Maybe you want to crawl a specific news source instead. Let's crawl news articles form Washington Times only:
+Maybe you want to crawl a specific news source instead. Let's crawl news articles from Washington Times only:
 
 ```python
 
@@ -75,7 +78,7 @@ from fundus import PublisherCollection, Crawler
 crawler = Crawler(PublisherCollection.us.WashingtonTimes)
 
 # crawl 5 articles and print
-for article in crawler.crawl(max_articles=5):
+for article in crawler.crawl(max_articles=2):
     print(article)
 ```
 
@@ -83,9 +86,11 @@ for article in crawler.crawl(max_articles=5):
 
 We provide **quick tutorials** to get you started with the library:
 
-1. [**Tutorial 1: How to crawl news with Fundus**](docs/...)
+1. [**Tutorial 1: How to crawl news with Fundus**](docs/1_getting_started.md)
 2. [**Tutorial 2: The Article Class**](docs/...)
-3. [**Tutorial 3: How to add a new news-source**](docs/how_to_contribute.md)
+
+If you wish to contribute check out these tutorials
+1. [**How to add a new news-source**](docs/how_to_contribute.md)
 
 The tutorials explain how ...
 
@@ -97,7 +102,7 @@ Also: **Adding a new source is easy - consider contributing to the project!**
 
 ## Contact
 
-Please email your questions or comments to ...
+Please email your questions or comments to [**Max Dallabetta**](mailto:max.dallebtta@googlemail.com?subject=[GitHub]%20Fundus)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ for article in crawler.crawl(max_articles=2):
 We provide **quick tutorials** to get you started with the library:
 
 1. [**Tutorial 1: How to crawl news with Fundus**](docs/1_getting_started.md)
-2. [**Tutorial 2: The Article Class**](docs/...)
+2. [**Tutorial 2: The Article Class**](docs/2_the_article_class.md)
 
 If you wish to contribute check out these tutorials
 1. [**How to add a new news-source**](docs/how_to_contribute.md)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ We provide **quick tutorials** to get you started with the library:
 
 1. [**Tutorial 1: How to crawl news with Fundus**](docs/1_getting_started.md)
 2. [**Tutorial 2: The Article Class**](docs/2_the_article_class.md)
+3. [**Tutorial 2: How to filter articles**](docs/3_how_to_filter_articles.md)
 
 If you wish to contribute check out these tutorials
 1. [**How to add a new news-source**](docs/how_to_contribute.md)

--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -7,7 +7,7 @@ This tutorial explains the basic concepts of Fundus:
 
 ## `PublisherCollection`
 
-Fundus comes with a collection of publisher-specific parsers grouped by country of origin.
+Fundus includes a collection of publisher-specific parsers grouped by country of origin.
 You can access these publishers through a single class called `PublisherCollection` using the [Alpha-2](https://www.iban.com/country-codes) codes described in ISO 3166 as identifiers.
 The `PublisherCollection` works as an information hub describing publishers [currently supported](supported_publishers.md) by Fundus.
 

--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -3,27 +3,29 @@
 This tutorial explains the basic concepts of Fundus:
 - What is the `PublisherCollection`
 - What is a `Crawler`
-- How to retrieve articles
+- How to crawl articles
 
-## `PublisherCollection`
+## What is the `PublisherCollection`
 
 Fundus includes a collection of publisher-specific parsers grouped by country of origin.
 You can access these publishers through a single class called `PublisherCollection` using the [Alpha-2](https://www.iban.com/country-codes) codes described in ISO 3166 as identifiers.
-The `PublisherCollection` works as an information hub describing publishers [currently supported](supported_publishers.md) by Fundus.
+You can see which publishers are currently supported by Fundus [here](supported_publishers.md).
 
-For example, to access all publishers based in the US simply write:
+To access all publishers based in the US simply write:
+
 ````python
 from fundus import PublisherCollection
 
 PublisherCollection.us
 ````
 
-## The crawler
+## What is a `Crawler`
 
-If you want to crawl articles, you need to initialize a crawler first.
-You can do so by using the publisher collection (recommended) or low-level objects.
+The `Crawler` is Fundus' main pipeline for crawling articles from supported publishers.
+If you want to crawl articles, the first step is to initialize a crawler.
+You can do so by making use of the `PublisherCollection`.
 
-As an example, let's initiate a crawler capable of crawling publishers based in the US by utilizing the `PublisherCollection`
+Let's initiate a crawler capable of crawling publishers based in the US.
 
 ````python
 from fundus import PublisherCollection, Crawler
@@ -37,12 +39,14 @@ You can also initialize a crawler for the entire publisher collection
 crawler = Crawler(PublisherCollection)
 ````
 
+**_NOTE:_** To build a pipeline from low-level `Scraper` objects make use of the `BaseCrawler` class.
+
 # How to crawl articles
 
 Now to crawl articles make use of the `crawl()` method of the initialized crawler class.
 Calling this will return an `Iterator` over articles.
 
-As an example let us crawl one news article from all publishers based in the US.
+Let's crawl one news article from all publishers based in the US.
 
 ````python
 from fundus import PublisherCollection, Crawler
@@ -67,14 +71,11 @@ Fundus-Article:
 ```
 
 You can also crawl all available articles by simply removing the `max_articles` parameter.
+
 ```` python
 # crawl 2 articles and print
 for article in crawler.crawl():
     print(article)
 ````
-
-**_NOTE:_** There is also an `async` access point for crawling called `crawl_async`. 
-If you want to crawl articles within any async workflow we highly recommend using this instead.
-This async access point will return an `AsyncIterator[Article]`.
 
 In the [next section](2_the_article_class.md) we will introduce you to the `Article` class.

--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -1,0 +1,80 @@
+# Basics
+
+This tutorial explains the basic concepts of Fundus:
+- What is the `PublisherCollection`
+- What is a `Crawler`
+- How to retrieve articles
+
+## `PublisherCollection`
+
+Fundus comes with a collection of publisher-specific parsers grouped by country of origin.
+You can access these publishers through a single class called `PublisherCollection` using the [Alpha-2](https://www.iban.com/country-codes) codes described in ISO 3166 as identifiers.
+The `PublisherCollection` works as an information hub describing publishers [currently supported](supported_publishers.md) by Fundus.
+
+For example, to access all publishers based in the US simply write:
+````python
+from fundus import PublisherCollection
+
+PublisherCollection.us
+````
+
+## The crawler
+
+If you want to crawl articles, you need to initialize a crawler first.
+You can do so by using the publisher collection (recommended) or low-level objects.
+
+As an example, let's initiate a crawler capable of crawling publishers based in the US by utilizing the `PublisherCollection`
+
+````python
+from fundus import PublisherCollection, Crawler
+
+crawler = Crawler(PublisherCollection.us)
+````
+
+You can also initialize a crawler for the entire publisher collection
+
+```` python
+crawler = Crawler(PublisherCollection)
+````
+
+# How to crawl articles
+
+Now to crawl articles make use of the `crawl()` method of the initialized crawler class.
+Calling this will return an `Iterator` over articles.
+
+As an example let us crawl one news article from all publishers based in the US.
+
+````python
+from fundus import PublisherCollection, Crawler
+
+# initialize the crawler for news publishers based in the US
+crawler = Crawler(PublisherCollection.us)
+
+# crawl 2 articles and print
+for article in crawler.crawl(max_articles=1):
+    print(article)
+````
+
+This should print something like this:
+
+```console
+Fundus-Article:
+- Title: "Feinstein's Return Not Enough for Confirmation of Controversial New [...]"
+- Text:  "Democrats jammed three of President Joe Biden's controversial court nominees
+          through committee votes on Thursday thanks to a last-minute [...]"
+- URL:    https://freebeacon.com/politics/feinsteins-return-not-enough-for-confirmation-of-controversial-new-hampshire-judicial-nominee/
+- From:   FreeBeacon (2023-05-11 18:41)
+```
+
+You can also crawl all available articles by simply removing the `max_articles` parameter.
+```` python
+# crawl 2 articles and print
+for article in crawler.crawl():
+    print(article)
+````
+
+**_NOTE:_** There is also an `async` access point for crawling called `crawl_async`. 
+If you want to crawl articles within any async workflow we highly recommend using this instead.
+This async access point will return an `AsyncIterator[Article]`.
+
+In the [next section](2_the_article_class.md) we will introduce you to the `Article` class.

--- a/docs/2_the_article_class.md
+++ b/docs/2_the_article_class.md
@@ -1,0 +1,114 @@
+# The Article class
+
+This tutorial introduces you to the article class and how to access parsed data.
+
+## What is an article
+
+The `Article` class is the base data container Fundus uses to store information about an article.
+You can find the parsed attributes as well as the article's origin here.
+The parsed information is stored as attributes of the `Article` instance.
+
+As an example let us print some titles.
+
+````python
+from fundus import Crawler, PublisherCollection
+
+crawler = Crawler(PublisherCollection.us)
+
+for article in crawler.crawl(max_articles=2):
+    print(article.title) # <- you can use any kind of attribute access Python supports on objects here
+````
+
+This should print something like this:
+
+```console
+Shutterstock shares pop as company expands partnership with OpenAI
+Donald Trump asks judge to delay classified documents trial
+```
+
+Now have a look at the [**attribute guidelines**](attribute_guidelines.md).
+All attributes listed here can be safely accessed through the `Article` class.
+
+**_NOTE:_** The listed attributes represent fields of the `Article` dataclass with all of them having default values.
+
+Some parsers may support additional attributes not listed in the guidelines.
+You can find those attributes under the [**supported publisher**](supported_publishers.md) tables under `Additional Attributes`.
+
+**_NOTE:_** Keep in mind that these additional attributes are specific to a parser and cannot be accessed safely for every article.
+
+Sometimes an attribute listed in the attribute guidelines isn't supported at all by a specific parser.
+You can find this information under the `Missing Attributes` tab within the supported publisher tables.
+There is also a built-in search mechanic you can learn about [here](4_how_to_search_for_publishers.md)
+
+## The articles' body
+
+Fundus supports two methods to access the body of the article
+1. Accessing the `plaintext` property of `Article` with `article.plaintext`.
+   This will return a cleaned and formatted version of the article body as a single string object and should be suitable for most use cases. <br>
+   **_NOTE:_** The different DOM elements are joined with two new lines and cleaned with `split()` and `' '.join()`.
+2. Accessing the `body` attribute of `Article`. This returns an `ArticleBody` instance, granting more fine-grained access to the DOM structure of the article body.
+
+As an example let's print the headline and paragraphs for the last section of the article body.
+````python
+from fundus import Crawler, PublisherCollection
+from textwrap import TextWrapper
+
+crawler = Crawler(PublisherCollection.us.CNBC)
+wrapper = TextWrapper(width=80, max_lines=1)
+
+for article in crawler.crawl(max_articles=1):
+    last_section = article.body.sections[-1]
+    if last_section.headline:
+        print(wrapper.fill(f"This is a headline: {last_section.headline}"))
+    for paragraph in last_section.paragraphs:
+        print(wrapper.fill(f"This is a paragraph: {paragraph}"))
+````
+
+Will print something like this:
+```console
+This is a headline: Even a proper will is superseded in some cases
+This is a paragraph: A will is superseded in some cases, such as with [...]
+This is a paragraph: That may also happen if a decedent owns property in [...]
+This is a paragraph: "You have to also look at how your assets are [...]
+This is a paragraph: When someone dies, the executor presents their will [...]
+This is a paragraph: People who would like to keep the details of their [...]
+```
+
+**_NOTE:_** Not all publishers support the layout format shown above.
+Sometimes headlines are missing or the entire summary is.
+You can always check the specific parser what to expect, but even within publishers, the layout differs from article to article.
+
+## HTML
+
+Fundus keeps track of the origins of an article.
+You can access this information with the `html` field of `Article`.
+Here you have access to the following information:
+1. `requested_url: str`: The original URL used to request the HTML.
+2. `responded_url: str`: The URL attached to the server response.
+   Often the same; can change with redirects.
+3. `content: str`: The HTML content.
+4. `crawl_date: datetime`: The exact timestamp the article was crawled.
+5. `source: HTMLSource`: The internal source object the article originates from.
+
+## Language detection
+
+Sometimes publishers support articles in different languages.
+To address this Fundus comes with native support for language detection.
+You can access the detected language with `Article.lang`.
+
+As an example let's print some languages' for our articles.
+````python
+from fundus import Crawler, PublisherCollection
+
+crawler = Crawler(PublisherCollection.us)
+
+for article in crawler.crawl(max_articles=1):
+    print(article.lang)
+````
+
+Should print this:
+``console
+en
+``
+
+In the [**next section**](3_how_to_filter_articles.md) we will show you how to filter articles.

--- a/docs/2_the_article_class.md
+++ b/docs/2_the_article_class.md
@@ -1,14 +1,13 @@
 # The Article class
 
-This tutorial introduces you to the article class and how to access parsed data.
+This tutorial introduces you to the article class and how to access the parsed data.
 
-## What is an article
+## What is an `Article`
 
 The `Article` class is the base data container Fundus uses to store information about an article.
-You can find the parsed attributes as well as the article's origin here.
-The parsed information is stored as attributes of the `Article` instance.
+It contains the parsed attributes as well as the article's origin.
 
-As an example let us print some titles.
+As an example, let's print some titles.
 
 ````python
 from fundus import Crawler, PublisherCollection
@@ -16,10 +15,10 @@ from fundus import Crawler, PublisherCollection
 crawler = Crawler(PublisherCollection.us)
 
 for article in crawler.crawl(max_articles=2):
-    print(article.title) # <- you can use any kind of attribute access Python supports on objects here
+    print(article.title)  # <- you can use any kind of attribute access Python supports on objects here
 ````
 
-This should print something like this:
+This should print something like:
 
 ```console
 Shutterstock shares pop as company expands partnership with OpenAI
@@ -46,9 +45,10 @@ Fundus supports two methods to access the body of the article
 1. Accessing the `plaintext` property of `Article` with `article.plaintext`.
    This will return a cleaned and formatted version of the article body as a single string object and should be suitable for most use cases. <br>
    **_NOTE:_** The different DOM elements are joined with two new lines and cleaned with `split()` and `' '.join()`.
-2. Accessing the `body` attribute of `Article`. This returns an `ArticleBody` instance, granting more fine-grained access to the DOM structure of the article body.
+2. Accessing the `body` attribute of `Article`. 
+   This returns an `ArticleBody` instance, granting more fine-grained access to the DOM structure of the article body.
 
-As an example let's print the headline and paragraphs for the last section of the article body.
+Let's print the headline and paragraphs for the last section of the article body.
 ````python
 from fundus import Crawler, PublisherCollection
 from textwrap import TextWrapper
@@ -65,6 +65,7 @@ for article in crawler.crawl(max_articles=1):
 ````
 
 Will print something like this:
+
 ```console
 This is a headline: Even a proper will is superseded in some cases
 This is a paragraph: A will is superseded in some cases, such as with [...]
@@ -80,12 +81,13 @@ You can always check the specific parser what to expect, but even within publish
 
 ## HTML
 
-Fundus keeps track of the origins of an article.
-You can access this information with the `html` field of `Article`.
+Fundus keeps track of the origin of each article.
+You can access this information using the `html` field of `Article`.
 Here you have access to the following information:
+
 1. `requested_url: str`: The original URL used to request the HTML.
 2. `responded_url: str`: The URL attached to the server response.
-   Often the same; can change with redirects.
+   Often the same as `requested_url`; can change with redirects.
 3. `content: str`: The HTML content.
 4. `crawl_date: datetime`: The exact timestamp the article was crawled.
 5. `source: HTMLSource`: The internal source object the article originates from.
@@ -93,10 +95,10 @@ Here you have access to the following information:
 ## Language detection
 
 Sometimes publishers support articles in different languages.
-To address this Fundus comes with native support for language detection.
+To address this Fundus includes native support for language detection.
 You can access the detected language with `Article.lang`.
 
-As an example let's print some languages' for our articles.
+Let's print some languages for our articles.
 ````python
 from fundus import Crawler, PublisherCollection
 

--- a/docs/3_how_to_filter_articles.md
+++ b/docs/3_how_to_filter_articles.md
@@ -4,13 +4,14 @@ This tutorial shows you how to filter articles based on their attribute values, 
 
 ## Extraction filter
 
-Often the attributes a parser is capable of parsing are not fully supported by a specific article.
-By default, Fundus drops all articles which aren't fully extracted to ensure data quality. 
-This also means that you miss a lot of data potentially useful for your project.
-You can alter this behavior by utilizing the `extration_filter` parameter.
+A specific article may not contain all attributes the parser is capable of extracting.
+By default, Fundus drops all articles that aren't fully extracted to ensure data quality.
+You may miss a lot of data potentially useful for your project.
+To alter this behavior make use of the `extration_filter` parameter of the `crawl()` method.
 You do so by either using the built-in `ExtractionFilter` `Requires` or writing a custom one.
 
 Let's print some articles with at least a `body` and `title` set.
+
 ````python
 from fundus import Crawler, PublisherCollection, Requires
 
@@ -24,10 +25,11 @@ for article in crawler.crawl(max_articles=2, only_complete=Requires("title", "bo
 
 ### Custom extraction filter
 
-You can write custom extraction filters as well.
-All it takes is a `Callable` satisfying the `ExtractionFilter` protocol which you can find [here](../src/fundus/scraping/filter.py).
+Writing custom extraction filters is supported and encouraged.
+To do so you need to define a `Callable` satisfying the `ExtractionFilter` protocol which you can find [here](../src/fundus/scraping/filter.py).
 
 Let's build a custom extraction filter that filters out all articles not written by an author called `Donald Duck`
+
 ````python
 from typing import Dict, Any
 
@@ -37,7 +39,9 @@ def author_filter(extracted: Dict[str, Any]) -> bool:
         return 'Donal Duck' not in authors
     return True
 ````
+
 and put it to work.
+
 ```` python
 from fundus import Crawler, PublisherCollection
 
@@ -52,10 +56,12 @@ If a filter returns True on a specific element the element will be dropped.
 
 ## URL filter
 
-Fundus provides a mechanic to filter articles by URL both before and after the HTML is downloaded.
-There is a built-in filter that filters out URLs based on regular expressions.
+Fundus allows you to filter articles by URL both before and after the HTML is downloaded.
+You do so by making use of the `url_filter` parameter of the `crawl()` method.
+There is a built-in filter called `regex_filter` that filters out URLs based on regular expressions.
 
 Let's crawl a bunch of articles with URLs not including the word `advertisement` or `podcast` and print their `resuestd_url`'s.
+
 ````python
 from fundus import Crawler, PublisherCollection
 from fundus.scraping.filter import regex_filter
@@ -70,6 +76,7 @@ Often it's useful to select certain criteria rather than filtering them.
 To do so use the `inverse` operator from `fundus.scraping.filter.py`.
 
 Let's crawl a bunch of articles with URLs including the string `politic`.
+
 ````python
 from fundus import Crawler, PublisherCollection
 from fundus.scraping.filter import inverse, regex_filter
@@ -79,7 +86,9 @@ crawler = Crawler(PublisherCollection.us)
 for article in crawler.crawl(max_articles=5, url_filter=inverse(regex_filter("politic"))):
     print(article.html.requested_url)
 ````
+
 Which should print something like this:
+
 ````console
 https://www.foxnews.com/politics/matt-gaetz-fisa-surveillance-citizens
 https://www.thenation.com/article/politics/jim-jordan-chris-wray/
@@ -97,6 +106,7 @@ You can do so by using the `lor` (logic `or`) and `land` (logic `and`) operators
 
 Let's combine both URL filters from the examples above and add a new condition.
 Our goal is to get articles that include both strings 'politic' and 'trump' in their URL and don't include the strings 'podcast' or 'advertisement'.
+
 ````python
 from fundus import Crawler, PublisherCollection
 from fundus.scraping.filter import inverse, regex_filter, lor, land
@@ -111,6 +121,7 @@ for article in crawler.crawl(max_articles=10, url_filter=lor(filter1, filter2)):
 ````
 
 Which should print something like this:
+
 ````console
 https://www.foxnews.com/politics/desantis-meet-donors-new-yorks-southampton-next-week-pitch-campaigns-long-game-trump
 https://occupydemocrats.com/2023/06/25/the-grift-trump-shifting-political-contributions-from-his-campaign-to-defense-fund/
@@ -130,11 +141,15 @@ Make sure to only use them on filters of the same kind.
 ## Filter sources
 
 Fundus supports different sources for articles which are split into two categories:
+
 1. Only recent articles: `RSSFeed`, `NewsMap` (recommended for continuous crawling jobs)
-2. Pretty much the whole site: `Sitemap` (recommended for one-time crawling)
+2. The whole site: `Sitemap` (recommended for one-time crawling)
+
+**_NOTE:_** Sometimes the `Sitemap` provided by a specific publisher won't span the entire site.
 
 You can preselect the source for your articles when initializing a new `Crawler`.
 Let's initiate a crawler who only crawls from `NewsMaps`'s.
+
 ````python
 from fundus import Crawler, PublisherCollection, NewsMap
 

--- a/docs/3_how_to_filter_articles.md
+++ b/docs/3_how_to_filter_articles.md
@@ -1,0 +1,151 @@
+# How to filter articles
+
+This tutorial shows you how to filter articles based on their attribute values, URLs, and news sources.
+
+## Extraction filter
+
+Often the attributes a parser is capable of parsing are not fully supported by a specific article.
+By default, Fundus drops all articles which aren't fully extracted to ensure data quality. 
+This also means that you miss a lot of data potentially useful for your project.
+You can alter this behavior by utilizing the `extration_filter` parameter.
+You do so by either using the built-in `ExtractionFilter` `Requires` or writing a custom one.
+
+Let's print some articles with at least a `body` and `title` set.
+````python
+from fundus import Crawler, PublisherCollection, Requires
+
+crawler = Crawler(PublisherCollection.de)
+
+for article in crawler.crawl(max_articles=2, only_complete=Requires("title", "body")):
+    print(article)
+````
+
+**_NOTE:_** We recommend thinking about what kind of data is needed first and then running Fundus with a configured extraction filter afterward.
+
+### Custom extraction filter
+
+You can write custom extraction filters as well.
+All it takes is a `Callable` satisfying the `ExtractionFilter` protocol which you can find [here](../src/fundus/scraping/filter.py).
+
+Let's build a custom extraction filter that filters out all articles not written by an author called `Donald Duck`
+````python
+from typing import Dict, Any
+
+
+def author_filter(extracted: Dict[str, Any]) -> bool:
+    if authors := extracted.get('authors'):
+        return 'Donal Duck' not in authors
+    return True
+````
+and put it to work.
+```` python
+from fundus import Crawler, PublisherCollection
+
+crawler = Crawler(PublisherCollection.us)
+for article_from_donald_duck in crawler.crawl(only_complete=author_filter):
+    print(article_from_donald_duck)
+````
+
+**_NOTE:_** Fundus' filters work inversely to Python's built-in filter.
+A filter in Fundus describes what is filtered out and not what's kept.
+If a filter returns True on a specific element the element will be dropped.
+
+## URL filter
+
+Fundus provides a mechanic to filter articles by URL both before and after the HTML is downloaded.
+There is a built-in filter that filters out URLs based on regular expressions.
+
+Let's crawl a bunch of articles with URLs not including the word `advertisement` or `podcast` and print their `resuestd_url`'s.
+````python
+from fundus import Crawler, PublisherCollection
+from fundus.scraping.filter import regex_filter
+
+crawler = Crawler(PublisherCollection.us)
+
+for article in crawler.crawl(max_articles=5, url_filter=regex_filter("advertisement|podcast")):
+    print(article.html.requested_url)
+````
+
+Often it's useful to select certain criteria rather than filtering them.
+To do so use the `inverse` operator from `fundus.scraping.filter.py`.
+
+Let's crawl a bunch of articles with URLs including the string `politic`.
+````python
+from fundus import Crawler, PublisherCollection
+from fundus.scraping.filter import inverse, regex_filter
+
+crawler = Crawler(PublisherCollection.us)
+
+for article in crawler.crawl(max_articles=5, url_filter=inverse(regex_filter("politic"))):
+    print(article.html.requested_url)
+````
+Which should print something like this:
+````console
+https://www.foxnews.com/politics/matt-gaetz-fisa-surveillance-citizens
+https://www.thenation.com/article/politics/jim-jordan-chris-wray/
+https://www.newyorker.com/podcast/political-scene/will-record-temperatures-finally-force-political-change
+https://www.cnbc.com/2023/07/12/thai-elections-deep-generational-divides-belie-thailands-politics.html
+https://www.reuters.com/business/autos-transportation/volkswagens-china-chief-welcomes-political-goal-germanys-beijing-strategy-2023-07-13/
+````
+
+**_NOTE:_** As with the `ExtractionFilter` you can also write custom URL filters satisfying the `URLFilter` protocol.
+
+### Combine filters
+
+Sometimes it is useful to combine filters of the same kind.
+You can do so by using the `lor` (logic `or`) and `land` (logic `and`) operators from `fundus.scraping.filter.py`.
+
+Let's combine both URL filters from the examples above and add a new condition.
+Our goal is to get articles that include both strings 'politic' and 'trump' in their URL and don't include the strings 'podcast' or 'advertisement'.
+````python
+from fundus import Crawler, PublisherCollection
+from fundus.scraping.filter import inverse, regex_filter, lor, land
+
+crawler = Crawler(PublisherCollection.us)
+
+filter1 = regex_filter("advertisement|podcast") # drop all URLs including the strings "advertisement" or "podcast"
+filter2 = inverse(land(regex_filter("politic"), regex_filter("trump"))) # drop all URLs not including the strings "politic" and "trump"
+
+for article in crawler.crawl(max_articles=10, url_filter=lor(filter1, filter2)):
+    print(article.html.requested_url)
+````
+
+Which should print something like this:
+````console
+https://www.foxnews.com/politics/desantis-meet-donors-new-yorks-southampton-next-week-pitch-campaigns-long-game-trump
+https://occupydemocrats.com/2023/06/25/the-grift-trump-shifting-political-contributions-from-his-campaign-to-defense-fund/
+https://www.foxnews.com/politics/trump-slams-doj-not-backing-him-e-jean-carroll-case-repeats-claim-doesnt-know-her
+https://www.foxnews.com/politics/ron-desantis-wont-consider-being-trumps-running-mate-says-hes-not-number-2
+https://www.foxnews.com/politics/georgia-swears-grand-jury-hear-trump-2020-election-case
+https://www.foxnews.com/politics/chris-christie-tim-scott-reach-donor-requirement-participate-first-gop-debate-trump-yet-commit
+https://www.newyorker.com/news/the-political-scene/will-trumps-crimes-matter-on-the-campaign-trail
+https://occupydemocrats.com/2023/02/22/exploitation-trump-slammed-for-politicizing-toxic-train-derailment-with-ohio-visit/
+https://www.thegatewaypundit.com/2023/06/pres-trump-defends-punching-down-politics-says-its/
+https://www.thegatewaypundit.com/2023/06/breaking-poll-trump-most-popular-politician-country-rfk/
+````
+
+**_NOTE:_** You can use the `combine`, `lor`, and `land` operators on `ExtractionFilter` as well.
+Make sure to only use them on filters of the same kind.
+
+## Filter sources
+
+Fundus supports different sources for articles which are split into two categories:
+1. Only recent articles: `RSSFeed`, `NewsMap` (recommended for continuous crawling jobs)
+2. Pretty much the whole site: `Sitemap` (recommended for one-time crawling)
+
+You can preselect the source for your articles when initializing a new `Crawler`.
+Let's initiate a crawler who only crawls from `NewsMaps`'s.
+````python
+from fundus import Crawler, PublisherCollection, NewsMap
+
+crawler = Crawler(PublisherCollection.us, restrict_sources_to=[NewsMap])
+````
+
+**_NOTE:_** The `restrict_sources_to` parameter expects a list as value to specify multiple sources at once, e.g. `[RSSFeed, NewsMap]`
+
+## Filter unique articles
+
+The `crawl()` method supports functionality to filter out articles with URLs previously encountered in this run.
+You can alter this behavior by setting the `only_unique` parameter.
+
+In the [next section](4_how_to_search_for_publishers.md) we will show you how to search through publishers in the `PublisherCollection`.

--- a/docs/4_how_to_search_for_publishers.md
+++ b/docs/4_how_to_search_for_publishers.md
@@ -1,0 +1,16 @@
+# How to search for publishers
+
+This tutorial will show you how to search for specific publishers in the `PublisherCollection`.
+
+## Using `search()`
+There a quite a few differences between the publishers, especially in the attributes the underlying parser supports.
+You can search through the collection to get only publishers fitting your use case by utilizing the `search()` method.
+
+Let's get some publishers based in the US, supporting an attribute called `topics` and `NewsMap` as a source, and use them to initialize a crawler afterward.
+
+````python
+from fundus import Crawler, PublisherCollection, NewsMap
+
+fitting_publishers = PublisherCollection.us.search(attributes=["topics"], source_types=[NewsMap])
+crawler = Crawler(fitting_publishers)
+````

--- a/docs/4_how_to_search_for_publishers.md
+++ b/docs/4_how_to_search_for_publishers.md
@@ -3,7 +3,8 @@
 This tutorial will show you how to search for specific publishers in the `PublisherCollection`.
 
 ## Using `search()`
-There a quite a few differences between the publishers, especially in the attributes the underlying parser supports.
+
+There are quite a few differences between the publishers, especially in the attributes the underlying parser supports.
 You can search through the collection to get only publishers fitting your use case by utilizing the `search()` method.
 
 Let's get some publishers based in the US, supporting an attribute called `topics` and `NewsMap` as a source, and use them to initialize a crawler afterward.

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -165,9 +165,6 @@ class TextSequence(Sequence[str]):
     def __init__(self, texts: Iterable[str]):
         self._data: Tuple[str, ...] = tuple(texts)
 
-    def text(self, join_on: str = "\n") -> str:
-        return join_on.join(self)
-
     @overload
     def __getitem__(self, i: int) -> str:
         ...
@@ -187,6 +184,9 @@ class TextSequence(Sequence[str]):
 
     def __repr__(self) -> str:
         return repr(self._data)
+
+    def __str__(self) -> str:
+        return "\n".join(self)
 
 
 @dataclass

--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -13,6 +13,20 @@ def inverse(filter_func: Callable[P, bool]) -> Callable[P, bool]:
     return __call__
 
 
+def lor(*filters: Callable[P, bool]) -> Callable[P, bool]:
+    def __call__(*args: P.args, **kwargs: P.kwargs) -> bool:
+        return any(f(*args, **kwargs) for f in filters)
+
+    return __call__
+
+
+def land(*filters: Callable[P, bool]) -> Callable[P, bool]:
+    def __call__(*args: P.args, **kwargs: P.kwargs) -> bool:
+        return all(f(*args, **kwargs) for f in filters)
+
+    return __call__
+
+
 class URLFilter(Protocol):
     """Protocol to define filter used before article download.
 


### PR DESCRIPTION
This adds missing tutorials for the library, updates the README.md, and adds some more logic to the filter behavior. 

The tutorials are:
1. Getting started
2. The Article class
3. How to filter articles
4. How to search for publishers

The changes made to the filter logic include.
- adding logic operators (or, and) to combine filters
**_NOTE:_** I'm not fully satisfied with how it is right now, but I'm fine with it. It still seems a bit complicated, but writing tutorial number three made it very obvious that we need something to combine filters. 

closes #198