### PR TITLE
Add `free_access` as attribute to `Article`

### DIFF
--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -24,6 +24,7 @@ class Article:
     body: Optional[ArticleBody] = None
     publishing_date: Optional[datetime] = None
     topics: List[str] = field(default_factory=list)
+    free_access: bool = True
 
     @classmethod
     def from_extracted(cls, html: HTML, extracted: Dict[str, Any], exception: Optional[Exception] = None) -> "Article":

--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -18,7 +18,7 @@ class Article:
     html: HTML
     exception: Optional[Exception] = None
 
-    # supported attributes as defined in the guidelines
+    # supported (validated) attributes as defined in the guidelines
     title: Optional[str] = None
     authors: List[str] = field(default_factory=list)
     body: Optional[ArticleBody] = None


### PR DESCRIPTION
Unfortunately, we forgot to add the `free_access` attribute, which was introduced in #362, to the `Article` class. This PR finally addresses this issue.