### PR TITLE
Publisher Coverage Script and Badge

### DIFF
--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 1 * * *'  # Runs at 01:00
 
+  push:
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -1,0 +1,78 @@
+name: Publisher Coverage
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # Runs at 01:00
+
+  workflow_dispatch:
+
+jobs:
+  validate_crawlers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install Fundus
+        run: pip install -e .
+
+      - name: Validate Crawlers
+        run: |
+          set -o pipefail
+          exec python scripts/publisher_coverage.py | tee publisher_coverage.txt
+
+      - name: Upload Coverage Report
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Publisher Coverage
+          path: publisher_coverage.txt
+
+
+  create_badge:
+    runs-on: ubuntu-latest
+    needs: validate_crawlers
+    if: success() || failure()
+
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Download Coverage Report
+        uses: actions/download-artifact@v3
+        with:
+          name: Publisher Coverage
+
+      - name: Get Success Rate
+        run: echo "SUCCESS_RATE=$(tail -n 1 publisher_coverage.txt | grep -P -o '\d+\/\d+')" >> $GITHUB_ENV
+
+      - name: Get Coverage Bounds
+        run: |
+          echo "TOTAL_PUBLISHERS=$(echo ${{ env.SUCCESS_RATE }} | grep -P -o '\d+' | tail -1)" >> $GITHUB_ENV
+          echo "PASSED_PUBLISHERS=$(echo ${{ env.SUCCESS_RATE }} | grep -P -o '\d+' | head -1)" >> $GITHUB_ENV
+
+      - name: Get Red Threshold
+        # We set the badge colour to red when at least one publisher failed the tests.
+        run: echo "RED_THRESHOLD=$(( ${{ env.TOTAL_PUBLISHERS }} - 1 ))" >> $GITHUB_ENV
+
+      - name: Create Badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.DOBBERSC_GIST_SECRET }}
+          gistID: ca0ae056b05cbfeaf30fa42f84ddf458
+          filename: fundus_publisher_coverage.json
+          label: Publisher Coverage
+          message: ${{ env.SUCCESS_RATE }}
+          valColorRange: ${{ env.PASSED_PUBLISHERS }}
+          maxColorRange: ${{ env.TOTAL_PUBLISHERS }}
+          minColorRange: ${{ env.RED_THRESHOLD }}

--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 1 * * *'  # Runs at 01:00
 
-  push:
-
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Developed at <a href="https://www.informatik.hu-berlin.de/en/forschung-en/gebiet
 <img alt="version" src="https://img.shields.io/badge/version-0.1-green">
 <img alt="python" src="https://img.shields.io/badge/python-3.8-blue">
 <img alt="Static Badge" src="https://img.shields.io/badge/license-MIT-green">
-<img alt="Publisher Coverage" scr="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/dobbersc/ca0ae056b05cbfeaf30fa42f84ddf458/raw/fundus_publisher_coverage.json">
+<img alt="Publisher Coverage" src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/dobbersc/ca0ae056b05cbfeaf30fa42f84ddf458/raw/fundus_publisher_coverage.json">
 </p>
 <div align="center">
 <hr>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Developed at <a href="https://www.informatik.hu-berlin.de/en/forschung-en/gebiet
 <img alt="version" src="https://img.shields.io/badge/version-0.1-green">
 <img alt="python" src="https://img.shields.io/badge/python-3.8-blue">
 <img alt="Static Badge" src="https://img.shields.io/badge/license-MIT-green">
+<img alt="Publisher Coverage" scr="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/dobbersc/ca0ae056b05cbfeaf30fa42f84ddf458/raw/fundus_publisher_coverage.json">
 </p>
 <div align="center">
 <hr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest~=7.2.2",
-    "mypy>=1.1.1",
+    "mypy==1.1.1",
     "isort==5.12.0",
     "black==23.1.0",
     # type stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest~=7.2.2",
-    "mypy~=1.1.1",
+    "mypy>=1.1.1",
     "isort==5.12.0",
     "black==23.1.0",
     # type stubs

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -1,6 +1,6 @@
 """
-This script performs a baseline crawler validation for every publisher and reports the test coverage.
-The tests include a real-time crawl for each publisher's news map and RSS-Feed
+This script performs a baseline real-time crawler validation for every publisher and reports the test coverage.
+The tests include a real-time crawl for each publisher's news map and RSS Feed
 checking the received articles for attribute completeness.
 Note that this script does not check the attributes' correctness, only their presence.
 """

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -7,7 +7,7 @@ Note that this script does not check the attributes' correctness, only their pre
 import sys
 import traceback
 from enum import EnumMeta
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from fundus import Crawler, NewsMap, PublisherCollection, RSSFeed
 from fundus.publishers.base_objects import PublisherEnum
