### PR TITLE
fix free_access for various publishers

### DIFF
--- a/src/fundus/publishers/us/la_times.py
+++ b/src/fundus/publishers/us/la_times.py
@@ -37,3 +37,8 @@ class LATimesParser(ParserProxy):
         @attribute
         def title(self) -> Optional[str]:
             return self.precomputed.meta.get("og:title")
+
+        @attribute
+        def free_access(self) -> bool:
+            # LA Times sets the corresponding JSON Element to False by default, but all articles are still available
+            return True

--- a/src/fundus/publishers/us/the_intercept.py
+++ b/src/fundus/publishers/us/the_intercept.py
@@ -59,6 +59,12 @@ class TheInterceptParser(ParserProxy):
 
             return [keyword[9:] for keyword in keywords if keyword.startswith("Subject: ")]
 
+        @attribute
+        def free_access(self) -> bool:
+            # The Intercept set the corresponding JSON Value to False by default, it seems like they don't really have
+            # a paywall that would block fundus
+            return True
+
     class V1_1(V1):
         VALID_UNTIL = date.today()
         _summary_selector = XPath(

--- a/src/fundus/publishers/us/the_nation.py
+++ b/src/fundus/publishers/us/the_nation.py
@@ -78,6 +78,12 @@ class TheNationParser(ParserProxy):
         def topics(self) -> List[str]:
             return generic_topic_parsing(self.precomputed.meta.get("keywords"))
 
+        @attribute
+        def free_access(self) -> bool:
+            # The Nation sets the corresponding JSON Value to False by default. Access Control is done in away that
+            # is irrelevant for fundus
+            return True
+
     class V2(V1):
         VALID_UNTIL = date.today()
 


### PR DESCRIPTION
it turns out a couple of us publishers do not properly implement the isAccessibleForFree attribute. This PR addresses this.