### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/fundus/py.typed


### PR DESCRIPTION
This PR is a follow-up to #387 to include the `py.typed` file in the built distribution for the end user.