### PR TITLE
Guard download and streaming of WARC files

### DIFF
--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -395,7 +395,7 @@ class CCNewsCrawler(CrawlerBase):
         url_filter: Optional[URLFilter] = None,
     ) -> Iterator[Article]:
         retries: int = 0
-        while True and retries <= self.retries:
+        while retries <= self.retries:
             source = CCNewsSource(*publishers, warc_path=warc_path)
             scraper = CCNewsScraper(source)
             try:

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -29,7 +29,6 @@ from typing import (
     Union,
     cast,
 )
-from urllib.error import HTTPError
 from urllib.parse import urljoin, urlparse
 
 import dill
@@ -38,6 +37,7 @@ import more_itertools
 import requests
 from dateutil.rrule import MONTHLY, rrule
 from more_itertools import roundrobin
+from requests import HTTPError
 from tqdm import tqdm
 from typing_extensions import ParamSpec, TypeAlias
 
@@ -390,10 +390,10 @@ class CCNewsCrawler(CrawlerBase):
             yield from scraper.scrape(error_handling, extraction_filter, url_filter)
         except HTTPError as exception:
             logger.error(f"Could not load WARC file {warc_path!r}: {exception!r}")
-            time.sleep(10)
+            time.sleep(30)
         except fastwarc.stream_io.StreamError:
             logger.error(f"Error during streaming of {warc_path!r}")
-            time.sleep(10)
+            time.sleep(30)
 
     @staticmethod
     def _single_crawl(

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -221,9 +221,10 @@ class CCNewsSource:
             return None
 
         with requests.Session() as session:
-            stream = session.get(self.warc_path, stream=True, headers=self.headers).raw
+            response = session.get(self.warc_path, stream=True, headers=self.headers)
+            response.raise_for_status()
 
-            for warc_record in ArchiveIterator(stream, record_types=WarcRecordType.response, verify_digests=True):
+            for warc_record in ArchiveIterator(response.raw, record_types=WarcRecordType.response, verify_digests=True):
                 target_url = str(warc_record.headers["WARC-Target-URI"])
 
                 if url_filter is not None and url_filter(target_url):


### PR DESCRIPTION
This PR guards the download and streaming of specific WARC files by catching `requests.HTTPError`s and `fastwarc.stream_io.StreamError`s and logging the corresponding WARC path at `error` level. This is in order to prevent Fundus from crashing when something went wrong during the processing of an individual WARC file.

This PR also adds a naive retry mechanic, that tries to reload said WARC file every 30 * current try seconds. By default, it does so three times.