### PR TITLE
Adjust paragraph selector for Fox News parser

### DIFF
--- a/src/fundus/publishers/us/fox_news.py
+++ b/src/fundus/publishers/us/fox_news.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List, Optional
 
-from lxml.cssselect import CSSSelector
+from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import (
@@ -14,7 +14,7 @@ from fundus.parser.utility import (
 
 class FoxNewsParser(ParserProxy):
     class V1(BaseParser):
-        _paragraph_selector = CSSSelector(".article-body > p")
+        _paragraph_selector = XPath("//div[@class='article-body'] / p[text()]")
 
         @attribute
         def body(self) -> ArticleBody:

--- a/src/fundus/publishers/us/fox_news.py
+++ b/src/fundus/publishers/us/fox_news.py
@@ -17,7 +17,7 @@ class FoxNewsParser(ParserProxy):
     class V1(BaseParser):
         _summary_selector = CSSSelector(".article-meta > h2")
         _paragraph_selector = XPath(
-            "(//div[@class='article-body'] | //div[@class='article-body']/div[@class='paywall']) "
+            "(//div[@class='article-body'] | //div[@class='article-body']/div[contains(@class, 'paywall')]) "
             "/p[not(child::script) and text()]"
         )
 

--- a/src/fundus/publishers/us/fox_news.py
+++ b/src/fundus/publishers/us/fox_news.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import List, Optional
 
+from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
@@ -14,7 +15,11 @@ from fundus.parser.utility import (
 
 class FoxNewsParser(ParserProxy):
     class V1(BaseParser):
-        _paragraph_selector = XPath("//div[@class='article-body'] / p[text()]")
+        _summary_selector = CSSSelector(".article-meta > h2")
+        _paragraph_selector = XPath(
+            "(//div[@class='article-body'] | //div[@class='article-body']/div[@class='paywall']) "
+            "/p[not(child::script) and text()]"
+        )
 
         @attribute
         def body(self) -> ArticleBody:


### PR DESCRIPTION
This adds a new `summary` selector as well as including paragraphs with optional `div.paywall` parent node.