### PR TITLE
Adjust paragraph selector for CNBC

### DIFF
--- a/src/fundus/publishers/us/cnbc.py
+++ b/src/fundus/publishers/us/cnbc.py
@@ -2,6 +2,7 @@ import datetime
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
+from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import (
@@ -15,7 +16,7 @@ from fundus.parser.utility import (
 class CNBCParser(ParserProxy):
     class V1(BaseParser):
         _subheadline_selector: CSSSelector = CSSSelector("div[data-module = 'ArticleBody'] > h2")
-        _paragraph_selector: CSSSelector = CSSSelector("div.group > p")
+        _paragraph_selector: CSSSelector = XPath("//div[@data-module='ArticleBody'] / div[@class='group'] / p[text()]")
         _key_points_selector: CSSSelector = CSSSelector("div.RenderKeyPoints-list li")
 
         @attribute

--- a/src/fundus/publishers/us/cnbc.py
+++ b/src/fundus/publishers/us/cnbc.py
@@ -16,7 +16,7 @@ from fundus.parser.utility import (
 class CNBCParser(ParserProxy):
     class V1(BaseParser):
         _subheadline_selector: CSSSelector = CSSSelector("div[data-module = 'ArticleBody'] > h2")
-        _paragraph_selector: CSSSelector = XPath("//div[@data-module='ArticleBody'] / div[@class='group'] / p[text()]")
+        _paragraph_selector: XPath = XPath("//div[@data-module='ArticleBody'] / div[@class='group'] / p[text()]")
         _key_points_selector: CSSSelector = CSSSelector("div.RenderKeyPoints-list li")
 
         @attribute


### PR DESCRIPTION
Adjusts the CNBC paragraph selector slightly for better quality.

Example articles:
https://www.cnbc.com/2023/04/28/many-new-bitcoin-crypto-buyers-influenced-by-friends-why-to-be-cautious.html
https://www.cnbc.com/2024/02/22/americans-with-debt-putting-less-money-toward-credit-card-payments.html