### PR TITLE
Rework `ExtractionFilter` to adept to boolean values

### DIFF
--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -9,7 +9,7 @@ from fundus import Crawler, PublisherCollection
 from fundus.logging import basic_logger
 from fundus.publishers.base_objects import PublisherEnum
 from fundus.scraping.article import Article
-from fundus.scraping.filter import RequiresAllSkipBoolean
+from fundus.scraping.filter import RequiresAll
 from fundus.scraping.html import WebSource
 from fundus.scraping.scraper import BaseScraper, WebScraper
 from tests.test_parser import attributes_required_to_cover
@@ -20,10 +20,10 @@ def get_test_article(enum: PublisherEnum, url: Optional[str] = None) -> Optional
     if url is not None:
         source = WebSource([url], publisher=enum.publisher_name)
         scraper = BaseScraper(source, parser_mapping={enum.publisher_name: enum.parser})
-        return next(scraper.scrape(error_handling="suppress", extraction_filter=RequiresAllSkipBoolean()), None)
+        return next(scraper.scrape(error_handling="suppress", extraction_filter=RequiresAll()), None)
 
     crawler = Crawler(enum)
-    return next(crawler.crawl(max_articles=1, error_handling="suppress", only_complete=RequiresAllSkipBoolean()), None)
+    return next(crawler.crawl(max_articles=1, error_handling="suppress", only_complete=RequiresAll()), None)
 
 
 def parse_arguments() -> Namespace:

--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -9,7 +9,7 @@ from fundus import Crawler, PublisherCollection
 from fundus.logging import basic_logger
 from fundus.publishers.base_objects import PublisherEnum
 from fundus.scraping.article import Article
-from fundus.scraping.filter import RequiresAll
+from fundus.scraping.filter import RequiresAllSkipBoolean
 from fundus.scraping.html import WebSource
 from fundus.scraping.scraper import BaseScraper, WebScraper
 from tests.test_parser import attributes_required_to_cover
@@ -20,10 +20,10 @@ def get_test_article(enum: PublisherEnum, url: Optional[str] = None) -> Optional
     if url is not None:
         source = WebSource([url], publisher=enum.publisher_name)
         scraper = BaseScraper(source, parser_mapping={enum.publisher_name: enum.parser})
-        return next(scraper.scrape(error_handling="suppress", extraction_filter=RequiresAll()), None)
+        return next(scraper.scrape(error_handling="suppress", extraction_filter=RequiresAllSkipBoolean()), None)
 
     crawler = Crawler(enum)
-    return next(crawler.crawl(max_articles=1, error_handling="suppress", only_complete=True), None)
+    return next(crawler.crawl(max_articles=1, error_handling="suppress", only_complete=RequiresAllSkipBoolean()), None)
 
 
 def parse_arguments() -> Namespace:

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -7,18 +7,12 @@ Note that this script does not check the attributes' correctness, only their pre
 import sys
 import traceback
 from enum import EnumMeta
-from typing import Any, Dict, List, Optional, cast
+from typing import List, Optional, cast
 
 from fundus import Crawler, NewsMap, PublisherCollection, RSSFeed
 from fundus.publishers.base_objects import PublisherEnum
 from fundus.scraping.article import Article
-
-
-class RequiresAllSkipBoolean:
-    """Custom filter skipping boolean values"""
-
-    def __call__(self, extraction: Dict[str, Any]) -> bool:
-        return not all([bool(value) for value in extraction.values() if not isinstance(value, bool)])
+from fundus.scraping.filter import RequiresAllSkipBoolean
 
 
 def main() -> None:

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -12,7 +12,7 @@ from typing import List, Optional, cast
 from fundus import Crawler, NewsMap, PublisherCollection, RSSFeed
 from fundus.publishers.base_objects import PublisherEnum
 from fundus.scraping.article import Article
-from fundus.scraping.filter import RequiresAllSkipBoolean
+from fundus.scraping.filter import RequiresAll
 
 
 def main() -> None:
@@ -38,7 +38,7 @@ def main() -> None:
 
             crawler: Crawler = Crawler(publisher, restrict_sources_to=[NewsMap, RSSFeed])
             complete_article: Optional[Article] = next(
-                crawler.crawl(max_articles=1, only_complete=RequiresAllSkipBoolean(), error_handling="catch"), None
+                crawler.crawl(max_articles=1, only_complete=RequiresAll(), error_handling="catch"), None
             )
 
             if complete_article is None:

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -39,12 +39,7 @@ from fundus.logging import basic_logger
 from fundus.publishers.base_objects import PublisherCollectionMeta, PublisherEnum
 from fundus.scraping.article import Article
 from fundus.scraping.delay import Delay