@@ -17,7 +17,7 @@ from fundus.scraping.article import Article
 def main() -> None:
     failed: int = 0
 
-    publisher_regions: list[EnumMeta] = sorted(
+    publisher_regions: List[EnumMeta] = sorted(
         PublisherCollection.get_publisher_enum_mapping().values(), key=lambda region: region.__name__
     )
 

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -28,6 +28,8 @@ def main() -> None:
         for publisher in sorted(
             publisher_region, key=lambda p: cast(PublisherEnum, p).name  # type: ignore[no-any-return]
         ):
+            publisher_name: str = publisher.name  # type: ignore[attr-defined]
+
             crawler: Crawler = Crawler(publisher, restrict_sources_to=[NewsMap, RSSFeed])
             complete_article: Optional[Article] = next(
                 crawler.crawl(max_articles=1, only_complete=True, error_handling="catch"), None
@@ -39,10 +41,10 @@ def main() -> None:
                 )
 
                 if incomplete_article is None:
-                    print(f"❌ FAILED: {publisher.name!r} - No articles received")
+                    print(f"❌ FAILED: {publisher_name!r} - No articles received")
                 else:
                     print(
-                        f"❌ FAILED: {publisher.name!r} - No complete articles received "
+                        f"❌ FAILED: {publisher_name!r} - No complete articles received "
                         f"(URL of an incomplete article: {incomplete_article.html.requested_url})"
                     )
                 failed += 1
@@ -50,7 +52,7 @@ def main() -> None:
 
             if complete_article.exception is not None:
                 print(
-                    f"❌ FAILED: {publisher.name!r} - Encountered exception during crawling "
+                    f"❌ FAILED: {publisher_name!r} - Encountered exception during crawling "
                     f"(URL: {complete_article.html.requested_url})"
                 )
                 traceback.print_exception(
@@ -63,7 +65,7 @@ def main() -> None:
                 failed += 1
                 continue
 
-            print(f"✔️ PASSED: {publisher.name!r}")
+            print(f"✔️ PASSED: {publisher_name!r}")
         print()
 
     total_publishers: int = len(PublisherCollection)

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -1,0 +1,81 @@
+"""
+This script performs a baseline crawler validation for every publisher and reports the test coverage.
+The tests include a real-time crawl for each publisher's news map and RSS-Feed
+checking the received articles for attribute completeness.
+Note that this script does not check the attributes' correctness, only their presence.
+"""
+import sys
+import traceback
+from enum import EnumMeta
+from typing import Optional, cast
+
+from fundus import Crawler, NewsMap, PublisherCollection, RSSFeed
+from fundus.publishers.base_objects import PublisherEnum
+from fundus.scraping.article import Article
+
+
+def main() -> None:
+    failed: int = 0
+
+    publisher_regions: list[EnumMeta] = sorted(
+        PublisherCollection.get_publisher_enum_mapping().values(), key=lambda region: region.__name__
+    )
+
+    for publisher_region in publisher_regions:
+        print(f"{publisher_region.__name__:-^50}")
+
+        publisher: PublisherEnum
+        for publisher in sorted(
+            publisher_region, key=lambda p: cast(PublisherEnum, p).name  # type: ignore[no-any-return]
+        ):
+            crawler: Crawler = Crawler(publisher, restrict_sources_to=[NewsMap, RSSFeed])
+
+            complete_article: Optional[Article] = next(
+                crawler.crawl(max_articles=1, only_complete=True, error_handling="catch"), None
+            )
+
+            if complete_article is None:
+                incomplete_article: Optional[Article] = next(
+                    crawler.crawl(max_articles=1, only_complete=False, error_handling="suppress"), None
+                )
+
+                if incomplete_article is None:
+                    print(f"❌ FAILED: {publisher.name!r} - No articles received")
+                else:
+                    print(
+                        f"❌ FAILED: {publisher.name!r} - No complete articles received "
+                        f"(URL of an incomplete article: {incomplete_article.html.requested_url})"
+                    )
+                failed += 1
+                continue
+
+            if complete_article.exception is not None:
+                print(
+                    f"❌ FAILED: {publisher.name!r} - Encountered exception during crawling "
+                    f"(URL: {complete_article.html.requested_url})"
+                )
+                traceback.print_exception(
+                    etype=type(complete_article.exception),
+                    value=complete_article.exception,
+                    tb=complete_article.exception.__traceback__,
+                    file=sys.stdout,
+                )
+
+                failed += 1
+                continue
+
+            print(f"✔️ PASSED: {publisher.name!r}")
+        print()
+
+    total_publishers: int = len(PublisherCollection)
+    pass_ratio: str = f"{total_publishers - failed}/{total_publishers}"
+    if failed:
+        print(f"🚨 {pass_ratio} - Some publishers finished in a 'FAILED' state")
+    else:
+        print(f"✨ {pass_ratio} - All publishers passed the tests")
+
+    exit(failed)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -28,8 +28,9 @@ def main() -> None:
         for publisher in sorted(
             publisher_region, key=lambda p: cast(PublisherEnum, p).name  # type: ignore[no-any-return]
         ):
-            crawler: Crawler = Crawler(publisher, restrict_sources_to=[NewsMap, RSSFeed])
+            publisher_name: str = publisher.name  # type: ignore[attr-defined]
 
+            crawler: Crawler = Crawler(publisher, restrict_sources_to=[NewsMap, RSSFeed])
             complete_article: Optional[Article] = next(
                 crawler.crawl(max_articles=1, only_complete=True, error_handling="catch"), None
             )
@@ -40,10 +41,10 @@ def main() -> None:
                 )
 
                 if incomplete_article is None:
-                    print(f"❌ FAILED: {publisher.name!r} - No articles received")
+                    print(f"❌ FAILED: {publisher_name!r} - No articles received")
                 else:
                     print(
-                        f"❌ FAILED: {publisher.name!r} - No complete articles received "
+                        f"❌ FAILED: {publisher_name!r} - No complete articles received "
                         f"(URL of an incomplete article: {incomplete_article.html.requested_url})"
                     )
                 failed += 1
@@ -51,7 +52,7 @@ def main() -> None:
 
             if complete_article.exception is not None:
                 print(
-                    f"❌ FAILED: {publisher.name!r} - Encountered exception during crawling "
+                    f"❌ FAILED: {publisher_name!r} - Encountered exception during crawling "
                     f"(URL: {complete_article.html.requested_url})"
                 )
                 traceback.print_exception(
@@ -64,7 +65,7 @@ def main() -> None:
                 failed += 1
                 continue
 
-            print(f"✔️ PASSED: {publisher.name!r}")
+            print(f"✔️ PASSED: {publisher_name!r}")
         print()
 
     total_publishers: int = len(PublisherCollection)

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -28,8 +28,6 @@ def main() -> None:
         for publisher in sorted(
             publisher_region, key=lambda p: cast(PublisherEnum, p).name  # type: ignore[no-any-return]
         ):
-            publisher_name: str = publisher.name  # type: ignore[attr-defined]
-
             crawler: Crawler = Crawler(publisher, restrict_sources_to=[NewsMap, RSSFeed])
             complete_article: Optional[Article] = next(
                 crawler.crawl(max_articles=1, only_complete=True, error_handling="catch"), None
@@ -41,10 +39,10 @@ def main() -> None:
                 )
 
                 if incomplete_article is None:
-                    print(f"❌ FAILED: {publisher_name!r} - No articles received")
+                    print(f"❌ FAILED: {publisher.name!r} - No articles received")
                 else:
                     print(
-                        f"❌ FAILED: {publisher_name!r} - No complete articles received "
+                        f"❌ FAILED: {publisher.name!r} - No complete articles received "
                         f"(URL of an incomplete article: {incomplete_article.html.requested_url})"
                     )
                 failed += 1
@@ -52,7 +50,7 @@ def main() -> None:
 
             if complete_article.exception is not None:
                 print(
-                    f"❌ FAILED: {publisher_name!r} - Encountered exception during crawling "
+                    f"❌ FAILED: {publisher.name!r} - Encountered exception during crawling "
                     f"(URL: {complete_article.html.requested_url})"
                 )
                 traceback.print_exception(
@@ -65,7 +63,7 @@ def main() -> None:
                 failed += 1
                 continue
 
-            print(f"✔️ PASSED: {publisher_name!r}")
+            print(f"✔️ PASSED: {publisher.name!r}")
         print()
 
     total_publishers: int = len(PublisherCollection)


### PR DESCRIPTION
This PR adds a script to execute a baseline real-time crawler validation. A problem with the current crawler unit tests is that the crawlers are only validated on pre-fetched articles. This script aims to check a publisher's availability and basic crawl results.
The tests include a real-time crawl for each publisher's news map and RSS Feed checking the received articles for attribute completeness. Note that this script does not check the attributes' correctness, only their presence. The resulting publisher coverage is then summarised in the output report.

To automate the publisher coverage script this PR includes an action that runs every day at 01:00 generating a badge containing the publisher coverage displayed in the README. See [here](https://github.com/flairNLP/fundus/actions/runs/6632110282/job/18017082728) for a current action run.

To enhance the functionality we could also run the tests for each source independently, e.g. news map and RSS feed if specified, such that a crawler only passes the tests if all specified sources return appropriate articles.


