### PR TITLE
Improve text extraction for `TheNation`

### DIFF
--- a/src/fundus/publishers/us/the_nation_parser.py
+++ b/src/fundus/publishers/us/the_nation_parser.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute, function
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
@@ -14,8 +14,24 @@ from fundus.parser.utility import (
 
 class TheNationParser(ParserProxy):
     class V1(BaseParser):
+        # There is a known issue preventing lxml from extracting text content within
+        # the specified summary node.
+        # This is due to invalid XML provided by TheNation.
+        # Currently, (lxml 4.9.3) lxml does not accept p tags within any headline (h*) tag.
+        # .article-header-content > h2 > p
         _summary_selector = CSSSelector(".article-header-content > h2")
         _paragraph_selector = CSSSelector(".article-body-inner > p")
+        _aside_selector = CSSSelector("aside")
+
+        # We remove aside tags here because the provided HTML does not enclose <p> tags
+        # within .article-header-content. As a result, following <aside> tags get attached
+        # to the paragraph. This is valid HTML5 behaviour.
+        # see https://stackoverflow.com/questions/8460993/p-end-tag-p-is-not-needed-in-html
+        @function(priority=1)
+        def _remove_aside(self) -> None:
+            for aside in self._aside_selector.__call__(self.precomputed.doc):
+                if (parent := aside.getparent()) is not None:
+                    parent.remove(aside)
 
         @attribute
         def body(self) -> ArticleBody:

--- a/src/fundus/publishers/us/the_nation_parser.py
+++ b/src/fundus/publishers/us/the_nation_parser.py
@@ -16,20 +16,20 @@ class TheNationParser(ParserProxy):
     class V1(BaseParser):
         # There is a known issue preventing lxml from extracting text content within
         # the specified summary node.
-        # This is due to invalid XML provided by TheNation.
-        # Currently, (lxml 4.9.3) lxml does not accept p tags within any headline (h*) tag.
-        # .article-header-content > h2 > p
+        # This is due to invalid XML provided by The Nation.
+        # Currently(lxml 4.9.3), lxml does not accept p tags within any heading (h*) tag.
+        # The "correct" selector would be ".article-header-content > h2 > p"
         _summary_selector = CSSSelector(".article-header-content > h2")
         _paragraph_selector = CSSSelector(".article-body-inner > p")
         _aside_selector = CSSSelector("aside")
 
         # We remove aside tags here because the provided HTML does not enclose <p> tags
-        # within .article-header-content. As a result, following <aside> tags get attached
+        # within .article-header-content. As a result, <aside> tags following <p> tags get attached
         # to the paragraph. This is valid HTML5 behaviour.
         # see https://stackoverflow.com/questions/8460993/p-end-tag-p-is-not-needed-in-html
         @function(priority=1)
         def _remove_aside(self) -> None:
-            for aside in self._aside_selector.__call__(self.precomputed.doc):
+            for aside in self._aside_selector(self.precomputed.doc):
                 if (parent := aside.getparent()) is not None:
                     parent.remove(aside)
 


### PR DESCRIPTION
As mentioned by @lukasgarbas within #275, `TheNation` consists of many JS within the extracted code. While #275 asked for a quality check in general, this PR solves the issue only specific to `TheNation`. Quality control should still be a thing coming to Fundus.

After a really long hunt, I finally found what was causing the extraction noise and learned a lot about HTML5. In short, the DOM layout `The Nation` uses isn't HTML5 compliant. There are two things especially annoying.
1. The site uses `<p>` tags within `<h*>` tags which isn't allowed according to [w3c](https://www.w3.org/TR/2014/REC-html5-20141028/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements), judging by [this](https://stackoverflow.com/a/19779520) comment. This causes the `lxml.html` parser to fail since it is built around w3c compliance. While `BeautifulSoup` would be able to parse the HTML properly in this particular case, it comes with many other downsides.
2. The site's not closing `<p>` tags, resulting in both `lxml` and `BeautifulSoup` attaching the following flow tag to the current `<p>` tag. In the case of #275 a `<aside>` tag is following certain `<p>` tags and thus attached to the not properly enclosed tag. 

This PR fixes the latter by removing all `<aside>` tags before extracting the body. This behavior is specific to the `TheNation` parser.