### PR TITLE
Set ˋeval_booleansˋ to True in publisher_coverage

### DIFF
--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -54,7 +54,7 @@ def main() -> None:
                 )
 
                 if incomplete_article is None:
-                    print(f"❌ FAILED: {publisher_name!r} - No articles received")
+                    print(f"❌ FAILED: {publisher_name!r} - No free articles received")
 
                 elif incomplete_article.exception is not None:
                     print(

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -12,7 +12,7 @@ from typing import List, Optional, cast
 from fundus import Crawler, PublisherCollection
 from fundus.publishers.base_objects import PublisherEnum
 from fundus.scraping.article import Article
-from fundus.scraping.filter import RequiresAll
+from fundus.scraping.filter import Requires, RequiresAll
 from fundus.utils.timeout import timeout
 
 
@@ -44,12 +44,13 @@ def main() -> None:
             timed_next = timeout(next, seconds=20, silent=True)
 
             complete_article: Optional[Article] = timed_next(  # type: ignore[call-arg]
-                crawler.crawl(max_articles=1, only_complete=RequiresAll(), error_handling="suppress"), None
+                crawler.crawl(max_articles=1, only_complete=RequiresAll(eval_booleans=True), error_handling="suppress"),
+                None,
             )
 
             if complete_article is None:
                 incomplete_article: Optional[Article] = timed_next(  # type: ignore[call-arg]
-                    crawler.crawl(max_articles=1, only_complete=False, error_handling="catch"), None
+                    crawler.crawl(max_articles=1, only_complete=Requires("free_access"), error_handling="catch"), None
                 )
 
                 if incomplete_article is None:


### PR DESCRIPTION
Since in most cases, there is no plaintext available to be parsed I would suggest restricting the publisher_coverage to assess articles that are marked to be free_access. While this doesn't have a big effect on whether or not a complete article can be found, it makes debugging easier, when an article is returned that is actually incomplete and not just a premium article