### PR TITLE
Refactor metadata parsing to include multiple values using the same key

### DIFF
--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -381,6 +381,9 @@ def title(self) -> Optional[str]:
    return self.precomputed.meta.get("og:title")
 ```
 
+**_NOTE:_** In case a `class` is present in the HTML `meta` tag, it will be appended as a namespace to avoid collisions.
+I.e. the content of the following meta tag `<meta class="swiftype" name="author" ...` can be accessed with the key `swiftype:author`.
+
 ### Extracting Attributes with XPath and CSS-Select
 
 When parsing the `ArticleBody`, or the desired information cannot be extracted from the `ld` or `meta` attributes, you need to directly obtain information from the [Document Object Model](https://en.wikipedia.org/wiki/Document_Object_Model) (DOM) of the HTML/XML.

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -1,5 +1,6 @@
 import itertools
 import re
+from collections import defaultdict
 from copy import copy
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -143,18 +144,35 @@ def extract_article_body_with_selector(
     return ArticleBody(summary=summary, sections=sections)
 
 
-_meta_node_selector = CSSSelector("meta[name], meta[property]")
+_meta_node_selector = CSSSelector("head > meta, body > meta")
 
 
-def get_meta_content(tree: lxml.html.HtmlElement) -> Dict[str, str]:
-    meta_nodes = _meta_node_selector(tree)
-    meta: Dict[str, str] = {}
-    for node in meta_nodes:
-        key = node.attrib.get("name") or node.attrib.get("property")
-        value = node.attrib.get("content")
-        if key and value:
-            meta[key] = value
-    return meta
+def get_meta_content(root: lxml.html.HtmlElement) -> Dict[str, str]:
+    data = defaultdict(list)
+    for node in _meta_node_selector(root):
+        attributes = node.attrib
+        if len(attributes) == 1:
+            data[attributes.keys()[0]].append(attributes.values()[0])
+        elif key := (  # these keys are ordered by frequency
+            attributes.get("name")
+            or attributes.get("property")
+            or attributes.get("http-equiv")
+            or attributes.get("itemprop")
+        ):
+            if ns := attributes.get("class"):
+                key = f"{ns}:{key}"
+            if content := attributes.get("content"):
+                data[key].append(content)
+
+    metadata: Dict[str, str] = {}
+    for name, listed_content in data.items():
+        if len(listed_content) == 1:
+            metadata[name] = listed_content[0]
+        else:
+            # for ease of typing we join multiple contents for the same key using ','
+            metadata[name] = ",".join(listed_content)
+
+    return metadata
 
 
 def strip_nodes_to_text(text_nodes: List[lxml.html.HtmlElement], join_on: str = "\n\n") -> Optional[str]:

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -148,6 +148,21 @@ _meta_node_selector = CSSSelector("head > meta, body > meta")
 
 
 def get_meta_content(root: lxml.html.HtmlElement) -> Dict[str, str]:
+    """Parse metadata from HTML.
+
+    This function parses single values (i.e. charset=...), nodes containing name, property, http-equiv or
+    itemprop attributes. When multiple values for the same key occur, they will be joined using `,`. This
+    is in order to ease typing and avoid list as additional type.
+
+    In case an HTML tag consists a class, it will be appended as namespace to avoid key collisions.
+    I.e. <meta class="swiftype" name="author" ... > will be stored using `swiftype:author` as a key.
+
+    Args:
+        root: The HTML document given as a lxml.html.HtmlElement.
+
+    Returns:
+        The metadata as a dictionary
+    """
     data = defaultdict(list)
     for node in _meta_node_selector(root):
         attributes = node.attrib

--- a/src/fundus/publishers/us/rolling_stone.py
+++ b/src/fundus/publishers/us/rolling_stone.py
@@ -33,12 +33,12 @@ class RollingStoneParser(ParserProxy):
 
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:
-            return generic_date_parsing(self.precomputed.meta.get("published_at"))
+            return generic_date_parsing(self.precomputed.meta.get("swiftype:published_at"))
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.meta.get("title")
+            return self.precomputed.meta.get("swiftype:title")
 
         @attribute
         def topics(self) -> List[str]:
-            return generic_topic_parsing(self.precomputed.meta.get("topics"))
+            return generic_topic_parsing(self.precomputed.meta.get("swiftype:topics"))

--- a/tests/resources/parser/test_data/us/RollingStone.json
+++ b/tests/resources/parser/test_data/us/RollingStone.json
@@ -26,6 +26,7 @@
     "publishing_date": "2024-04-25 04:21:02",
     "title": "Donna Kelce Calls Taylor Swift's ‘The Tortured Poets Department’ Her 'Best Work'",
     "topics": [
+      "Music",
       "Music News"
     ]
   }


### PR DESCRIPTION
In the previous implementation, key collisions where just overwritten. With this PR, each value is stored individually. For ease of typing, we store multi values as a string by joining them on `,`

closes #336