### PR TITLE
Add `.DS_Store` to `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 data
 
 
+# MacOS specific
+.DS_Store
 
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
I stumbled over quite a lot of PRs accidentally adding these files. They [seem](https://en.wikipedia.org/wiki/.DS_Store) to be part of MacOS' file system.