### PR TITLE
Fix a bug in bf_search regarding boolean values

### DIFF
--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -18,6 +18,8 @@ from typing_extensions import TypeAlias
 
 LDMappingValue: TypeAlias = Union[List[Dict[str, Any]], Dict[str, Any]]
 
+_sentinel = object()
+
 
 class LinkedDataMapping:
     """
@@ -123,19 +125,28 @@ class LinkedDataMapping:
 
         def search_recursive(nodes: Iterable[LDMappingValue], current_depth: int):
             if current_depth == depth:
-                return None
+                return _sentinel
             else:
                 new: List[Dict[str, Any]] = []
                 for node in nodes:
                     if isinstance(node, list):
                         new.extend(node)
                         continue
-                    elif value := node.get(key):
+                    elif (value := node.get(key, _sentinel)) is not _sentinel:
                         return value
                     new.extend(v for v in node.values() if isinstance(v, dict))
-                return search_recursive(new, current_depth + 1) if new else None
 
-        return search_recursive([self.__dict__], 0) or default
+                if not new:
+                    return _sentinel
+
+                return search_recursive(new, current_depth + 1)
+
+        result = search_recursive([self.__dict__], 0)
+
+        if result == _sentinel:
+            return default
+
+        return result
 
     def __repr__(self):
         return f"LD containing '{', '.join(content)}'" if (content := self.__dict__.keys()) else "Empty LD"


### PR DESCRIPTION
There was a nasty bug in `LD.bf_search` basically rendering the parsing of boolean values unusable. This PR fixes this issue by introducing a new sentinel value and fixing some logic bugs.

One problem this could cause is that now the `free_access` attribute finally works as intended and this may cause some trouble since the publishers won't set it honestly.

Update: I opened another PR #423 to address this