### PR TITLE
Rework logging and fix overwritten config

### DIFF
--- a/src/fundus/logging.py
+++ b/src/fundus/logging.py
@@ -1,28 +1,110 @@
 import logging
-from typing import Dict
+from typing import Dict, Set, Union, cast
 
-__all__ = ["set_log_level", "add_handler", "create_logger", "loggers"]
+from fundus.utils.serialization import JSONVal
 
-loggers: Dict[str, logging.Logger] = {}
+_default_handler_level = logging.ERROR
 
+__all__ = ["set_log_level", "add_handler", "create_logger", "loggers", "handlers"]
+
+# create std-handler
 _stream_handler = logging.StreamHandler()
+_stream_handler.name = "std-handler"
 _formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 _stream_handler.setFormatter(_formatter)
+_stream_handler.setLevel(_default_handler_level)
+
+loggers: Dict[str, logging.Logger] = {}
+handlers: Dict[str, logging.Handler] = {_stream_handler.name: _stream_handler}
 
 
 def create_logger(name: str) -> logging.Logger:
+    """Create a new logger with as <name>.
+
+    Per defaults the loggers' log level is set to DEBUG and the following handlers will be added
+    automatically (see <handlers> for more details):
+
+    std-handler: StreamHandler | ERROR | %(asctime)s - %(name)s - %(levelname)s - %(message)s
+
+    Args:
+        name: Reference name for the created logger.
+
+    Returns:
+        A new logger with name <name>
+    """
     logger = logging.getLogger(name)
-    logger.setLevel(logging.ERROR)
-    logger.addHandler(_stream_handler)
+    logger.setLevel(logging.DEBUG)
+    for handler in handlers.values():
+        logger.addHandler(handler)
     loggers[name] = logger
     return logger
 
 
 def set_log_level(level: int):
-    for logger in loggers.values():
-        logger.setLevel(level)
+    """Set log level for all handlers.
+
+    Args:
+        level: The new log level to set
+    """
+    for handler in handlers.values():
+        handler.setLevel(level)
 
 
 def add_handler(handler: logging.Handler):
+    """Add a new handler to all logger.
+
+    Args:
+        handler: The new handler to add.
+    """
+    if handler.name is None:
+        raise ValueError(f"Handlers to add must have a name set")
+
+    if handlers.get(handler.name) is not None:
+        raise ValueError(f"Handler with name {handler.name} already exists")
+
+    handlers[handler.name] = handler
     for logger in loggers.values():
         logger.addHandler(handler)
+
+
+def get_current_config() -> JSONVal:
+    """Get the current logging configuration as JSON.
+
+    Returns:
+        The current logging configuration as JSON.
+    """
+
+    formatters: Set[logging.Formatter] = cast(
+        Set[logging.Formatter], {handler.formatter for handler in handlers.values()}
+    )
+
+    def get_formatter_config(formatter: logging.Formatter) -> JSONVal:
+        return {"format": formatter._fmt}
+
+    def get_handler_config(handler: logging.Handler) -> JSONVal:
+        config: Dict[str, Union[int, str]] = {
+            "level": handler.level,
+            "formatter": hex(id(handler.formatter)),
+            "class": handler.__class__.__module__ + "." + handler.__class__.__name__,
+        }
+        if isinstance(handler, logging.FileHandler):
+            config["filename"] = handler.baseFilename
+            config["mode"] = handler.mode
+            if handler.encoding is not None:
+                config["encoding"] = handler.encoding
+            config["delay"] = handler.delay
+        return config  # type: ignore[return-value]
+
+    def get_logger_config(logger: logging.Logger) -> JSONVal:
+        return {
+            "level": logger.level,
+            "handlers": [handler.name for handler in logger.handlers],
+            "propagate": logger.propagate,
+        }
+
+    return {
+        "version": 1,
+        "formatters": {hex(id(formatter)): get_formatter_config(formatter) for formatter in formatters},
+        "handlers": {str(handler.name): get_handler_config(handler) for handler in handlers.values()},
+        "loggers": {logger.name: get_logger_config(logger) for logger in loggers.values()},
+    }

--- a/src/fundus/logging.py
+++ b/src/fundus/logging.py
@@ -82,7 +82,7 @@ def get_current_config() -> JSONVal:
         return {"format": formatter._fmt}
 
     def get_handler_config(handler: logging.Handler) -> JSONVal:
-        config: Dict[str, Union[int, str]] = {
+        config: Dict[str, JSONVal] = {
             "level": handler.level,
             "formatter": hex(id(handler.formatter)),
             "class": handler.__class__.__module__ + "." + handler.__class__.__name__,
@@ -93,7 +93,7 @@ def get_current_config() -> JSONVal:
             if handler.encoding is not None:
                 config["encoding"] = handler.encoding
             config["delay"] = handler.delay
-        return config  # type: ignore[return-value]
+        return config
 
     def get_logger_config(logger: logging.Logger) -> JSONVal:
         return {

--- a/src/fundus/utils/serialization.py
+++ b/src/fundus/utils/serialization.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Sequence, Union, cast
+from typing import Dict, Sequence, Union
 
 from typing_extensions import TypeAlias
 


### PR DESCRIPTION
## Fixes a bug when using `spawn` as start method for multiprocessing
Previously, when using `spawn` as a start method, already set logging configurations are overwritten, when starting a new process. This PR introduces a workaround, passing the current configuration to the `Pool` and initializing the logging module with said config when a new process is started for the `CCNewsCrawler`.

## Reworks parts of the logging module
IMO adding handlers and setting levels was still pretty tedious, even after the last rework. With this PR, the logger debug level is set to `DEBUG` by default, and one controls debugging with handler levels instead of the logger level. 