### PR TITLE
Add `parse` method to `ParserProxy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "tqdm>=4.66, <5",
     "fastwarc>=0.14, <1",
     "chardet>=5.2, <6",
-    "dill>=0.3, <1"
+    "dill>=0.3, <1",
+    "deprecated>=1.2.14, <2"
 ]
 
 [project.urls]
@@ -53,6 +54,7 @@ dev = [
     "types-python-dateutil>=2.8, <3",
     "types-requests>=2.28, <3",
     "types-colorama>=0.4, <1",
+    "types-deprecated>=1.2.9, <2"
 ]
 
 [tool.mypy]

--- a/src/fundus/parser/base_parser.py
+++ b/src/fundus/parser/base_parser.py
@@ -295,9 +295,9 @@ class ParserProxy(ABC):
         reason=f"Calling <class: ParserProxy> is legacy behaviour. Use <method: parse> of <class: ParserProxy> instead",
     )
     def __call__(self, crawl_date: Optional[Union[datetime, date]] = None) -> BaseParser:
-        return self._get_parser(crawl_date)
+        return self.get_parser(crawl_date)
 
-    def _get_parser(self, crawl_date: Optional[Union[datetime, date]] = None) -> BaseParser:
+    def get_parser(self, crawl_date: Optional[Union[datetime, date]] = None) -> BaseParser:
         if crawl_date is None:
             return self._get_latest_cache()()
 
@@ -358,4 +358,4 @@ class ParserProxy(ABC):
         crawl_date: Union[datetime, date],
         error_handling: Literal["suppress", "catch", "raise"] = "raise",
     ) -> Dict[str, Any]:
-        return self._get_parser(crawl_date).parse(html, error_handling)
+        return self.get_parser(crawl_date).parse(html, error_handling)

--- a/src/fundus/parser/base_parser.py
+++ b/src/fundus/parser/base_parser.py
@@ -24,6 +24,7 @@ from typing import (
 
 import lxml.html
 import more_itertools
+from deprecated import deprecated
 from lxml.etree import XPath
 
 from fundus.logging import create_logger
@@ -289,7 +290,14 @@ class ParserProxy(ABC):
             mapping[validation_date] = _ParserCache(versioned_parser)
         self._parser_mapping = mapping
 
+    @deprecated(
+        version="0.4.1",
+        reason=f"Calling <class: ParserProxy> is legacy behaviour. Use <method: parse> of <class: ParserProxy> instead",
+    )
     def __call__(self, crawl_date: Optional[Union[datetime, date]] = None) -> BaseParser:
+        return self._get_parser(crawl_date)
+
+    def _get_parser(self, crawl_date: Optional[Union[datetime, date]] = None) -> BaseParser:
         if crawl_date is None:
             return self._get_latest_cache()()
 
@@ -343,3 +351,11 @@ class ParserProxy(ABC):
     @property
     def latest_version(self) -> Type[BaseParser]:
         return self._get_latest_cache().factory
+
+    def parse(
+        self,
+        html: str,
+        crawl_date: Union[datetime, date],
+        error_handling: Literal["suppress", "catch", "raise"] = "raise",
+    ) -> Dict[str, Any]:
+        return self._get_parser(crawl_date).parse(html, error_handling)

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -162,7 +162,7 @@ class PublisherGroup(type):
         unique_attributes = set(attributes)
         spec: Publisher
         for publisher in cls:
-            if unique_attributes.issubset(publisher.parser().attributes().names) and (
+            if unique_attributes.issubset(publisher.parser.latest_version.attributes().names) and (
                 publisher.supports(source_types) if source_types else True
             ):
                 matched.append(publisher)

--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict, Iterator, List, Literal, Optional, Type
 
 import more_itertools
@@ -34,7 +35,7 @@ class BaseScraper:
                 parser = self.parser_mapping[html.source_info.publisher]
 
                 try:
-                    extraction = parser(html.crawl_date).parse(html.content, error_handling)
+                    extraction = parser.parse(html.content, html.crawl_date, error_handling)
 
                 except Exception as error:
                     if error_handling == "raise":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -108,13 +108,13 @@ class TestParserProxy:
         assert parser_proxy.latest_version == parser_proxy.Later
 
     def test_call(self, proxy_with_two_versions_and_different_attrs):
-        parser_proxy = proxy_with_two_versions_and_different_attrs()
-        assert type(parser_proxy()) == parser_proxy.latest_version
+        parser_proxy: ParserProxy = proxy_with_two_versions_and_different_attrs()
+        assert type(parser_proxy.get_parser()) == parser_proxy.latest_version
 
         for versioned_parser in parser_proxy:
-            from_proxy = parser_proxy(versioned_parser.VALID_UNTIL)
+            from_proxy = parser_proxy.get_parser(versioned_parser.VALID_UNTIL)
             assert isinstance(from_proxy, versioned_parser)
-            assert from_proxy == parser_proxy(versioned_parser.VALID_UNTIL)
+            assert from_proxy == parser_proxy.get_parser(versioned_parser.VALID_UNTIL)
 
     def test_mapping(self, proxy_with_two_versions_and_different_attrs):
         parser_proxy = proxy_with_two_versions_and_different_attrs()

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -263,7 +263,7 @@ def load_html_test_file_mapping(publisher: Publisher) -> Dict[Type[BaseParser], 
     html_files = [HTMLTestFile.load(path) for path in html_paths]
     html_mapping: Dict[Type[BaseParser], HTMLTestFile] = {}
     for html_file in html_files:
-        versioned_parser = publisher.parser(html_file.crawl_date)
+        versioned_parser = publisher.parser.get_parser(html_file.crawl_date)
         if html_mapping.get(type(versioned_parser)):
             raise KeyError(f"Duplicate html files for {publisher.name!r} and version {type(versioned_parser).__name__}")
         html_mapping[type(versioned_parser)] = html_file


### PR DESCRIPTION
The purpose of this PR is to unify the versioning mechanics of `ParserProxy` and the `BaseParser` in a new interface called `parse` within `ParserProxy`. 

```python

#prev
extraction = parser(crawl_date).parse(html, ...)

#now
extraction = parser.parse(html, crawl_date, ...)
```

This change is primarily a preparation for an upcoming feature that will enable contributors to deprecate individual attributes.

Update: Maybe that's not really necessary