### PR TITLE
Guard key access for RSSFeed entries

### DIFF
--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -90,8 +90,7 @@ class RSSFeed(URLSource):
             logger.warning(f"Warning! Couldn't parse rss feed {self.url!r} because of {exception}")
             return
         else:
-            for url in (entry["link"] for entry in rss_feed["entries"]):
-                yield url
+            yield from filter(bool, (entry.get("link") for entry in rss_feed["entries"]))
 
 
 @dataclass


### PR DESCRIPTION
This fixes a bug regarding RSS feeds.

While parsing the feeds and yielding resulting URLs, the current implementation is based on the assumption that every feed entry has at least a `link` field, which is not the case.

This PR guards the key access.

See [this](https://github.com/flairNLP/fundus/actions/runs/10616770184/job/29427987839#step:5:145) for further details.