### PR TITLE
This is a renewed PR for BI Germany, that keeps the mostly Test files unmodified

### DIFF
--- a/src/fundus/publishers/de/business_insider.py
+++ b/src/fundus/publishers/de/business_insider.py
@@ -19,12 +19,14 @@ class BusinessInsiderParser(ParserProxy):
         _subheadline_selector = CSSSelector("article > div > h2, article > div > h3")
         _paragraph_selector = XPath(
             """
-            //article//div[
+            //article
+            //div[
                 contains(@class, 'article-body') 
                 or contains(@class, 'piano-article')]
-            /p[not(ancestor::*[@class='bi-bulletpoints']
-                or mark[@class='has-inline-color has-cyan-bluish-gray-color']
-                or @class='has-text-align-right')]
+            /p[
+                not(ancestor::*[@class='bi-bulletpoints']
+                    or mark[@class='has-inline-color has-cyan-bluish-gray-color']
+                    or @class='has-text-align-right')]
             """
         )
 

--- a/src/fundus/publishers/de/business_insider.py
+++ b/src/fundus/publishers/de/business_insider.py
@@ -15,20 +15,16 @@ from fundus.parser.utility import (
 
 class BusinessInsiderParser(ParserProxy):
     class V1(BaseParser):
-        _summary_selector = CSSSelector("article div.bi-bulletpoints > p")
-        _subheadline_selector = CSSSelector("article h2")
-
+        _summary_selector = CSSSelector("article div.bi-bulletpoints li, article div.bi-bulletpoints > p")
+        _subheadline_selector = CSSSelector("article > div > h2, article > div > h3")
         _paragraph_selector = XPath(
             """
-            //article 
-            //div[contains(@class, 'article-body')] 
-            //p[
-                not(
-                    ancestor::*[@class='bi-bulletpoints'] or
-                    mark[@class='has-inline-color has-cyan-bluish-gray-color'] or 
-                    @class='has-text-align-right'
-                )
-            ]
+            //article//div[
+                contains(@class, 'article-body') 
+                or contains(@class, 'piano-article')]
+            /p[not(ancestor::*[@class='bi-bulletpoints']
+                or mark[@class='has-inline-color has-cyan-bluish-gray-color']
+                or @class='has-text-align-right')]
             """
         )
 
@@ -51,7 +47,7 @@ class BusinessInsiderParser(ParserProxy):
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.bf_search("headline")
+            return self.precomputed.meta.get("og:title")
 
         @attribute
         def topics(self) -> List[str]:

--- a/tests/resources/parser/test_data/de/BusinessInsider.json
+++ b/tests/resources/parser/test_data/de/BusinessInsider.json
@@ -4,7 +4,7 @@
       "Matthew Loh"
     ],
     "publishing_date": "2024-01-29 19:00:45+00:00",
-    "title": "Wie groß ist Evergrande, Chinas strauchelnder Immobilienriese?",
+    "title": "6 Statistiken, die die enorme Größe von Evergrande, Chinas hoch verschuldeten Immobilienriesen verdeutlichen",
     "topics": [
       "China",
       "Immobilien",


### PR DESCRIPTION
As requested, I have opened in new PR containing the changes from and closing #376  , including changes to the paragraph and summary selector to also include an alternative layout in premium articles: https://www.businessinsider.de/wirtschaft/finanzen/ich-habe-meinen-job-mit-52-jahren-gekuendigt-und-lebe-seitdem-von-den-dividenden-auf-diese-aktien-setze-ich-dabei/ 

Since the changes include changing the way the title is parsed I had to modify the JSON accordingly.