### PR TITLE
Add `robots.txt` based filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "tqdm>=4.66, <5",
     "fastwarc>=0.14, <1",
     "chardet>=5.2, <6",
-    "dill>=0.3, <1"
+    "dill>=0.3, <1",
+    "robotspy>=0.9, <1"
 ]
 
 [project.urls]

--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -21,7 +21,7 @@ logger = create_logger(__name__)
 
 def get_test_article(publisher: Publisher, url: Optional[str] = None) -> Optional[Article]:
     if url is not None:
-        source = WebSource([url], publisher=publisher.name)
+        source = WebSource([url], publisher=publisher)
         scraper = BaseScraper(source, parser_mapping={publisher.name: publisher.parser})
         return next(scraper.scrape(error_handling="suppress", extraction_filter=RequiresAll()), None)
 

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -46,7 +46,7 @@ class Publisher:
         self.url_filter = url_filter
         self.request_header = request_header
         self.deprecated = deprecated
-        self.robots = RobotFileParser(self.domain + "robots.txt")
+        self.robots = RobotFileParser(self.domain + "robots.txt" if self.domain.endswith("/") else self.domain + "/robots.txt")
         # we define the dict here manually instead of using default dict so that we can control
         # the order in which sources are proceeded.
         source_mapping: Dict[Type[URLSource], List[URLSource]] = {

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -46,7 +46,9 @@ class Publisher:
         self.url_filter = url_filter
         self.request_header = request_header
         self.deprecated = deprecated
-        self.robots = RobotFileParser(self.domain + "robots.txt" if self.domain.endswith("/") else self.domain + "/robots.txt")
+        self.robots = RobotFileParser(
+            self.domain + "robots.txt" if self.domain.endswith("/") else self.domain + "/robots.txt"
+        )
         # we define the dict here manually instead of using default dict so that we can control
         # the order in which sources are proceeded.
         source_mapping: Dict[Type[URLSource], List[URLSource]] = {

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -2,6 +2,8 @@ import inspect
 from textwrap import indent
 from typing import Dict, Iterator, List, Optional, Type, Union
 
+from robots import RobotFileParser
+
 from fundus.parser.base_parser import ParserProxy
 from fundus.scraping.filter import URLFilter
 from fundus.scraping.url import NewsMap, RSSFeed, Sitemap, URLSource
@@ -44,6 +46,7 @@ class Publisher:
         self.url_filter = url_filter
         self.request_header = request_header
         self.deprecated = deprecated
+        self.robots = RobotFileParser(self.domain + "robots.txt")
         # we define the dict here manually instead of using default dict so that we can control
         # the order in which sources are proceeded.
         source_mapping: Dict[Type[URLSource], List[URLSource]] = {

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -324,6 +324,7 @@ class Crawler(CrawlerBase):
         ignore_deprecated: bool = False,
         delay: Optional[Union[float, Delay]] = 1.0,
         threading: bool = True,
+        ignore_robots: bool = False,
     ):
         """Fundus base class for crawling articles from the web.
 
@@ -348,6 +349,9 @@ class Crawler(CrawlerBase):
                 the crawler will use a single thread for all publishers and load articles successively. This will
                 greatly influence performance, and it is highly recommended to use a threaded crawler.
                 Defaults to True.
+            ignore_robots (bool): Determines whether to bypass the consideration of the robots.txt file when
+                filtering URLs from publishers. If set to True, the URLs will not be filtered based on the
+                robots.txt file. Defaults to False.
         """
 
         def filter_publishers(publisher: Publisher) -> bool:
@@ -368,6 +372,7 @@ class Crawler(CrawlerBase):
         self.restrict_sources_to = restrict_sources_to
         self.delay = delay
         self.threading = threading
+        self.ignore_robots = ignore_robots
 
     def _fetch_articles(
         self,
@@ -391,7 +396,7 @@ class Crawler(CrawlerBase):
             else:
                 raise TypeError("param <delay> of <Crawler.__init__>")
 
-        scraper = WebScraper(publisher, self.restrict_sources_to, build_delay())
+        scraper = WebScraper(publisher, self.restrict_sources_to, build_delay(), ignore_robots=self.ignore_robots)
         yield from scraper.scrape(error_handling, extraction_filter, url_filter)
 
     @staticmethod

--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -69,6 +69,7 @@ class WebScraper(BaseScraper):
         publisher: Publisher,
         restrict_sources_to: Optional[List[Type[URLSource]]] = None,
         delay: Optional[Delay] = None,
+        ignore_robots: bool = False,
     ):
         if restrict_sources_to:
             url_sources = tuple(
@@ -80,11 +81,12 @@ class WebScraper(BaseScraper):
         html_sources = [
             WebSource(
                 url_source=url_source,
-                publisher=publisher.name,
+                publisher=publisher,
                 request_header=publisher.request_header,
                 delay=delay,
                 url_filter=publisher.url_filter,
                 query_parameters=publisher.query_parameter,
+                ignore_robots=ignore_robots,
             )
             for url_source in url_sources
         ]


### PR DESCRIPTION
This PR finally implements `robots.txt` based filtering of URLs.

Unfortunately the stdlib implementation of the `RobotFileParser` seems to have trouble fetching some pages so I had to add additional dependencies.