### PR TITLE
bi authentication bug workaround

### DIFF
--- a/src/fundus/publishers/us/business_insider.py
+++ b/src/fundus/publishers/us/business_insider.py
@@ -15,12 +15,16 @@ from fundus.parser.utility import (
 
 class BusinessInsiderParser(ParserProxy):
     class V1(BaseParser):
-        _summary_selector = CSSSelector("article ul.summary-list > li")
+        _summary_selector = CSSSelector("article ul[class^='summary-list'] > li")
         _subheadline_selector = CSSSelector("article h2")
         _paragraph_selector = XPath(
             """
             //article 
             //div[contains(@class, 'content-lock-content')] 
+            /p[not(contains(@class, 'disclaimer'))] | 
+            //article 
+            //div[contains(@class, 'content-lock-content')]
+            /div[contains(@class, 'premium-content')] 
             /p[not(contains(@class, 'disclaimer'))]
             """
         )


### PR DESCRIPTION
After discovering a bug that BI US sometimes prints incomplete articles, the closest @MaxDall and I got to tracing the issue is that there seems to be some kind of error within the authentication of premium users of the US bi website. The incomplete version is a slight modification of the complete version, where the main content is within another div container, which is blocked from view, when using a browser. What triggers whether or not they ask for a premium login could not be determined. So, the workaround is to expand the selectors to cover both cases.