### PR TITLE
Fix a bug in generate_parser_test_files.py

### DIFF
--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -38,8 +38,8 @@ def parse_arguments() -> Namespace:
     parser.add_argument(
         "-a",
         "--attributes",
-        metavar="A",
-        nargs="*",
+        nargs="+",
+        default=[],
         help=(
             "the attributes which should be used to create test cases. "
             f"default: {', '.join(attributes_required_to_cover)}"


### PR DESCRIPTION
Fixes a bug where the script will crash when no attributes are given.