### PR TITLE
Fix Freie Presse

### DIFF
--- a/src/fundus/publishers/de/freiepresse.py
+++ b/src/fundus/publishers/de/freiepresse.py
@@ -15,7 +15,7 @@ from fundus.parser.utility import (
 class FreiePresseParser(ParserProxy):
     class V1(BaseParser):
         _summary_selector = CSSSelector("#artikel-content > p.bold")
-        _paragraph_selector = CSSSelector("#artikel-content > p:not(.bold)")
+        _paragraph_selector = CSSSelector("#artikel-content p:not(.bold)")
         _subheadline_selector = CSSSelector("#artikel-content h2")
 
         @attribute

--- a/tests/resources/parser/test_data/de/FreiePresse.json
+++ b/tests/resources/parser/test_data/de/FreiePresse.json
@@ -11,6 +11,7 @@
         {
           "headline": [],
           "paragraphs": [
+            "Am letzten Maiwochenende wird es so weit sein. Das Hutfestival verwandelt die Chemnitzer Innenstadt in ein Zentrum der Straßenkunst. Neu bei dem seit 2018 stattfindenden Festival ist in diesem Jahr die Veranstaltungsfläche am Roten Turm. Hier wird ein Schlappseil für das in Köln beheimatete Rope Theatre gespannt. Damit steigt die Zahl der Veranstaltungsflächen auf sieben. Die Innenstadt zwischen Stadthalle und Rosenhof, Theaterstraße und Neumarkt verwandelt sich in eine große Bühne mit mehr als 200 Künstlern und vielen Live-Darbietungen.",
             "Wieder wurde ein Programm mit internationalen Höhepunkten und lokalen Akteuren zusammengestellt. Zu den bekanntesten Namen gehören der spanische Pantomime-Künstler Hugo Miro und das Artistik-Trio Bard Theatro Fisico aus Argentinien. Wise Fool ist eine Luftakrobatik-Show am Trapez mit drei jungen Frauen aus Finnland und Südafrika auf dem Neumarkt. Humorvoll geht es beim Varieté Marlon Band aus Italien sowie Maya and Brend aus den USA zu. Die Soap Stunters aus den Niederlanden bieten eine Retro-Stunt-Show."
           ]
         },


### PR DESCRIPTION
The paragraph selectors seem to always have missed at least a paragraph. Now, with FP changing most of their articles to Premium only, the only free articles are just on paragraph long, which was then not parsed properly. It should work now, the test file was updated accordingly.