### PR TITLE
Attributes Parameter in Test Generation Script

### DIFF
--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -36,7 +36,8 @@ def parse_arguments() -> Namespace:
         ),
     )
     parser.add_argument(
-        "attributes",
+        "-a",
+        "--attributes",
         metavar="A",
         nargs="*",
         help=(


### PR DESCRIPTION
I noticed that the attributes paramater of the `scripts.generate_parser_test_files` script, does not work properly or at least does not work as the others do. I updated this to have the default syntax which requires the user to input the parameters:
`--attributes attr1 att2 attr3` or `-a attr1 attr2 attr3`