-from fundus.scraping.filter import (
-    ExtractionFilter,
-    Requires,
-    RequiresAllSkipBoolean,
-    URLFilter,
-)
+from fundus.scraping.filter import ExtractionFilter, Requires, RequiresAll, URLFilter
 from fundus.scraping.html import CCNewsSource
 from fundus.scraping.scraper import CCNewsScraper, WebScraper
 from fundus.scraping.session import session_handler
@@ -178,7 +173,7 @@ class CrawlerBase(ABC):
 
         def build_extraction_filter() -> Optional[ExtractionFilter]:
             if isinstance(only_complete, bool):
-                return None if only_complete is False else RequiresAllSkipBoolean()
+                return None if only_complete is False else RequiresAll()
             else:
                 return only_complete
 

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -39,7 +39,12 @@ from fundus.logging import basic_logger
 from fundus.publishers.base_objects import PublisherCollectionMeta, PublisherEnum
 from fundus.scraping.article import Article
 from fundus.scraping.delay import Delay
-from fundus.scraping.filter import ExtractionFilter, Requires, RequiresAll, URLFilter
+from fundus.scraping.filter import (
+    ExtractionFilter,
+    Requires,
+    RequiresAllSkipBoolean,
+    URLFilter,
+)
 from fundus.scraping.html import CCNewsSource
 from fundus.scraping.scraper import CCNewsScraper, WebScraper
 from fundus.scraping.session import session_handler
@@ -173,7 +178,7 @@ class CrawlerBase(ABC):
 
         def build_extraction_filter() -> Optional[ExtractionFilter]:
             if isinstance(only_complete, bool):
-                return None if only_complete is False else RequiresAll()
+                return None if only_complete is False else RequiresAllSkipBoolean()
             else:
                 return only_complete
 

--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -163,10 +163,14 @@ class Requires:
 
 
 class RequiresAll(Requires):
-    def __init__(self):
-        """Name wrap for Requires(skip_bool=True)
+    def __init__(self, skip_boolean: bool = True) -> None:
+        """Name wrap for Requires()
 
-        This is for readability only. It requires all non-boolean attributes of the extraction to evaluate to True.
+        This is for readability only. By default, it requires all non-boolean attributes of the extraction
+        to evaluate to True. Set `skip_boolean=False` to alter this behaviour.
         See class:Requires docstring for more information.
+
+        Args:
+            skip_boolean: See Requires docstring for more information. Defaults to True.
         """
-        super().__init__(skip_bool=True)
+        super().__init__(skip_bool=skip_boolean)

--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -163,7 +163,11 @@ class Requires:
 
 
 class RequiresAll(Requires):
-    """Custom filter skipping boolean values"""
+    """Name wrap for Requires(skip_bool=False)
+
+    This is for readability only. It requires all attributes of the extraction to evaluate to True.
+        See class:Requires docstring for more information.
+    """
 
     def __init__(self):
         super().__init__(skip_bool=False)
@@ -171,9 +175,9 @@ class RequiresAll(Requires):
 
 class RequiresAllSkipBoolean(Requires):
     def __init__(self):
-        """Name wrap for Requires()
+        """Name wrap for Requires(skip_bool=True)
 
-        This is for readability only. It requires all attributes of the extraction to evaluate to True.
+        This is for readability only. It requires all non-boolean attributes of the extraction to evaluate to True.
         See class:Requires docstring for more information.
         """
         super().__init__(skip_bool=True)

--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -127,7 +127,7 @@ def _guarded_bool(value: Any):
 
 
 class Requires:
-    def __init__(self, *required_attributes: str, skip_bool: bool = False) -> None:
+    def __init__(self, *required_attributes: str, eval_bools: bool = True) -> None:
         """Class to filter extractions based on attribute values
 
         If a required_attribute is not present in the extracted data or evaluates to bool() -> False,
@@ -146,12 +146,12 @@ class Requires:
         Args:
             *required_attributes: Attributes required to evaluate to True in order to
                 pass the filter. If no attributes are given, all attributes will be evaluated
-            skip_boolean: If True then all attributes with boolean value will be evaluated with
-                <value> != None. If false, with bool(<value>). Defaults to False.
+            eval_bools: If True the boolean values will also be evaluated with bool(<value>).
+                If False, all boolean values evaluate to True. Defaults to True.
         """
         self.required_attributes = set(required_attributes)
         # somehow mypy does not recognize bool as callable :(
