### PR TITLE
Expose loggers and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ We provide **quick tutorials** to get you started with the library:
 2. [**Tutorial 2: How to crawl articles from CC-NEWS**](docs/2_crawl_from_cc_news.md)
 3. [**Tutorial 3: The Article Class**](docs/3_the_article_class.md)
 4. [**Tutorial 4: How to filter articles**](docs/4_how_to_filter_articles.md)
-5. [**Tutorial 5: How to search for publishers**](docs/5_advanced_topics)
+5. [**Tutorial 5: Advanced topics**](docs/5_advanced_topics)
+6. [**Tutorial 6: Logging**](docs/6_logging.md)
 
 If you wish to contribute check out these tutorials:
 1. [**How to contribute**](docs/how_to_contribute.md)

--- a/docs/4_how_to_filter_articles.md
+++ b/docs/4_how_to_filter_articles.md
@@ -196,4 +196,4 @@ crawler = Crawler(PublisherCollection.us, restrict_sources_to=[NewsMap])
 The `crawl()` method supports functionality to filter out articles with URLs previously encountered in this run.
 You can alter this behavior by setting the `only_unique` parameter.
 
-In the [next section](5_advanced_topics) we will show you how to search through publishers in the `PublisherCollection`.
+In the [next section](5_advanced_topics) we will guide you through advanced topics as how to search through publishers in the `PublisherCollection`, how to save articles and how to deal with deprecated publishers.

--- a/docs/5_advanced_topics.md
+++ b/docs/5_advanced_topics.md
@@ -1,9 +1,10 @@
 # Table of Contents
 
