### PR TITLE
Two major bug fixes

### DIFF
--- a/src/fundus/scraping/pipeline.py
+++ b/src/fundus/scraping/pipeline.py
@@ -65,7 +65,7 @@ class BaseCrawler:
         self,
         max_articles: Optional[int] = None,
         error_handling: Literal["suppress", "catch", "raise"] = "suppress",
-        only_complete: Union[bool, ExtractionFilter] = Requires("title, body", "publishing_date"),
+        only_complete: Union[bool, ExtractionFilter] = Requires("title", "body", "publishing_date"),
         delay: Optional[Union[float, Delay]] = None,
         url_filter: Optional[URLFilter] = None,
         only_unique: bool = True,
@@ -232,7 +232,7 @@ class Crawler(BaseCrawler):
 
         Args:
             *publishers (Union[PublisherEnum, Type[PublisherEnum]]): The publishers to crawl.
-            restrict_sources_to (Optional[List[Type[URLSource]]]): Let's you restrict
+            restrict_sources_to (Optional[List[Type[URLSource]]]): Lets you restrict
                 sources defined in the publisher specs. If set, only articles from given source types
                 will be yielded.
         """

--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -62,7 +62,7 @@ class Scraper:
                         continue
                     elif error_handling == "suppress":
                         basic_logger.info(f"Skipped article at '{html.requested_url}' because of: {err!r}")
-                        continue
+                        yield None
                     else:
                         raise ValueError(f"Unknown value '{error_handling}' for parameter <error_handling>'")
 


### PR DESCRIPTION
- Fixes a faulty default parameter for `crawl_async` making it unusable using default parameters.
- Fixes a bug that caused bugged parser with uncaught exceptions to occupy the pipeline making `PublisherCollection.de` almost unusable.