### PR TITLE
Remove previous file when using `-o` option in test case script

### DIFF
--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -105,7 +105,7 @@ def main() -> None:
             test_data = content if not arguments.overwrite_json and (content := test_data_file.load()) else {}
 
             # load html
-            html_mapping = load_html_test_file_mapping(publisher) if not arguments.overwrite else {}
+            html_mapping = load_html_test_file_mapping(publisher)
 
             if arguments.overwrite or not html_mapping.get(publisher.parser.latest_version):
                 if not (article := get_test_article(publisher, url)):
@@ -119,6 +119,10 @@ def main() -> None:
                 )
                 html.write()
                 subprocess.call(["git", "add", html.path], stdout=subprocess.PIPE)
+
+                # remove previous file
+                if previous_file := html_mapping.get(publisher.parser.latest_version):
+                    previous_file.remove()
 
                 html_mapping[publisher.parser.latest_version] = html
                 test_data[publisher.parser.latest_version.__name__] = {}

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -1,6 +1,7 @@
 import datetime
 import gzip
 import json
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -201,6 +202,15 @@ class HTMLTestFile:
         if not (meta_info := get_meta_info_file(publisher).load()):
             raise ValueError(f"Missing meta info for file {path.name!r}")
         return cls(content=content, publisher=publisher, encoding=encoding, **meta_info[path.name])
+
+    def remove(self) -> None:
+        if meta_info_file := get_meta_info_file(self.publisher):
+            meta_info = meta_info_file.load() or {}
+            meta_info.pop(self.path.name)
+            meta_info_file.write(meta_info)
+
+        if self.path.exists():
+            os.remove(self.path)
 
     def _register_at_meta_info(self) -> None:
         """Writes meta information about the file to the corresponding meta.info file.


### PR DESCRIPTION
Previously, when using `-o` option to overwrite existing test cases, the HTML file and meta.info entry had to be removed by hand. This PR automates that step.