### PR TITLE
Allow additional selectors for meta parsing

### DIFF
--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -121,7 +121,9 @@ def extract_article_body_with_selector(
 _meta_node_selector = CSSSelector("meta[name], meta[property]")
 
 
-def get_meta_content(tree: lxml.html.HtmlElement) -> Dict[str, str]:
+def get_meta_content(
+    tree: lxml.html.HtmlElement, additional_selectors: Optional[Dict[str, Union[XPath, CSSSelector]]] = None
+) -> Dict[str, str]:
     meta_nodes = _meta_node_selector(tree)
     meta: Dict[str, str] = {}
     for node in meta_nodes:
@@ -129,6 +131,13 @@ def get_meta_content(tree: lxml.html.HtmlElement) -> Dict[str, str]:
         value = node.attrib.get("content")
         if key and value:
             meta[key] = value
+
+    if additional_selectors:
+        for key, selector in additional_selectors.items():
+            for node in selector(tree):
+                if content := node.attrib.get("content"):
+                    meta[node.attrib[key]] = content
+
     return meta
 
 


### PR DESCRIPTION
This adds a new parameter `additional_selectors` to `get_meta_content`. The parameter expects a mapping in the form of a dictionary to add additional selectors to the meta parser.

Let's assume the following meta tag:
```html
<meta itemprop="headline" content="The Gospel According to Paul: A Comprehensive Study of Paul's Message in the 'New Testament'">
```

One can now pass the following mapping to the parser to extract this malformed `meta` tag.
```python
{
    "itemprop": CSSSelector("meta[itemprop]")
}
```