### PR TITLE
Add release workflow to automatically publish on PyPi

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+  workflow_call:
 
 jobs:
   black:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -57,6 +57,7 @@ jobs:
     environment:
       name: testpypi
       url: https://test.pypi.org/p/fundus
+      
     permissions:
       id-token: write
 
@@ -66,6 +67,7 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+          
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -113,6 +115,7 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+          
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,114 @@
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+
+  test:
+    name: Test the latest release commit
+    uses: ./.github/workflows/tests.yml
+
+  lint:
+    name: Lint the latest release commit
+    uses: ./.github/workflows/lint.yml
+
+  build:
+    name: Build distribution 📦
+    needs:
+      - test
+      - lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: 'pyproject.toml'
+
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distribution
+          path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/<package-name>fundus
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  test-distribution:
+    name: Install and test TestPyPi distribution
+    needs:
+      - publish-to-testpypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: 'pyproject.toml'
+
+      - name: Install package
+        run: >- 
+          python3 -m 
+          pip install 
+          --index-url https://test.pypi.org/simple/ 
+          --extra-index-url https://pypi.org/simple/ 
+          fundus==${{ github.event.release.tag_name }}
+
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+
+    needs:
+    - test-distribution
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fundus
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -56,7 +56,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/<package-name>fundus
+      url: https://test.pypi.org/p/fundus
     permissions:
       id-token: write
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,3 +1,6 @@
+# This release workflow was created using the following guide
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -73,6 +73,10 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
+      - name: Sleep for 2 minutes
+        run: sleep 2m
+        shell: bash
+
   test-distribution:
     name: Install and test TestPyPi distribution
     needs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -87,7 +87,7 @@ jobs:
           python-version-file: 'pyproject.toml'
 
       - name: Install package
-        run: >- 
+        run: >-
           python3 -m 
           pip install 
           --index-url https://test.pypi.org/simple/ 
@@ -96,10 +96,8 @@ jobs:
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
-
     needs:
-    - test-distribution
+      - test-distribution
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Store the distribution packages
         uses: actions/upload-artifact@v3
         with:
-          name: python-package-distribution
+          name: python-package-distributions
           path: dist/
 
   publish-to-testpypi:
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: 'pyproject.toml'
+          python-version: '3.8'
 
       - name: Install pypa/build
         run: >-
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: 'pyproject.toml'
+          python-version: '3.8'
 
       - name: Install package
         run: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see:
-# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: tests
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+  workflow_call:
 
 jobs:
   pytest:


### PR DESCRIPTION
This workflow adds the following jobs that trigger on any release with [type](https://docs.github.com/en/webhooks/webhook-events-and-payloads#release) `released`.

Jobs:

1. Test/Lint using existing workflows
2. Build distribution
3. Upload to TestPyPi
4. Test installation from TestPyPi
5. Upload to PyPi