### PR TITLE
Fix `LD` parsing

### DIFF
--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -38,6 +38,8 @@ class LinkedDataMapping:
     In this context an LD is represented as a python dict.
     """
 
+    __UNKNOWN_TYPE__ = "UNKNOWN_TYPE"
+
     def __init__(self, lds: Iterable[Dict[str, Any]] = ()):
         for ld in lds:
             if graph := ld.get("@graph"):
@@ -60,7 +62,9 @@ class LinkedDataMapping:
             else:
                 self.__dict__[ld_type] = ld
         else:
-            raise ValueError(f"Found no type for LD")
+            if not self.__dict__.get(self.__UNKNOWN_TYPE__):
+                self.__dict__[self.__UNKNOWN_TYPE__] = []
+            self.__dict__[self.__UNKNOWN_TYPE__].append(ld)
 
     def get(self, ld_type: str, default: Any = None) -> Optional[LDMappingValue]:
         """


### PR DESCRIPTION
This fixes an issue within LD parsing that caused LD's without an `@type` property to raise an exception.
This will also fix issues with `TheIndependent` noticeable in the [coverage action](https://github.com/flairNLP/fundus/actions/runs/7496921585/job/20409726758).