### PR TITLE
Show details about incomplete articles in Publisher Coverage

### DIFF
--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -68,7 +68,12 @@ def main() -> None:
                 else:
                     print(
                         f"❌ FAILED: {publisher_name!r} - No complete articles received "
-                        f"(URL of an incomplete article: {incomplete_article.html.requested_url})"
+                        f"(URL of an incomplete article: {incomplete_article.html.requested_url}) with attributes: "
+                        f"title: {incomplete_article.title is not None} "
+                        f"plaintext: {incomplete_article.plaintext is not None}"
+                        f"publishing_date: {incomplete_article.publishing_date is not None}"
+                        f"authors: {incomplete_article.authors is not None and not len(incomplete_article.authors) == 0}"
+                        f"topics: {incomplete_article.topics is not None and not len(incomplete_article.topics) == 0}"
                     )
                 failed += 1
                 continue

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -68,12 +68,12 @@ def main() -> None:
                 else:
                     print(
                         f"❌ FAILED: {publisher_name!r} - No complete articles received "
-                        f"(URL of an incomplete article: {incomplete_article.html.requested_url}) with attributes: "
-                        f"title: {incomplete_article.title is not None} "
-                        f"plaintext: {incomplete_article.plaintext is not None}"
-                        f"publishing_date: {incomplete_article.publishing_date is not None}"
-                        f"authors: {incomplete_article.authors is not None and not len(incomplete_article.authors) == 0}"
-                        f"topics: {incomplete_article.topics is not None and not len(incomplete_article.topics) == 0}"
+                        f"(URL of an incomplete article: {incomplete_article.html.requested_url}) with attributes:\n"
+                        f"title: {incomplete_article.title is not None}\n"
+                        f"plaintext: {incomplete_article.plaintext is not None}\n"
+                        f"publishing_date: {incomplete_article.publishing_date is not None}\n"
+                        f"authors: {incomplete_article.authors is not None and not len(incomplete_article.authors) == 0}\n"
+                        f"topics: {incomplete_article.topics is not None and not len(incomplete_article.topics) == 0}\n"
                     )
                 failed += 1
                 continue


### PR DESCRIPTION
When going through the failed publishers, I that it is a bit tedious to find the problem of why a certain article is not being parsed and the publisher coverage fails for a certain article. Hence I added some lines to the output to give an idea of how serious the fail is: e.g. there are no authors -> probably none given in the article and can just be ignored. No title or no plaintext -> something weird is going on and should be checked out. And also, we would know exactly where to look.