### PR TITLE
Landing page wording and style

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ for article in crawler.crawl(max_articles=2):
     print(article)
 ```
 
-This should print something like this:
+That's already it!
+
+If you run this code, it should print out something like this:
 
 ```console
 Fundus-Article:

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Fundus-Article:
 This printout that you succesfully crawled to articles!
 
 For each article, the printout details:
-- the "Title" of the article, i.e. its headline _(truncated in the printout)_
-- the "Text", i.e. the main article body text _(truncated in the printout)_
+- the "Title" of the article, i.e. its headline 
+- the "Text", i.e. the main article body text
 - the "URL" from which it was crawled
 - the news source it is "From"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Developed at <a href="https://www.informatik.hu-berlin.de/en/forschung-en/gebiet
 <div align="center">
 <hr>
 
-[Quick Start](#installation) |  [Tutorials](tutorials/TUTORIAL-1_OVERVIEW.md)  | [Citation](#citation)
+[Quick Start](#quick-start) |  [Tutorials](#tutorials)  | [Supprted News Sources](/docs/supported_publishers.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Developed at <a href="https://www.informatik.hu-berlin.de/en/forschung-en/gebiet
 <div align="center">
 <hr>
 
-[Quick Start](#quick-start) |  [Tutorials](#tutorials)  | [Supprted News Sources](/docs/supported_publishers.md)
+[Quick Start](#quick-start) |  [Tutorials](#tutorials)  | [News Sources](/docs/supported_publishers.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pip install fundus
 
 Fundus requires Python 3.8+.
 
+---
 ### Example 1: Crawl a bunch of English-language news articles
 
 Let's use Fundus to crawl 2 articles from publishers based in the US.
@@ -75,6 +76,7 @@ Fundus-Article:
 
 This means that you crawled 2 articles from different US publishers.
 
+---
 ### Example 2: Crawl a specific news source
 
 Maybe you want to crawl a specific news source instead. Let's crawl news articles from Washington Times only:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ Fundus is:
 
 <hr>
 
-# Quick Start
+## Quick Start
 
-## Requirements and Installation
-
-In your favorite virtual environment, simply do:
+To install from pip, simply do:
 
 ```
 pip install fundus

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Fundus-Article:
 - From:   FoxNews (2023-05-09 14:37)
 ```
 
-This means that you crawled 2 articles from different US publishers.
+This printout shows two crawled articles. For each article, the printout shows the "title" (headline) of the article and its "text" (main article text). It also shows which URL it was crawled from and which news source. 
 
 
 ## Example 2: Crawl a specific news source

--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 <img alt="alt text" src="resources/fundus_logo.png" width="180"/>
 
-[![PyPI version](https://badge.fury.io/py/fundus.svg)](https://badge.fury.io/py/fundus)
-[![GitHub Issues](https://img.shields.io/github/issues/flairNLP/fundus.svg)](https://github.com/flairNLP/fundus/issues)
-[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](docs/how_to_contribute.md)
-[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
+<p align="center">A very simple <b>news crawler</b> in Python.
+Developed at <a href="https://www.informatik.hu-berlin.de/en/forschung-en/gebiete/ml-en/">Humboldt University of Berlin</a>.
+</p>
+<p align="center">
+<img alt="version" src="https://img.shields.io/badge/version-0.1-green">
+<img alt="python" src="https://img.shields.io/badge/python-3.8-blue">
+<img alt="Static Badge" src="https://img.shields.io/badge/license-MIT-green">
+</p>
+<div align="center">
+<hr>
 
-A very simple **news crawler**.
-Developed at [Humboldt University of Berlin](https://www.informatik.hu-berlin.de/en/forschung-en/gebiete/ml-en/).
+[Quick Start](#installation) |  [Tutorials](tutorials/TUTORIAL-1_OVERVIEW.md)  | [Citation](#citation)
+
+</div>
+
 
 ---
 
 Fundus is:
 
 * **A static news crawler.** 
-  Fundus lets you gather a ton of news articles already in shape from a huge variety of news sources in only a couple of lines of code.
-  Be it for your thesis about political bias or training your home-brewed stock prediction model, Fundus gets you covered with the data.
+  Fundus lets you crawl online news articles with only a few lines of Python code!
 
 * **An open-source Python package.**
-  Fundus is built around and based on the idea of building something together.
-  The more people want to be a part of this the better. So feel free to check out if you can help Fundus [growing](docs/how_to_contribute.md).
+  Fundus is built around and based on the idea of building something together. We welcome your
+  contribution to  help Fundus [grow](docs/how_to_contribute.md)!
+
+<hr>
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Fundus-Article:
 - From:   FoxNews (2023-05-09 14:37)
 ```
 
-This printout that you succesfully crawled to articles!
+This printout tells you that you succesfully crawled to articles!
 
 For each article, the printout details:
 - the "Title" of the article, i.e. its headline 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Fundus-Article:
 - From:   FoxNews (2023-05-09 14:37)
 ```
 
-This printout tells you that you succesfully crawled to articles!
+This printout tells you that you succesfully crawled two articles!
 
 For each article, the printout details:
 - the "Title" of the article, i.e. its headline 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Fundus-Article:
 ```
 
 This printout shows two crawled articles. For each article, the printout shows:
-- the "title" of the article, i.e. its headline
-- the "text", i.e. the main article body text
-- the URL from which it was crawled
-- the news source it is from 
+- the "Title" of the article, i.e. its headline
+- the "Text", i.e. the main article body text
+- the "URL" from which it was crawled
+- the news source it is "From"
 
 ## Example 2: Crawl a specific news source
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ Fundus-Article:
 - From:   FoxNews (2023-05-09 14:37)
 ```
 
-This printout shows two crawled articles. For each article, the printout shows the "title" (headline) of the article and its "text" (main article text). It also shows which URL it was crawled from and which news source. 
-
+This printout shows two crawled articles. For each article, the printout shows:
+- the "title" of the article, i.e. its headline
+- the "text", i.e. the main article body text
+- the URL from which it was crawled
+- the news source it is from 
 
 ## Example 2: Crawl a specific news source
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Fundus-Article:
           through committee votes on Thursday thanks to a last-minute [...]"
 - URL:    https://freebeacon.com/politics/feinsteins-return-not-enough-for-confirmation-of-controversial-new-hampshire-judicial-nominee/
 - From:   FreeBeacon (2023-05-11 18:41)
+
 Fundus-Article:
 - Title: "Northwestern student government freezes College Republicans funding over [...]"
 - Text:  "Student government at Northwestern University in Illinois "indefinitely" froze

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Fundus is:
 
 <hr>
 
-## Quick Start
+# Quick Start
 
-### Requirements and Installation
+## Requirements and Installation
 
 In your favorite virtual environment, simply do:
 
@@ -41,8 +41,8 @@ pip install fundus
 
 Fundus requires Python 3.8+.
 
----
-### Example 1: Crawl a bunch of English-language news articles
+
+## Example 1: Crawl a bunch of English-language news articles
 
 Let's use Fundus to crawl 2 articles from publishers based in the US.
 
@@ -76,8 +76,8 @@ Fundus-Article:
 
 This means that you crawled 2 articles from different US publishers.
 
----
-### Example 2: Crawl a specific news source
+
+## Example 2: Crawl a specific news source
 
 Maybe you want to crawl a specific news source instead. Let's crawl news articles from Washington Times only:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Fundus is:
   Fundus lets you crawl online news articles with only a few lines of Python code!
 
 * **An open-source Python package.**
-  Fundus is built around and based on the idea of building something together. We welcome your
+  Fundus is built on the idea of building something together. We welcome your
   contribution to  help Fundus [grow](docs/how_to_contribute.md)!
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ Fundus-Article:
 - From:   FoxNews (2023-05-09 14:37)
 ```
 
-This printout shows two crawled articles. For each article, the printout shows:
-- the "Title" of the article, i.e. its headline
-- the "Text", i.e. the main article body text
+This printout that you succesfully crawled to articles!
+
+For each article, the printout details:
+- the "Title" of the article, i.e. its headline _(truncated in the printout)_
+- the "Text", i.e. the main article body text _(truncated in the printout)_
 - the "URL" from which it was crawled
 - the news source it is "From"
+
 
 ## Example 2: Crawl a specific news source
 


### PR DESCRIPTION
This PR suggest some minor tweaks to the landing README page: 
- centered tagline and starting links, inspired from Fabricator
- made the "Fundus is.." part less verbose 
- made the "Quick Start" part less verbose by removing the "requirements and installation" subheader
- slightly expanded on the explanation of example 1