### PR TITLE
Change default value for `only_complete` parameter.

### DIFF
--- a/docs/3_how_to_filter_articles.md
+++ b/docs/3_how_to_filter_articles.md
@@ -16,19 +16,21 @@ This tutorial shows you how to filter articles based on their attribute values, 
 ## Extraction filter
 
 A specific article may not contain all attributes the parser is capable of extracting.
-By default, Fundus drops all articles that aren't fully extracted to ensure data quality.
-You may miss a lot of data potentially useful for your project.
-To alter this behavior make use of the `extration_filter` parameter of the `crawl()` method.
-You do so by either using the built-in `ExtractionFilter` `Requires` or writing a custom one.
+By default, Fundus drops all articles without at least a title, body, and publishing date extracted to ensure data quality.
+To alter this behavior make use of the `only_complete` parameter of the `crawl()` method.
+You have three options to do so:
+- Use the build in `ExtractionFilter` `Requires`, or write a custome one.
+- Set it to `false` to disable extraction filtering entirely.
+- Set it to `true` to yield only fully extracted articles.
 
-Let's print some articles with at least a `body` and `title` set.
+Let's print some articles with at least a `body`, `title`, and `topics` set.
 
 ````python
 from fundus import Crawler, PublisherCollection, Requires
 
-crawler = Crawler(PublisherCollection.de)
+crawler = Crawler(PublisherCollection.us)
 
-for article in crawler.crawl(max_articles=2, only_complete=Requires("title", "body")):
+for article in crawler.crawl(max_articles=2, only_complete=Requires("title", "body", "topics")):
     print(article)
 ````
 

--- a/src/fundus/scraping/pipeline.py
+++ b/src/fundus/scraping/pipeline.py
@@ -21,7 +21,7 @@ from fundus import PublisherCollection
 from fundus.logging import basic_logger
 from fundus.publishers.base_objects import PublisherEnum
 from fundus.scraping.article import Article
-from fundus.scraping.filter import ExtractionFilter, URLFilter
+from fundus.scraping.filter import ExtractionFilter, URLFilter, Requires
 from fundus.scraping.html import URLSource, session_handler
 from fundus.scraping.scraper import Scraper
 from fundus.utils.more_async import ManagedEventLoop, async_next
@@ -65,7 +65,7 @@ class BaseCrawler:
         self,
         max_articles: Optional[int] = None,
         error_handling: Literal["suppress", "catch", "raise"] = "suppress",
-        only_complete: Union[bool, ExtractionFilter] = True,
+        only_complete: Union[bool, ExtractionFilter] = Requires("title, body", "publishing_date"),
         delay: Optional[Union[float, Delay]] = None,
         url_filter: Optional[URLFilter] = None,
         only_unique: bool = True,
@@ -77,7 +77,8 @@ class BaseCrawler:
         Args:
             max_articles (Optional[int]): Number of articles to crawl. Defaults to None.
             error_handling (Literal["suppress", "catch", "raise"]): Set error handling. Defaults to "suppress".
-            only_complete (Union[bool, ExtractionFilter]): Set extraction filters. Defaults to True
+            only_complete (Union[bool, ExtractionFilter]): Set extraction filters. Defaults to
+                Requires("title", "body", "publishing_date").
             delay (Optional[Union[float, Delay]]): Set delay time between article batches. Defaults to None.
             url_filter (Optional[URLFilter]): Set URLFilter. Defaults to None.
             only_unique (bool): If true return only unique responses. Defaults to True.
@@ -163,7 +164,7 @@ class BaseCrawler:
         self,
         max_articles: Optional[int] = None,
         error_handling: Literal["suppress", "catch", "raise"] = "suppress",
-        only_complete: Union[bool, ExtractionFilter] = True,
+        only_complete: Union[bool, ExtractionFilter] = Requires("title", "body", "publishing_date"),
         delay: Optional[Union[float, Delay]] = 0.1,
         url_filter: Optional[URLFilter] = None,
         only_unique: bool = True,
@@ -181,8 +182,9 @@ class BaseCrawler:
                 through Article.exception. If set to "raise" all errors encountered during extraction will
                 be raised. Defaults to "suppress".
             only_complete (Union[bool, ExtractionFilter]): Set a callable satisfying the ExtractionFilter
-                protocol as extraction filters or use a boolean. If False, all articles will be yielded,
-                if True, only those with all attributes extracted. Defaults to True.
+                protocol as an extraction filter or use a boolean. If False, all articles will be yielded,
+                if True, only those with all attributes extracted. Defaults to ExtractionFilter letting
+                through all articles with at least title, body, and publishing_date set.
             delay (Optional[Union[float, Delay]]): Set a delay time in seconds to be used between article
                 batches. You can set a delay directly using float or any callable satisfying the Delay
                 protocol. If set to None, no delay will be used between batches. See Delay for more

--- a/src/fundus/scraping/pipeline.py
+++ b/src/fundus/scraping/pipeline.py
@@ -21,7 +21,7 @@ from fundus import PublisherCollection
 from fundus.logging import basic_logger
 from fundus.publishers.base_objects import PublisherEnum
 from fundus.scraping.article import Article
-from fundus.scraping.filter import ExtractionFilter, URLFilter, Requires
+from fundus.scraping.filter import ExtractionFilter, Requires, URLFilter
 from fundus.scraping.html import URLSource, session_handler
 from fundus.scraping.scraper import Scraper
 from fundus.utils.more_async import ManagedEventLoop, async_next


### PR DESCRIPTION
Problem: Accepting only fully extracted articles as a default slows down Fundus and also presents it in a bad way. Many articles only lack some authors or topics and one could argue that the main focus is about the body.

Solution: This PR tries to solve this by accepting articles with at least a title, body, and publishing date set, and thus loosening the default.