### PR TITLE
Update LD Selector

### DIFF
--- a/src/fundus/parser/base_parser.py
+++ b/src/fundus/parser/base_parser.py
@@ -156,7 +156,7 @@ class Precomputed:
 class BaseParser(ABC):
     VALID_UNTIL: date = date.today()
     precomputed: Precomputed
-    _ld_selector: XPath = XPath("//script[@type='application/ld+json']")
+    _ld_selector: XPath = XPath("//script[@type='application/ld+json' and contains(text(), 'Article')]")
 
     def __init__(self):
         predicate: Callable[[object], bool] = lambda x: isinstance(x, RegisteredFunction)

--- a/src/fundus/publishers/de/freiepresse.py
+++ b/src/fundus/publishers/de/freiepresse.py
@@ -33,7 +33,7 @@ class FreiePresseParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.bf_search("author"))
+            return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "author"]))
 
         @attribute
         def title(self) -> Optional[str]:

--- a/src/fundus/publishers/na/the_namibian.py
+++ b/src/fundus/publishers/na/the_namibian.py
@@ -15,6 +15,7 @@ from fundus.parser.utility import (
 class TheNamibianParser(ParserProxy):
     class V1(BaseParser):
         VALID_UNTIL = datetime(year=2024, month=1, day=31).date()
+        _ld_selector = XPath("//script[@type='application/ld+json']")
         _summary_selector = XPath("//div[contains(@class, 'tdb-block-inner')]/p[position()=1]")
         _paragraph_selector = XPath("//div[contains(@class, 'tdb-block-inner')]/p[position()>1]")
         _title_substitution_pattern: Pattern[str] = re.compile(r" - The Namibian$")

--- a/src/fundus/publishers/na/the_namibian.py
+++ b/src/fundus/publishers/na/the_namibian.py
@@ -15,7 +15,6 @@ from fundus.parser.utility import (
 class TheNamibianParser(ParserProxy):
     class V1(BaseParser):
         VALID_UNTIL = datetime(year=2024, month=1, day=31).date()
-        _ld_selector = XPath("//script[@type='application/ld+json']")
         _summary_selector = XPath("//div[contains(@class, 'tdb-block-inner')]/p[position()=1]")
         _paragraph_selector = XPath("//div[contains(@class, 'tdb-block-inner')]/p[position()>1]")
         _title_substitution_pattern: Pattern[str] = re.compile(r" - The Namibian$")

--- a/tests/resources/parser/test_data/de/FreiePresse.json
+++ b/tests/resources/parser/test_data/de/FreiePresse.json
@@ -1,7 +1,7 @@
 {
   "V1": {
     "authors": [
-      "Chemnitzer Verlag und Druck GmbH & Co. KG"
+      "Jens Kassner"
     ],
     "body": {
       "summary": [


### PR DESCRIPTION
When working with Fundus I found that way too much JSON is extracted when computing the self.precomputed elements. This causes multiple issues: 
- unnecessary but malformed JSON blocks cause avoidable crashes
- Additional JSON Blocks may cause irrelevant data to be extracted (e.g. the website (not article) author of the freiepresse test case: https://www.freiepresse.de/chemnitz/chemnitzer-hutfestival-wann-das-fest-steigt-was-neu-ist-und-wer-fuer-eine-gute-show-sorgen-wird-artikel13351201)
All current parsers mention the type within their JSON, only the old version of TheNamibian did not follow that convention, hence the override.