### PR TITLE
Set PYTHONPATH to the Root of the Repository for the Publisher Coverage Actions

### DIFF
--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -25,6 +25,8 @@ jobs:
         run: pip install -e .
 
       - name: Validate Crawlers
+        env:
+          PYTHONPATH: .
         run: |
           set -o pipefail
           exec python scripts/publisher_coverage.py | tee publisher_coverage.txt


### PR DESCRIPTION
Currently, the Publisher Coverage action fails because it can't find the `scripts.utility` module. Setting the PYTHONPATH correctly should fix this.


Traceback:

```
Traceback (most recent call last):
  File "/home/runner/work/fundus/fundus/scripts/publisher_coverage.py", line 16, in <module>
    from scripts.utility import timeout
ModuleNotFoundError: No module named 'scripts'
````
