### PR TITLE
Bump version to `0.4.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fundus"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
     { name = "Max Dallabetta", email = "max.dallabetta@googlemail.com" },
 ]


### PR DESCRIPTION
Release: v0.4.0 🎉

With the merge of #560, we are excited to announce the release of a new major version: 0.4.0.

Unfortunately, this release has taken a while, resulting in new features being accessible only through the master branch. Moving forward, we want to maintain a more frequent release cycle to ensure timely access to new features and improvements 🚀.

Happy crawling :)