### PR TITLE
Fix bug in test file generation

### DIFF
--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -116,6 +116,10 @@ def main() -> None:
                 if not (article := get_test_article(publisher, url)):
                     logger.error(f"Couldn't get article for {publisher.name}. Skipping")
                     continue
+
+                # remove previous file
+                if previous_file := html_mapping.get(publisher.parser.latest_version):
+                    previous_file.remove()
                 html = HTMLTestFile(
                     url=article.html.responded_url,
                     content=article.html.content,
@@ -124,10 +128,6 @@ def main() -> None:
                 )
                 html.write()
                 subprocess.call(["git", "add", html.path], stdout=subprocess.PIPE)
-
-                # remove previous file
-                if previous_file := html_mapping.get(publisher.parser.latest_version):
-                    previous_file.remove()
 
                 html_mapping[publisher.parser.latest_version] = html
                 test_data[publisher.parser.latest_version.__name__] = {}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -174,13 +174,15 @@ class TestParser:
             missing_attrs = attributes_required_to_cover & supported_attrs - set(version_data.keys())
             assert (
                 not missing_attrs
-            ), f"Test JSON for {version_name} does not cover the following attribute(s): {missing_attrs}"
+            ), f"Test JSON for {version_name} of publisher {publisher.name} does not cover the following attribute(s): {missing_attrs}"
 
             assert list(version_data.keys()) == sorted(
                 attributes_required_to_cover & supported_attrs
             ), f"Test JSON for {version_name} is not in alphabetical order"
 
-            assert (html := html_mapping.get(versioned_parser)), f"Missing test HTML for parser version {version_name}"
+            assert (
+                html := html_mapping.get(versioned_parser)
+            ), f"Missing test HTML for parser version {version_name} of publisher {publisher.name}"
             # compare data
             extraction = versioned_parser().parse(html.content, "raise")
             for key, value in version_data.items():


### PR DESCRIPTION
When overriding the parser test file data multiple times in a row, the script will delete the saved html every other time. Simply reordering the commands fixes this. Additionally I updated the error message to also reflect the publisher where it occured, even though it is visible by looking though the pytest summary as well, I thought this is simpler because all the necessary information is at the same place.