### PR TITLE
Fix upper bound for retries and catch `urllib3.exceptions.HTTPError`

### DIFF
--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -405,7 +405,7 @@ class CCNewsCrawler(CrawlerBase):
                 retries += 1
                 # depending on the spawning method, the current log level will be reset to basic configuration when
                 # spawning a new process, so this log massage will not be displayed on Windows machines
-                logger.error(
+                logger.warning(
                     f"Could not load WARC file {warc_path!r}. Retry after {30 * retries} seconds: {exception!r}"
                 )
                 time.sleep(30 * retries)


### PR DESCRIPTION
The previous retry implementation calculated retries incorrectly, as well as ignoring `urllib3.exceptions.HTTPError`.