### PR TITLE
GH264: Hardcode utc offsets

### DIFF
--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -217,8 +217,7 @@ def generic_topic_parsing(keyword_str: Optional[str], delimiter: str = ",") -> L
     return [keyword.strip() for keyword in keyword_str.split(delimiter)] if keyword_str else []
 
 
-_tzs = ["CET", "CEST"]
-_tz_infos = {tz: dateutil.tz.gettz(tz) for tz in _tzs}
+_tz_infos = {"CET": 3600, "CEST": 7200}
 
 
 def generic_date_parsing(date_str: Optional[str]) -> Optional[datetime]:

--- a/tests/resources/parser/test_data/de/FAZ.json
+++ b/tests/resources/parser/test_data/de/FAZ.json
@@ -3,7 +3,7 @@
     "authors": [
       "Ralf Euler"
     ],
-    "publishing_date": "2023-04-28 19:20:36",
+    "publishing_date": "2023-04-28 19:20:36+02:00",
     "title": "49-Euro-Ticket: Pendler zahlen 60 Prozent weniger",
     "topics": [
       "RMV",


### PR DESCRIPTION
This solves an issue encountered with #264 by hardcoding UTC offsets for the timezone identifier CET, CEST. We needed to do so because the previous implementation which utilizes `dateutil.tz.gettz()` returns different results on different OS'. 