### PR TITLE
Catch an error regarding `RSSFeed` and change `user-agent` for `Focus`

### DIFF
--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -73,6 +73,8 @@ class DE(PublisherEnum):
         domain="https://www.focus.de/",
         sources=[RSSFeed("https://rss.focus.de/fol/XML/rss_folnews.xml")],
         parser=FocusParser,
+        # Focus blocks access for all user-agents including the term 'Bot'
+        request_header={"user-agent": "Fundus"},
     )
 
     Merkur = PublisherSpec(

--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -74,7 +74,11 @@ class URLSource(Iterable[str], ABC):
 class RSSFeed(URLSource):
     def __iter__(self) -> Iterator[str]:
         session = session_handler.get_session()
-        response = session.get(self.url, headers=self._request_header)
+        try:
+            response = session.get(self.url, headers=self._request_header)
+        except HTTPError as exception:
+            basic_logger.warning(f"Warning! Couldn't parse rss feed '{self.url}' because of {exception}")
+            return
         html = response.text
         rss_feed = feedparser.parse(html)
         if exception := rss_feed.get("bozo_exception"):

--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -76,8 +76,8 @@ class RSSFeed(URLSource):
         session = session_handler.get_session()
         try:
             response = session.get(self.url, headers=self._request_header)
-        except HTTPError as exception:
-            basic_logger.warning(f"Warning! Couldn't parse rss feed '{self.url}' because of {exception}")
+        except HTTPError as err:
+            basic_logger.warning(f"Warning! Couldn't parse rss feed '{self.url}' because of {err}")
             return
         html = response.text
         rss_feed = feedparser.parse(html)


### PR DESCRIPTION
- catches `HTTPError`s when requesting an `RSSFeed` 
- with #440 `Focus` now denies access to their RSS feed. This PR changes the user-agent used for `Focus` back to `Fundus`