### PR TITLE
GH297: Introduce `ArticleBody` and `ArticleSection` within the tutorial

### DIFF
--- a/docs/2_the_article_class.md
+++ b/docs/2_the_article_class.md
@@ -56,6 +56,22 @@ Fundus supports two methods to access the body of the article
 2. Accessing the `body` attribute of `Article`. 
    This returns an `ArticleBody` instance, granting more fine-grained access to the DOM structure of the article body.
 
+The `ArticleBody` consists of
+- a `summary` giving a brief introduction of the article
+- a attribute `sections` containing multiple `ArticleSection`
+
+With `ArticleSection` including
+- a `headline`; separating the section from other sections
+- multiple `paragraphs` following the headline
+
+````console
+ArticleSection
+    |-- headline: TextSequence
+    |-- sections: List[ArticleSection]
+                            |-- headline: TextSequence
+                            |-- paragraphs: TextSequence
+````
+
 Let's print the headline and paragraphs for the last section of the article body.
 ````python
 from fundus import Crawler, PublisherCollection

--- a/docs/how_to_contribute.md
+++ b/docs/how_to_contribute.md
@@ -8,7 +8,7 @@
 
 # We Want You!
 
-First and foremost, thank you for considering contributing to the improvement of Fundus.
+First and foremost, thank you for thinking about making Fundus better.
 We aim to tackle news scraping by using domain-specific parsers to achieve precise extraction.
 To handle this substantial workload, we rely on contributions from people like you.
 


### PR DESCRIPTION
This resolves the second point of #297. There will be a major rework of the entire `ArticleBody` and everything related, so the documentation proposed here is only the bare minimum.