### PR TITLE
Patch `RobotsFileParser` and add crawl-delay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     "tqdm>=4.66, <5",
     "fastwarc>=0.14, <1",
     "chardet>=5.2, <6",
-    "dill>=0.3, <1",
-    "robotspy>=0.9, <1"
+    "dill>=0.3, <1"
 ]
 
 [project.urls]

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -325,6 +325,7 @@ class Crawler(CrawlerBase):
         delay: Optional[Union[float, Delay]] = 1.0,
         threading: bool = True,
         ignore_robots: bool = False,
+        ignore_crawl_delay: bool = False,
     ):
         """Fundus base class for crawling articles from the web.
 
@@ -352,6 +353,9 @@ class Crawler(CrawlerBase):
             ignore_robots (bool): Determines whether to bypass the consideration of the robots.txt file when
                 filtering URLs from publishers. If set to True, the URLs will not be filtered based on the
                 robots.txt file. Defaults to False.
+            ignore_crawl_delay (bool): Determines whether to ignore a crawl delay given by a publisher.
+                If set to False, this will overwrite <delay>. If ignore_robots is set to True, the crawl delay
+                will also be ignored.
         """
 
         def filter_publishers(publisher: Publisher) -> bool:
@@ -373,6 +377,7 @@ class Crawler(CrawlerBase):
         self.delay = delay
         self.threading = threading
         self.ignore_robots = ignore_robots
+        self.ignore_crawl_delay = ignore_crawl_delay
 
     def _fetch_articles(
         self,
@@ -396,7 +401,13 @@ class Crawler(CrawlerBase):
             else:
                 raise TypeError("param <delay> of <Crawler.__init__>")
 
-        scraper = WebScraper(publisher, self.restrict_sources_to, build_delay(), ignore_robots=self.ignore_robots)
+        scraper = WebScraper(
+            publisher,
+            self.restrict_sources_to,
+            build_delay(),
+            ignore_robots=self.ignore_robots,
+            ignore_crawl_delay=self.ignore_crawl_delay,
+        )
         yield from scraper.scrape(error_handling, extraction_filter, url_filter)
 
     @staticmethod

--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -70,6 +70,7 @@ class WebScraper(BaseScraper):
         restrict_sources_to: Optional[List[Type[URLSource]]] = None,
         delay: Optional[Delay] = None,
         ignore_robots: bool = False,
+        ignore_crawl_delay: bool = False,
     ):
         if restrict_sources_to:
             url_sources = tuple(
@@ -87,6 +88,7 @@ class WebScraper(BaseScraper):
                 url_filter=publisher.url_filter,
                 query_parameters=publisher.query_parameter,
                 ignore_robots=ignore_robots,
+                ignore_crawl_delay=ignore_crawl_delay,
             )
             for url_source in url_sources
         ]


### PR DESCRIPTION
This PR ...
- patches the stdlib `RobotsFileParser` to properly fetch robots.txt files again
- removes `robotspy `dependency
- add crawl-delay parsing

closes #601 