### PR TITLE
Fix domains for several publishers

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -238,8 +238,8 @@
         <div>N-Tv</div>
       </td>
       <td>
-        <a href="https://www.ntv.de/">
-          <span>www.ntv.de</span>
+        <a href="https://www.n-tv.de/">
+          <span>www.n-tv.de</span>
         </a>
       </td>
       <td>&#160;</td>
@@ -503,8 +503,8 @@
         <div>Associated Press News</div>
       </td>
       <td>
-        <a href="https://www.apnews.com/">
-          <span>www.apnews.com</span>
+        <a href="https://apnews.com/">
+          <span>apnews.com</span>
         </a>
       </td>
       <td>&#160;</td>
@@ -616,8 +616,8 @@
         <div>The Intercept</div>
       </td>
       <td>
-        <a href="https://www.theintercept.com/">
-          <span>www.theintercept.com</span>
+        <a href="https://theintercept.com/">
+          <span>theintercept.com</span>
         </a>
       </td>
       <td>&#160;</td>
@@ -666,8 +666,8 @@
         <div>The Washington Free Beacon</div>
       </td>
       <td>
-        <a href="https://www.freebeacon.com/">
-          <span>www.freebeacon.com</span>
+        <a href="https://freebeacon.com/">
+          <span>freebeacon.com</span>
         </a>
       </td>
       <td>&#160;</td>

--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -158,7 +158,7 @@ class DE(PublisherEnum):
 
     NTV = PublisherSpec(
         name="N-Tv",
-        domain="https://www.ntv.de/",
+        domain="https://www.n-tv.de/",
         sources=[NewsMap("https://www.n-tv.de/news.xml"), Sitemap("https://www.n-tv.de/sitemap.xml")],
         parser=NTVParser,
     )

--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -176,7 +176,7 @@ class DE(PublisherEnum):
 
     Taz = PublisherSpec(
         name="Die Tageszeitung (taz)",
-        domain="https://www.taz.de/",
+        domain="https://taz.de/",
         sources=[
             NewsMap("https://taz.de/sitemap-google-news.xml"),
             Sitemap("https://taz.de/sitemap-index.xml"),

--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -20,7 +20,7 @@ from .world_truth import WorldTruthParser
 class US(PublisherEnum):
     APNews = PublisherSpec(
         name="Associated Press News",
-        domain="https://www.apnews.com/",
+        domain="https://apnews.com/",
         sources=[
             Sitemap(
                 "https://apnews.com/sitemap.xml",
@@ -41,7 +41,7 @@ class US(PublisherEnum):
 
     TheIntercept = PublisherSpec(
         name="The Intercept",
-        domain="https://www.theintercept.com/",
+        domain="https://theintercept.com/",
         sources=[
             RSSFeed("https://theintercept.com/feed/?lang=en"),
             Sitemap(
@@ -100,7 +100,7 @@ class US(PublisherEnum):
 
     FreeBeacon = PublisherSpec(
         name="The Washington Free Beacon",
-        domain="https://www.freebeacon.com/",
+        domain="https://freebeacon.com/",
         sources=[NewsMap("https://freebeacon.com/post_google_news.xml")],
         parser=FreeBeaconParser,
     )


### PR DESCRIPTION
Including:
- `TAZ`
- `NTV`
- `APNews`
- `TheIntercept`
- `FreeBeacon`