### PR TITLE
Prepare version 0.1.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+.pypirc
 .Python
 build/
 develop-eggs/

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,11 @@ name = fundus
 description = A very simple news crawler
 long_description = file: README.md
 long_description_content_type = text/markdown
-version = 0.0.1
+version = 0.1.0
 url = https://github.com/flairNLP/fundus
 author = Max Dallabetta
 author_email = max.dallabetta@gmail.com
+license = MIT
 
 
 [options]

--- a/src/fundus/__init__.py
+++ b/src/fundus/__init__.py
@@ -1,7 +1,6 @@
 import pathlib
 import sys
 
-from fundus.logging import basic_logger
 from fundus.publishers import PublisherCollection
 from fundus.scraping.filter import Requires
 from fundus.scraping.html import NewsMap, RSSFeed, Sitemap


### PR DESCRIPTION
This PR makes some last adjustments in order to proceed with github and pypi release 0.1.0:
- fix version number; now `0.1.0`
- ignore `.pypirc` file
- remove `basic_logger` from `fundus.__init__`