### PR TITLE
Add timeout to publisher_coverage.py

### DIFF
--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -32,6 +32,11 @@ def main() -> None:
         ):
             publisher_name: str = publisher.name  # type: ignore[attr-defined]
 
+            if not any(publisher.source_mapping.values()):  # type: ignore[attr-defined]
+                # skip publishers providing no sources for forward crawling
+                print(f"⏩  SKIPPED: {publisher_name!r} - No sources defined")
+                continue
+
             crawler: Crawler = Crawler(publisher, delay=0.4)
 
             timed_next = timeout(next, time=20, silent=True)

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1,13 +1,9 @@
+import _thread as thread
 import threading
 from functools import wraps
 from typing import Callable, Optional, TypeVar, overload
 
 from typing_extensions import ParamSpec
-
-try:
-    import thread
-except ImportError:
-    import _thread as thread
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -39,7 +39,6 @@ def timeout(func: Callable[P, T], time: float, silent: bool = False) -> Callable
                 raise TimeoutError from err
         finally:
             timer.cancel()
-            timer.join()
         return result
 
     return wrapper

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -14,23 +14,23 @@ def _interrupt_handler() -> None:
 
 
 @overload
-def timeout(func: Callable[P, T], time: int, silent: bool = False) -> Callable[P, T]:
+def timeout(func: Callable[P, T], time: float, silent: bool = False) -> Callable[P, T]:
     ...
 
 
 @overload
-def timeout(func: Callable[P, T], time: int, silent: bool = True) -> Callable[P, Optional[T]]:
+def timeout(func: Callable[P, T], time: float, silent: bool = True) -> Callable[P, Optional[T]]:
     ...
 
 
-def timeout(func: Callable[P, T], time: int, silent: bool = False) -> Callable[P, Optional[T]]:
+def timeout(func: Callable[P, T], time: float, silent: bool = False) -> Callable[P, Optional[T]]:
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
         # register interrupt handler
         timer = threading.Timer(time, _interrupt_handler)
-        timer.start()
 
         try:
+            timer.start()
             result = func(*args, **kwargs)
         except KeyboardInterrupt as err:
             if silent:

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -14,16 +14,16 @@ def _interrupt_handler() -> None:
 
 
 @overload
-def timeout(func: Callable[P, T], time: int, silent: Literal[False] = ...) -> Callable[P, T]:
+def timeout(func: Callable[P, T], time: float, silent: Literal[False] = ...) -> Callable[P, T]:
     ...
 
 
 @overload
-def timeout(func: Callable[P, T], time: int, silent: Literal[True]) -> Callable[P, Optional[T]]:
+def timeout(func: Callable[P, T], time: float, silent: Literal[True]) -> Callable[P, Optional[T]]:
     ...
 
 
-def timeout(func: Callable[P, T], time: int, silent: bool = False) -> Callable[P, Optional[T]]:
+def timeout(func: Callable[P, T], time: float, silent: bool = False) -> Callable[P, Optional[T]]:
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
         # register interrupt handler

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1,7 +1,7 @@
 import _thread as thread
 import threading
 from functools import wraps
-from typing import Callable, Optional, TypeVar, overload
+from typing import Callable, Literal, Optional, TypeVar, overload
 
 from typing_extensions import ParamSpec
 
@@ -14,16 +14,16 @@ def _interrupt_handler() -> None:
 
 
 @overload
-def timeout(func: Callable[P, T], time: float, silent: bool = False) -> Callable[P, T]:
+def timeout(func: Callable[P, T], time: int, silent: Literal[False] = ...) -> Callable[P, T]:
     ...
 
 
 @overload
-def timeout(func: Callable[P, T], time: float, silent: bool = True) -> Callable[P, Optional[T]]:
+def timeout(func: Callable[P, T], time: int, silent: Literal[True]) -> Callable[P, Optional[T]]:
     ...
 
 
-def timeout(func: Callable[P, T], time: float, silent: bool = False) -> Callable[P, Optional[T]]:
+def timeout(func: Callable[P, T], time: int, silent: bool = False) -> Callable[P, Optional[T]]:
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
         # register interrupt handler

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1,0 +1,49 @@
+import threading
+from functools import wraps
+from typing import Callable, Optional, TypeVar, overload
+
+from typing_extensions import ParamSpec
+
+try:
+    import thread
+except ImportError:
+    import _thread as thread
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def _interrupt_handler() -> None:
+    thread.interrupt_main()
+
+
+@overload
+def timeout(func: Callable[P, T], time: int, silent: bool = False) -> Callable[P, T]:
+    ...
+
+
+@overload
+def timeout(func: Callable[P, T], time: int, silent: bool = True) -> Callable[P, Optional[T]]:
+    ...
+
+
+def timeout(func: Callable[P, T], time: int, silent: bool = False) -> Callable[P, Optional[T]]:
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
+        # register interrupt handler
+        timer = threading.Timer(time, _interrupt_handler)
+        timer.start()
+
+        try:
+            result = func(*args, **kwargs)
+        except KeyboardInterrupt as err:
+            if silent:
+                return None
+            else:
+                raise TimeoutError from err
+        finally:
+            timer.cancel()
+            timer.join()
+        return result
+
+    return wrapper


### PR DESCRIPTION
This adds a new timeout wrapper to publisher coverage enabling Fundus to use `Sitemap`s for coverage as well.