-        self._eval: Callable[[Any], bool] = _guarded_bool if skip_bool else bool  # type: ignore[assignment]
+        self._eval: Callable[[Any], bool] = bool if eval_bools else _guarded_bool  # type: ignore[assignment]
 
     def __call__(self, extraction: Dict[str, Any]) -> FilterResultWithMissingAttributes:
         missing_attributes = [
@@ -163,7 +163,7 @@ class Requires:
 
 
 class RequiresAll(Requires):
-    def __init__(self, skip_boolean: bool = True) -> None:
+    def __init__(self, eval_bool: bool = False) -> None:
         """Name wrap for Requires()
 
         This is for readability only. By default, it requires all non-boolean attributes of the extraction
@@ -171,6 +171,6 @@ class RequiresAll(Requires):
         See class:Requires docstring for more information.
 
         Args:
-            skip_boolean: See Requires docstring for more information. Defaults to True.
+            eval_bool: See Requires docstring for more information. Defaults to False.
         """
-        super().__init__(skip_bool=skip_boolean)
+        super().__init__(eval_bools=eval_bool)

--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -163,17 +163,6 @@ class Requires:
 
 
 class RequiresAll(Requires):
-    """Name wrap for Requires(skip_bool=False)
-
-    This is for readability only. It requires all attributes of the extraction to evaluate to True.
-        See class:Requires docstring for more information.
-    """
-
-    def __init__(self):
-        super().__init__(skip_bool=False)
-
-
-class RequiresAllSkipBoolean(Requires):
     def __init__(self):
         """Name wrap for Requires(skip_bool=True)
 

--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -127,7 +127,7 @@ def _guarded_bool(value: Any):
 
 
 class Requires:
-    def __init__(self, *required_attributes: str, eval_bools: bool = True) -> None:
+    def __init__(self, *required_attributes: str, eval_booleans: bool = True) -> None:
         """Class to filter extractions based on attribute values
 
         If a required_attribute is not present in the extracted data or evaluates to bool() -> False,
@@ -146,12 +146,12 @@ class Requires:
         Args:
             *required_attributes: Attributes required to evaluate to True in order to
                 pass the filter. If no attributes are given, all attributes will be evaluated
-            eval_bools: If True the boolean values will also be evaluated with bool(<value>).
+            eval_booleans: If True the boolean values will also be evaluated with bool(<value>).
                 If False, all boolean values evaluate to True. Defaults to True.
         """
         self.required_attributes = set(required_attributes)
         # somehow mypy does not recognize bool as callable :(
-        self._eval: Callable[[Any], bool] = bool if eval_bools else _guarded_bool  # type: ignore[assignment]
+        self._eval: Callable[[Any], bool] = bool if eval_booleans else _guarded_bool  # type: ignore[assignment]
 
     def __call__(self, extraction: Dict[str, Any]) -> FilterResultWithMissingAttributes:
         missing_attributes = [
@@ -163,7 +163,7 @@ class Requires:
 
 
 class RequiresAll(Requires):
-    def __init__(self, eval_bool: bool = False) -> None:
+    def __init__(self, eval_booleans: bool = False) -> None:
         """Name wrap for Requires()
 
         This is for readability only. By default, it requires all non-boolean attributes of the extraction
@@ -171,6 +171,6 @@ class RequiresAll(Requires):
         See class:Requires docstring for more information.
 
         Args:
-            eval_bool: See Requires docstring for more information. Defaults to False.
+            eval_booleans: See Requires docstring for more information. Defaults to False.
         """
-        super().__init__(eval_bools=eval_bool)
+        super().__init__(eval_booleans=eval_booleans)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,5 @@
 from fundus import Requires
-from fundus.scraping.filter import RequiresAll, RequiresAllSkipBoolean
+from fundus.scraping.filter import RequiresAll
 
 
 class TestExtractionFilter:
@@ -26,16 +26,7 @@ class TestExtractionFilter:
         extraction = {"a": "Some Stuff", "b": [], "c": False}
 
         assert (result := RequiresAll()(extraction))
-        assert sorted(result.missing_attributes) == sorted(("b", "c"))
-
-        extraction = {"a": "Some Stuff", "c": True}
-        assert not RequiresAll()(extraction)
-
-    def test_requires_all_skip_bool(self):
-        extraction = {"a": "Some Stuff", "b": [], "c": False}
-
-        assert (result := RequiresAllSkipBoolean()(extraction))
         assert result.missing_attributes == ("b",)
 
         extraction = {"a": "Some Stuff", "c": False}
-        assert not RequiresAllSkipBoolean()(extraction)
+        assert not RequiresAll()(extraction)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -20,7 +20,7 @@ class TestExtractionFilter:
 
         assert sorted(result.missing_attributes) == sorted(("b", "c"))
 
-        assert not Requires("c", skip_bool=True)(extraction)
+        assert not Requires("c", eval_bools=False)(extraction)
 
     def test_requires_all(self):
         extraction = {"a": "Some Stuff", "b": [], "c": False}
@@ -34,8 +34,8 @@ class TestExtractionFilter:
         # test skip_boolean=False
         extraction = {"a": "Some Stuff", "b": [], "c": False}
 
-        assert (result := RequiresAll(skip_boolean=False)(extraction))
+        assert (result := RequiresAll(eval_bool=True)(extraction))
         assert sorted(result.missing_attributes) == sorted(("b", "c"))
 
         extraction = {"a": "Some Stuff", "c": True}
-        assert not RequiresAll(skip_boolean=False)(extraction)
+        assert not RequiresAll(eval_bool=True)(extraction)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,41 @@
+from fundus import Requires
+from fundus.scraping.filter import RequiresAll, RequiresAllSkipBoolean
+
+
+class TestExtractionFilter:
+    def test_requires(self):
+        extraction = {"a": "Some Stuff", "b": [], "c": True}
+
+        assert not Requires("a")(extraction)
+
+        assert (result := Requires("a", "b")(extraction))
+
+        assert result.missing_attributes == ("b",)
+
+        assert not Requires("c")(extraction)
+
+        extraction = {"a": "Some Stuff", "b": [], "c": False}
+
+        assert (result := Requires("a", "b", "c")(extraction))
+
+        assert sorted(result.missing_attributes) == sorted(("b", "c"))
+
+        assert not Requires("c", skip_bool=True)(extraction)
+
+    def test_requires_all(self):
+        extraction = {"a": "Some Stuff", "b": [], "c": False}
+
+        assert (result := RequiresAll()(extraction))
+        assert sorted(result.missing_attributes) == sorted(("b", "c"))
+
+        extraction = {"a": "Some Stuff", "c": True}
+        assert not RequiresAll()(extraction)
+
+    def test_requires_all_skip_bool(self):
+        extraction = {"a": "Some Stuff", "b": [], "c": False}
+
+        assert (result := RequiresAllSkipBoolean()(extraction))
+        assert result.missing_attributes == ("b",)
+
+        extraction = {"a": "Some Stuff", "c": False}
+        assert not RequiresAllSkipBoolean()(extraction)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -30,3 +30,12 @@ class TestExtractionFilter:
 
         extraction = {"a": "Some Stuff", "c": False}
         assert not RequiresAll()(extraction)
+
+        # test skip_boolean=False
+        extraction = {"a": "Some Stuff", "b": [], "c": False}
+
+        assert (result := RequiresAll(skip_boolean=False)(extraction))
+        assert sorted(result.missing_attributes) == sorted(("b", "c"))
+
+        extraction = {"a": "Some Stuff", "c": True}
+        assert not RequiresAll(skip_boolean=False)(extraction)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -20,7 +20,7 @@ class TestExtractionFilter:
 
         assert sorted(result.missing_attributes) == sorted(("b", "c"))
 
-        assert not Requires("c", eval_bools=False)(extraction)
+        assert not Requires("c", eval_booleans=False)(extraction)
 
     def test_requires_all(self):
         extraction = {"a": "Some Stuff", "b": [], "c": False}
@@ -34,8 +34,8 @@ class TestExtractionFilter:
         # test skip_boolean=False
         extraction = {"a": "Some Stuff", "b": [], "c": False}
 
-        assert (result := RequiresAll(eval_bool=True)(extraction))
+        assert (result := RequiresAll(eval_booleans=True)(extraction))
         assert sorted(result.missing_attributes) == sorted(("b", "c"))
 
         extraction = {"a": "Some Stuff", "c": True}
-        assert not RequiresAll(eval_bool=True)(extraction)
+        assert not RequiresAll(eval_booleans=True)(extraction)


### PR DESCRIPTION
With #422, 'free_access' is computed correctly. Because not all publishers set this information correctly, I felt the need to rework the extraction filter again. 

- I added a new parameter to `Requires`, `skip_boolean` which enables one to skip boolean values for evaluation
- There are now two predefined extraction filters: `Requires`, `RequiresAll`,
- `RequiresAll` is a name wrap for Requires() and propagates the `skip_bool` parameter to the user.