### PR TITLE
Set `WashingtonPost` deprecated

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -1573,7 +1573,9 @@
         <code>WashingtonPost</code>
       </td>
       <td>
-        <div>Washington Post</div>
+        <div>
+          <strike>Washington Post</strike>
+        </div>
       </td>
       <td>
         <a href="https://www.washingtonpost.com/">

--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -160,6 +160,7 @@ class US(metaclass=PublisherGroup):
         ],
         # Adds a URL-filter to ignore incomplete URLs
         url_filter=regex_filter(r"washingtonpost.com(\/)?$"),
+        deprecated=True,
     )
 
     TheNewYorker = Publisher(


### PR DESCRIPTION
Unfortunately, another US publisher became unreachable. Maybe someone could figure out a solution.