### PR TITLE
Fix bugs in contribution tutorial and test generation

### DIFF
--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -73,7 +73,7 @@ class US(PublisherEnum):
     )
 ```
 
-If the country section for your publisher did not exist before step 1, please add the `PublisherEnum` to `src/library/collection/__init__.py'`.
+If the country section for your publisher did not exist before step 1, please add the `PublisherEnum` to the `PublisherCollection` in `fundus/publishers/__init__.py'`.
 
 ### Adding Sources
 
@@ -217,7 +217,7 @@ publisher = PublisherCollection.us.LosAngelesTimes
 
 crawler = Crawler(publisher)
 
-for article in crawler.crawl(max_articles=2):
+for article in crawler.crawl(max_articles=2, only_complete=False):
     print(article)
 ```
 

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -211,6 +211,10 @@ class HTMLTestFile:
             None
 
         """
+
+        # ensure that path exists
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
         with open(self.path, "wb") as file:
             file.write(gzip.compress(bytes(self.content, self.encoding)))
         self._register_at_meta_info()


### PR DESCRIPTION
Fixes the following bugs found by @addie9800 
1. `how_to_contribute_a_publisher.md`
     - leftover in section 2
     - a bug with the validation script in section 4
2. fixed a bug In the test case generation in which the script required a directory without ensuring that it was there.
