### PR TITLE
Adds a part about `generate_tables` script to the documentation

### DIFF
--- a/docs/3_the_article_class.md
+++ b/docs/3_the_article_class.md
@@ -114,7 +114,7 @@ Here you have access to the following information:
    Often the same as `requested_url`; can change with redirects.
 3. `content: str`: The HTML content.
 4. `crawl_date: datetime`: The exact timestamp the article was crawled.
-5. `source: HTMLSource`: The internal source object the article originates from.
+5. `source_info: SourceInfo`: Some information about the HTML's origins, mostly for debugging purpose.
 
 ## Language detection
 
@@ -133,8 +133,8 @@ for article in crawler.crawl(max_articles=1):
 ````
 
 Should print this:
-``console
+```console
 en
-``
+```
 
 In the [**next section**](4_how_to_filter_articles.md) we will show you how to filter articles.

--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -18,7 +18,9 @@
     * [XPath](#xpath)
   * [Checking the free_access attribute](#checking-the-free_access-attribute)
   * [Finishing the Parser](#finishing-the-parser)
-* [6. Generate unit tests](#6-generate-unit-tests)
+* [6. Generate unit tests](#6-generate-unit-tests-and-update-tables)
+  * [Add unit test](#add-unit-tests)
+  * [Update tables](#update-tables)
 * [7. Opening a Pull Request](#7-opening-a-pull-request)
 
 # How to add a Publisher
@@ -512,7 +514,7 @@ def free_access(self) -> bool:
 ```
 
 Usually you can identify a premium article by an indicator within the URL or by using XPath or CSSSelector and selecting
-the element asking to to purchase a subscription to view the article.
+the element asking to purchase a subscription to view the article.
 
 ### Finishing the Parser
 
@@ -574,7 +576,9 @@ Fundus-Article:
 - From:   Los Angeles Times (2023-06-25 21:30)
 ```
 
-## 6. Generate unit tests
+## 6. Generate unit tests and update tables
+
+### Add unit tests
 
 To finish your newly added publisher you should add unit tests for the parser.
 We recommend you do this with the provided [**script**](../scripts/generate_parser_test_files.py).
@@ -600,6 +604,15 @@ python -m scripts.generate_parser_test_files -p LATimes
 ````
 
 to generate a unit test for our parser.
+
+### Update tables
+
+To fully integrate your new publisher you have to add it to the [supported publishers](supported_publishers.md) table.
+You do so by simply running
+
+````shell
+python -m scritps.generate_tables.py
+````
 
 Now to test your newly added publisher you should run pytest with the following command:
 

--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -611,7 +611,7 @@ To fully integrate your new publisher you have to add it to the [supported publi
 You do so by simply running
 
 ````shell
-python -m scritps.generate_tables
+python -m scripts.generate_tables
 ````
 
 Now to test your newly added publisher you should run pytest with the following command:

--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -611,7 +611,7 @@ To fully integrate your new publisher you have to add it to the [supported publi
 You do so by simply running
 
 ````shell
-python -m scritps.generate_tables.py
+python -m scritps.generate_tables
 ````
 
 Now to test your newly added publisher you should run pytest with the following command:


### PR DESCRIPTION
This adds a part to the documentation encouraging users to run 

```shell
python -m scripts.generate_tables
```

before opening a PR. In addition I fixed some errors in the docs as well.