### PR TITLE
Makes article properties over writable by parser

### DIFF
--- a/src/fundus/parser/__init__.py
+++ b/src/fundus/parser/__init__.py
@@ -1,4 +1,10 @@
-from .base_parser import BaseParser, ParserProxy, attribute, function
+from .base_parser import (
+    BaseParser,
+    ParserProxy,
+    attribute,
+    function,
+    overwrite_attribute,
+)
 from .data import ArticleBody
 
-__all__ = ["ParserProxy", "BaseParser", "attribute", "function", "ArticleBody"]
+__all__ = ["ParserProxy", "BaseParser", "attribute", "function", "overwrite_attribute", "ArticleBody"]

--- a/src/fundus/parser/base_parser.py
+++ b/src/fundus/parser/base_parser.py
@@ -89,10 +89,7 @@ class Function(RegisteredFunction):
 
 def _register(cls, factory: Type[RegisteredFunction], **kwargs):
     def wrapper(func):
-        try:
-            return functools.update_wrapper(factory(func, **kwargs), func)
-        except TypeError as err:
-            raise err
+        return functools.update_wrapper(factory(func, **kwargs), func)
 
     # _register was called with parenthesis
     if cls is None:

--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -11,6 +11,7 @@ from colorama import Fore, Style
 from fundus.logging.logger import basic_logger
 from fundus.parser import ArticleBody
 from fundus.scraping.html import HTML
+from fundus.utils.caching import cached_attribute
 
 
 @dataclass(frozen=True)
@@ -41,12 +42,17 @@ class Article:
 
         return article
 
-    @property
+    @cached_attribute
     def plaintext(self) -> Optional[str]:
         return str(self.body) if self.body else None
 
-    @property
+    @cached_attribute
     def lang(self) -> Optional[str]:
+        """
+        computes used language
+        Returns:
+
+        """
         language: Optional[str] = None
 
         if self.plaintext:

--- a/src/fundus/utils/caching.py
+++ b/src/fundus/utils/caching.py
@@ -1,0 +1,39 @@
+import functools
+
+
+class _CachedAttribute(object):
+    """Computes attribute value and caches it in the instance.
+    From https://stackoverflow.com/questions/7388258/replace-property-for-perfomance-gain?noredirect=1&lq=1
+    Tweaked a bit to be used with a wrapper.
+    """
+
+    def __init__(self, method):
+        self.method = method
+
+    def __get__(self, inst, cls):
+        if inst is None:
+            return self
+        result = self.method(inst)
+        object.__setattr__(inst, self.__name__, result)  # type: ignore[attr-defined]
+        return result
+
+
+# This was implemented in order to
+def cached_attribute(attribute):
+    """Decorate attributes to be cached.
+
+    This works like `cached_property`, but instead of `property` or `cached_property`, the decorated attribute
+    can be overwritten.
+
+    Args:
+        attribute: The attribute to decorate.
+
+    Returns:
+        A wrapped _CachedAttribute instance.
+
+    """
+
+    def wrapper(func):
+        return functools.update_wrapper(_CachedAttribute(func), func)
+
+    return wrapper(attribute)


### PR DESCRIPTION
This PR adds functionality to write over properties like `lang` defined in the `article` class. We do so by replacing the former `property` logic with a custom one. The new implementation now caches the values as well so it now works like `cached_property` but instead of `cached_property` it can be overwritten.

I.e. to overwrite the `lang` attribute of `Article` use the following in your desired parser.

```python
from fundus.parser import ..., overwrite_attribute

    ...

    @overwrite_attribute
    def lang(self) -> str:
        return "This a new language value"
```

closes #328 