### PR TITLE
CC-News benchmark

### DIFF
--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, Dict, Protocol, cast
+from typing import Any, Callable, Dict, Protocol
 
 from typing_extensions import ParamSpec
 
@@ -119,7 +119,7 @@ class FilterResultWithMissingAttributes:
         return bool(self.missing_attributes)
 
 
-def _guarded_bool(value: Any):
+def guarded_bool(value: Any) -> bool:
     if isinstance(value, bool):
         return True
     else:
@@ -151,7 +151,7 @@ class Requires:
         """
         self.required_attributes = set(required_attributes)
         # somehow mypy does not recognize bool as callable :(
-        self._eval: Callable[[Any], bool] = bool if eval_booleans else _guarded_bool  # type: ignore[assignment]
+        self._eval: Callable[[Any], bool] = bool if eval_booleans else guarded_bool  # type: ignore[assignment]
 
     def __call__(self, extraction: Dict[str, Any]) -> FilterResultWithMissingAttributes:
         missing_attributes = [


### PR DESCRIPTION
This PR introduces functionality to benchmark publishers using the CC-NEWS dataset.

The benchmarking process involves retrieving HTML and articles at specified intervals (daily, weekly, monthly, etc.) from the CC-NEWS dataset, assessing the completeness of the article extraction, and offering utility and statistical functions for operating on the benchmark. The goal is to detect any layout changes that occurred before the initial implementation of a specific parser and to provide the relevant HTML to address these changes.