### PR TITLE
Change coverage schedule time to `14:00`

### DIFF
--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -2,7 +2,7 @@ name: Publisher Coverage
 
 on:
   schedule:
-    - cron: '0 1 * * *'  # Runs at 01:00
+    - cron: '0 14 * * *'  # Runs at 14:00
 
   workflow_dispatch:
 


### PR DESCRIPTION
The current schedule time (01:00) negatively impacts the certainty of coverage results of some german (i.g. European) publishers.
This PR tries to set a schedule time that is more "during the day" for most publishers, ensuring RSSFeeds are working properly.