-* [How to search for publishers](#how-to-search-for-publishers)
-  * [Using `search()`](#using-search)
-* [Saving the crawled articles](#saving-the-crawled-articles)
-* [Working with deprecated publishers](#working-with-deprecated-publishers)
+* [Advanced Topics](#advanced-topics)
+  * [How to search for publishers](#how-to-search-for-publishers)
+    * [Using `search()`](#using-search)
+  * [Save crawled articles to a file](#save-crawled-articles-to-a-file)
+  * [Working with deprecated publishers](#working-with-deprecated-publishers)
 
 # Advanced Topics
 
@@ -36,3 +37,5 @@ When given a path, the crawled articles will be saved as a JSON list using the
 When we notice that a publisher is uncrawlable for whatever reason, we will mark it with a deprecated flag.
 This mostly has internal usages, since the default value for the `Crawler` `ignore_deprecated` flag is `False`.
 You can alter this behaviour when initiating the `Crawler` and setting the `ignore_deprecated` flag.
+
+In the [next section](6_logging.md) introduce you to Fundus logging mechanics.

--- a/docs/5_advanced_topics.md
+++ b/docs/5_advanced_topics.md
@@ -38,4 +38,4 @@ When we notice that a publisher is uncrawlable for whatever reason, we will mark
 This mostly has internal usages, since the default value for the `Crawler` `ignore_deprecated` flag is `False`.
 You can alter this behaviour when initiating the `Crawler` and setting the `ignore_deprecated` flag.
 
-In the [next section](6_logging.md) introduce you to Fundus logging mechanics.
+In the [next section](6_logging.md) we introduce you to Fundus logging mechanics.

--- a/docs/6_logging.md
+++ b/docs/6_logging.md
@@ -39,6 +39,12 @@ Or find a collection of all existing loggers with their module names here:
 
 ````python
 from fundus.logging import loggers
+
+# print all modules having loggers
+print("\n".join(sorted(loggers.keys())))
+
+# accessing the 'url' logger
+url_logger = loggers["fundus.scraping.url"]
 ````
 
 ## Changing log levels

--- a/docs/6_logging.md
+++ b/docs/6_logging.md
@@ -15,12 +15,15 @@ This tutorial will introduce you to the logging mechanics used in Fundus
 Fundus uses module scoped logging with module names as logger names.
 Not every module has a logger per se, but every module that logs a message has.
 All module related implementation is centralized in Fundus' logging module under `fundus.logging`.
+
 Fundus uses 4 different log levels:
+
 - DEBUG: Not relevant to the average user and mainly used for debugging.
 - INFO: Could be interesting to the user, but not necessarily.
 - WARNING: Something went wrong, but we're trying to fix it.
 - ERROR: Either we tried or not even bothering to resolve this.
-With the default one being `ERROR`.
+
+with default log level for all Fundus loggers being `ERROR`.
 
 *__NOTE__*: Depending on the spawn method (spawn) your OS uses to spawn new processes in python (this effects mostly Windows), log messages beneath `ERROR` won't be received when using multiprocessing. 
 

--- a/docs/6_logging.md
+++ b/docs/6_logging.md
@@ -1,0 +1,67 @@
+# Table of Contents
+
+* [Logging in Fundus](#logging-in-fundus)
+  * [Principals](#principals)
+  * [Accessing loggers](#accessing-loggers)
+  * [Changing log levels](#changing-log-levels)
+  * [Format and handlers](#format-and-handlers)
+
+# Logging in Fundus
+
+This tutorial will introduce you to the logging mechanics used in Fundus
+
+## Principals
+
+Fundus uses module scoped logging with module names as logger names.
+Not every module has a logger per se, but every module that logs a message has.
+All module related implementation is centralized in Fundus' logging module under `fundus.logging`.
+Fundus uses 4 different log levels:
+- DEBUG: Not relevant to the average user and mainly used for debugging.
+- INFO: Could be interesting to the user, but not necessarily.
+- WARNING: Something went wrong, but we're trying to fix it.
+- ERROR: Either we tried or not even bothering to resolve this.
+With the default one being `ERROR`.
+
+*__NOTE__*: Depending on the spawn method (spawn) your OS uses to spawn new processes in python (this effects mostly Windows), log messages beneath `ERROR` won't be received when using multiprocessing. 
+
+## Accessing loggers
+
+You can import a specific logger from the corresponding module like this:
+
+````python
+from fundus.scraping.crawler import logger
+````
+
+Or find a collection of all existing loggers with their module names here:
+
+````python
+from fundus.logging import loggers
+````
+
+## Changing log levels
+
+You can change the log level for the entire library using the `set_log_level` function:
+
+````python
+import logging
+from fundus.logging import set_log_level
+
+set_log_level(logging.DEBUG)
+````
+
+## Format and handlers
+
+By default, all Fundus log messages are written to `stderr` with the following format `%(asctime)s - %(name)s - %(levelname)s - %(message)s`
+To add another handler use the `add_handler` function.
+
+````python
+import logging
+from fundus.logging import add_handler
+
+file_handler = logging.FileHandler(f"fundus.log", encoding="utf-8")
+file_handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+add_handler(file_handler)
+````
+
+*__NOTE__*: All of the above can also be done individually for every logger by [accessing loggers](#accessing-loggers) directly.
+

--- a/src/fundus/logging.py
+++ b/src/fundus/logging.py
@@ -1,8 +1,9 @@
 import logging
+from typing import Dict
 
-__all__ = ["set_log_level", "create_logger"]
+__all__ = ["set_log_level", "add_handler", "create_logger", "loggers"]
 
-_loggers = []
+loggers: Dict[str, logging.Logger] = {}
 
 _stream_handler = logging.StreamHandler()
 _formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -13,10 +14,15 @@ def create_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(logging.ERROR)
     logger.addHandler(_stream_handler)
-    _loggers.append(logger)
+    loggers[name] = logger
     return logger
 
 
 def set_log_level(level: int):
-    for logger in _loggers:
+    for logger in loggers.values():
         logger.setLevel(level)
+
+
+def add_handler(handler: logging.Handler):
+    for logger in loggers.values():
+        logger.addHandler(handler)


### PR DESCRIPTION
This PR
- exposes all loggers in a dictionary called `loggers` mapping module name to logger
- adds a new utility function to easily add a handler to all existing loggers
- add a new tutorial about logging and update the documentation accordingly