### PR TITLE
Clean URLs before inserting into response_cache

### DIFF
--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -26,6 +26,7 @@ from typing import (
     Union,
     cast,
 )
+from urllib.parse import urljoin, urlparse
 
 import dill
 import more_itertools
@@ -212,8 +213,11 @@ class CrawlerBase(ABC):
         for article in self._build_article_iterator(
             tuple(fitting_publishers), error_handling, build_extraction_filter(), url_filter
         ):
-            if not only_unique or article.html.responded_url not in response_cache:
-                response_cache.add(article.html.responded_url)
+            cached_url = article.html.responded_url
+            if any(parameter_indicator in cached_url for parameter_indicator in ('?', '#')):
+                cached_url = urljoin(article.html.responded_url, urlparse(article.html.responded_url).path)
+            if not only_unique or cached_url not in response_cache:
+                response_cache.add(cached_url)
                 article_count += 1
                 yield article
             if article_count == max_articles:

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -214,7 +214,7 @@ class CrawlerBase(ABC):
             tuple(fitting_publishers), error_handling, build_extraction_filter(), url_filter
         ):
             cached_url = article.html.responded_url
-            if any(parameter_indicator in cached_url for parameter_indicator in ('?', '#')):
+            if any(parameter_indicator in cached_url for parameter_indicator in ("?", "#")):
                 cached_url = urljoin(article.html.responded_url, urlparse(article.html.responded_url).path)
             if not only_unique or cached_url not in response_cache:
                 response_cache.add(cached_url)


### PR DESCRIPTION
Depending on the Source of the URL (RSSFeed or Sitemap) Publishers tend to sometimes add a parameter to the url indicating the origin. E.g. Kicker appends #rssom. If max_articles is set to a large enough value, this may lead to the same article being crawled twice, since the response_cache distinguishes the two URLs