### PR TITLE
Commit changes made from `documentation.yaml` to the fork repository

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -37,9 +37,17 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v4
+    # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#use-in-forks-from-public-repositories
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Checkout the fork/head-repository and push changes to the fork.
+          # If you skip this, the base repository will be checked out and changes
+          # will be committed to the base repository!
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+          # Checkout the branch made in the fork. Will automatically push changes
+          # back to this branch.
+          ref: ${{ github.head_ref }}
+
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v5


### PR DESCRIPTION
This should hopefully commit changes made by the `documentation.yaml` workflow back to the fork and thus finally work with forks. See stefanzweifel/git-auto-commit-action [docs on forks](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#use-in-forks-from-public-repositories) and [this](https://github.com/stefanzweifel/git-auto-commit-action/issues/211) issue.