### PR TITLE
Fix Sportschau

### DIFF
--- a/src/fundus/publishers/de/sportschau.py
+++ b/src/fundus/publishers/de/sportschau.py
@@ -14,7 +14,9 @@ from fundus.parser.utility import (
 
 class SportSchauParser(ParserProxy):
     class V1(BaseParser):
-        _summary_selector = CSSSelector("p >strong")
+        _summary_selector = CSSSelector(
+            "p[class='textabsatz columns twelve  m-ten  m-offset-one l-eight l-offset-two']" " > strong"
+        )
         _paragraph_selector = CSSSelector("article >p.textabsatz:not(p.textabsatz:nth-of-type(1))")
         _subheadline_selector = CSSSelector("article >h2")
 


### PR DESCRIPTION
The former summary selector was too broad, causing errors when paring articles like this one: https://www.sportschau.de/fussball/nationsleague/ein-wechselspiel-aus-licht-und-schatten,einzelkritik-dfb-102.html . The parsing crashed because the summary nodes are not restricted to the beginning of the article.