### PR TITLE
Adds Pretty Print for PublisherCollection and PublisherSpec

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -19,7 +19,7 @@
         <code>ORF</code>
       </td>
       <td>
-        <div>ORF</div>
+        <div>&#214;sterreichischer Rundfunk</div>
       </td>
       <td>
         <a href="https://www.orf.at">

--- a/src/fundus/publishers/at/__init__.py
+++ b/src/fundus/publishers/at/__init__.py
@@ -8,7 +8,7 @@ from .orf import OrfParser
 
 class AT(PublisherEnum):
     ORF = PublisherSpec(
-        name="ORF",
+        name="Österreichischer Rundfunk",
         domain="https://www.orf.at",
         sources=[RSSFeed("https://rss.orf.at/news.xml")],
         parser=OrfParser,

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -22,7 +22,7 @@ class PublisherSpec:
 
 class PublisherEnumMeta(EnumMeta):
     def __str__(self) -> str:
-        representation = f"Publisher Collection {self.__name__} containing {len(self)} publisher(s), including:"
+        representation = f"Region {self.__name__!r} containing {len(self)} publisher(s), including:"
         publisher: str
         for publisher in islice(self.__members__.values(), 0, 5):
             representation += f"\n\t {publisher}"

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -1,6 +1,7 @@
 import inspect
 from dataclasses import dataclass, field
 from enum import Enum, EnumMeta, unique
+from itertools import islice
 from typing import Any, Dict, Iterator, List, Optional, Type
 
 from fundus.parser.base_parser import ParserProxy
@@ -19,8 +20,17 @@ class PublisherSpec:
     request_header: Dict[str, str] = field(default_factory=dict)
 
 
+class PublisherEnumMeta(EnumMeta):
+    def __str__(self) -> str:
+        representation = f"Publisher Collection {self.__name__} containing {len(self)} publisher(s), including:"
+        publisher: str
+        for publisher in islice(self.__members__.values(), 0, 5):
+            representation += f"\n\t {publisher}"
+        return representation
+
+
 @unique
-class PublisherEnum(Enum):
+class PublisherEnum(Enum, metaclass=PublisherEnumMeta):
     def __new__(cls, *args, **kwargs):
         value = len(cls.__members__) + 1
         obj = object.__new__(cls)
@@ -58,6 +68,9 @@ class PublisherEnum(Enum):
             source_mapping[type(url_source)].append(source)
 
         self.source_mapping = source_mapping
+
+    def __str__(self) -> str:
+        return f"{self.publisher_name}"
 
     def supports(self, source_types: List[Type[URLSource]]) -> bool:
         if not source_types:
@@ -193,3 +206,15 @@ class PublisherCollectionMeta(type):
             int: The number of publishers.
         """
         return len(list(iter(cls)))
+
+    def __str__(self) -> str:
+        enum_mapping = self.get_publisher_enum_mapping()
+        enum_mapping_keys = enum_mapping.keys()
+        representation = f"The entire Publisher Collection consists of {len(self)} publishers from {len(enum_mapping_keys)} countries:"
+        publisher: str
+        country: str
+        for country in enum_mapping_keys:
+            representation += f"\n\t {country}:"
+            for publisher in enum_mapping[country]:
+                representation += f"\n\t\t {publisher}"
+        return representation

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -22,9 +22,9 @@ class PublisherSpec:
 
 class PublisherEnumMeta(EnumMeta):
     def __str__(self) -> str:
-        representation = f"Region {self.__name__!r} containing {len(self)} publisher(s), including:"
+        representation = f"Region {self.__name__!r} containing {len(self)} publisher(s):"
         publisher: str
-        for publisher in islice(self.__members__.values(), 0, 5):
+        for publisher in self.__members__.values():
             representation += f"\n\t {publisher}"
         return representation
 
@@ -210,11 +210,15 @@ class PublisherCollectionMeta(type):
     def __str__(self) -> str:
         enum_mapping = self.get_publisher_enum_mapping()
         enum_mapping_keys = enum_mapping.keys()
-        representation = f"The entire Publisher Collection consists of {len(self)} publishers from {len(enum_mapping_keys)} countries:"
+        representation = (
+            f"The {self.__name__!r} consists of {len(self)} publishers from {len(enum_mapping_keys)} , including:"
+        )
         publisher: str
         country: str
         for country in enum_mapping_keys:
             representation += f"\n\t {country}:"
-            for publisher in enum_mapping[country]:
+            for publisher in islice(enum_mapping[country], 0, 5):
                 representation += f"\n\t\t {publisher}"
+            if len(enum_mapping[country]) > 5:
+                representation += f"\n\t\t ..."
         return representation


### PR DESCRIPTION
Closes #345 

and has the following behavior:
`print(PublisherCollection)` prints

```python
The entire Publisher Collection consists of 38 publishers from 6 countries:
	 na:
		 The Namibian
	 de:
		 Die Welt
		 Mitteldeutscher Rundfunk (MDR)
		 Frankfurter Allgemeine Zeitung
		 Focus Online
		 Münchner Merkur
		 Süddeutsche Zeitung
		 Spiegel Online
		 Die Zeit
		 Berliner Zeitung
		 Tagesschau
		 Deutsche Welle
		 Stern
		 N-Tv
		 Norddeutscher Rundfunk (NDR)
		 Die Tageszeitung (taz)
		 Bild
		 Westdeutsche Allgemeine Zeitung (WAZ)
		 Braunschweiger Zeitung
		 Business Insider
	 at:
		 Österreichischer Rundfunk
	 us:
		 Associated Press News
		 CNBC
		 The Intercept
		 The Gateway Pundit
		 Fox News
		 The Nation
		 The Washington Free Beacon
		 The Washington Times
		 The New Yorker
		 Reuters
		 Occupy Democrats
		 Los Angeles Times
	 uk:
		 The Guardian
		 The Independent
		 The Telegraph
		 i
	 fr:
		 Le Monde
```

`print(PublisherCollection.us)` prints (a truncated list): 

```python
Publisher Collection US containing 12 publisher(s), including:
	 Associated Press News
	 CNBC
	 The Intercept
	 The Gateway Pundit
	 Fox News
```

And the publishers are printed using their name attribute.