### PR TITLE
Mark Occupy Democrats as deprecated 

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -1314,7 +1314,9 @@
         <code>OccupyDemocrats</code>
       </td>
       <td>
-        <div>Occupy Democrats</div>
+        <div>
+          <strike>Occupy Democrats</strike>
+        </div>
       </td>
       <td>
         <a href="https://occupydemocrats.com/">

--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -192,6 +192,7 @@ class US(PublisherEnum):
             )
         ],
         parser=OccupyDemocratsParser,
+        deprecated=True
     )
 
     LATimes = PublisherSpec(

--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -192,7 +192,7 @@ class US(PublisherEnum):
             )
         ],
         parser=OccupyDemocratsParser,
-        deprecated=True
+        deprecated=True,
     )
 
     LATimes = PublisherSpec(


### PR DESCRIPTION
The sitemaps are inaccessible due to the website asking for login credentials. Weirdly enough, you even need credentials to read the articles as a normal visitor...