### PR TITLE
Ignore `robots.txt` in coverage script

### DIFF
--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -35,7 +35,7 @@ def main() -> None:
             if publisher.deprecated:  # type: ignore[attr-defined]
                 print(f"⏩  SKIPPED: {publisher_name!r} - Deprecated")
                 continue
-            crawler: Crawler = Crawler(publisher, delay=0.4)
+            crawler: Crawler = Crawler(publisher, delay=0.4, ignore_robots=True)
 
             complete_article: Optional[Article] = next(
                 crawler.crawl(


### PR DESCRIPTION
With the introduction of a robots.txt parsed crawl-delay in #609, the coverage script won't work for publishers specifying said delay. Further, in disabled the entire robot's parser for the coverage script to prevent side effects. 