### PR TITLE
Add URL parameter to test generation script

### DIFF
--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -26,7 +26,7 @@ def get_test_article(enum: PublisherEnum, url: Optional[str] = None) -> Optional
     return next(crawler.crawl(max_articles=1, error_handling="suppress", only_complete=True), None)
 
 
-if __name__ == "__main__":
+def main() -> None:
     parser = ArgumentParser(
         prog="generate_parser_test_files",
         description=(
@@ -124,3 +124,7 @@ if __name__ == "__main__":
             test_data_file.write(test_data)
             bar.update()
             subprocess.call(["git", "add", test_data_file.path], stdout=subprocess.PIPE)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -39,13 +39,15 @@ if __name__ == "__main__":
         "attributes",
         metavar="A",
         nargs="*",
-        help=f"the attributes which should be used to create test cases. "
-        f"default: {', '.join(attributes_required_to_cover)}",
+        help=(
+            "the attributes which should be used to create test cases. "
+            f"default: {', '.join(attributes_required_to_cover)}"
+        ),
     )
     parser.add_argument("-p", dest="publishers", metavar="P", nargs="+", help="only consider given publishers")
     parser.add_argument(
         "-u",
-        dest="urls",
+        "--urls",
         metavar="U",
         nargs="+",
         help="use given URL instead of searching for an article. if set the urls will be mapped to the order of -p",


### PR DESCRIPTION
This adds a new parameter `-u` to `scripts.generate_parser_test_files`
This parameter enables one to specify a URL to be used as a test case, see #333 
The `-p` parameter is necessary if URL(s) are given and the order of given publishers corresponds to the order of given URL(s). 