### PR TITLE
Exclude `validators` verions `0.23.x`, log `URLSource` with invalid URL as init parameter as error instead of raising.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "langdetect>=1.0, <2",
     "aiohttp>=3.8, <4",
     "aioitertools>=0.11, <1",
-    "validators>=0.20, <1",
+    "validators>=0.20, <1, !=0.23",
     "requests>=2.28, <3",
     "tqdm>=4.66, <5",
     "fastwarc>=0.14, <1",

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -166,7 +166,7 @@ class URLSource(AsyncIterable[str], ABC):
         if not self._request_header:
             self._request_header = _default_header
         if not validators.url(self.url):
-            raise ValueError(f"Invalid url '{self.url}'")
+            basic_logger.error(f"{type(self).__name__} initialized with invalid URL {self.url}")
 
     def set_header(self, request_header: Dict[str, str]) -> None:
         self._request_header = request_header


### PR DESCRIPTION
This PR is an answer to recent troubles with the `validators` package. It:
- excludes `validators`' version `0.23.x`
- logs invalid init URLs for `URLSource` as an error instead of raising them, taking leverage away from the `validators` package.