### PR TITLE
Fix a bug when using float as value for `delay`

### DIFF
--- a/src/fundus/scraping/pipeline.py
+++ b/src/fundus/scraping/pipeline.py
@@ -67,7 +67,7 @@ class BaseCrawler:
         max_articles: Optional[int] = None,
         error_handling: Literal["suppress", "catch", "raise"] = "suppress",
         only_complete: Union[bool, ExtractionFilter] = True,
-        delay: Optional[Union[float, Delay]] = None,
+        delay: Optional[Union[float, Delay]] = 0.1,
         url_filter: Optional[URLFilter] = None,
         only_unique: bool = True,
     ) -> Iterator[Article]:
@@ -114,8 +114,10 @@ class BaseCrawler:
 
         if isinstance(delay, float):
 
+            tmp = delay
+
             def constant_delay() -> float:
-                return delay  # type: ignore[return-value]
+                return tmp
 
             delay = constant_delay
 

--- a/src/fundus/scraping/pipeline.py
+++ b/src/fundus/scraping/pipeline.py
@@ -113,7 +113,6 @@ class BaseCrawler:
             extraction_filter = only_complete
 
         if isinstance(delay, float):
-
             tmp = delay
 
             def constant_delay() -> float:


### PR DESCRIPTION
This is already fixed with #271, but since that PR is postponed, this PR will fix the issue additionally.
This PR also sets the default delay used to 0.1 seconds to ensure Fundus uses polite request frequencies when crawling small amounts of publishers.