### PR TITLE
Fix a bug with the `plaintext` property of `Article`

### DIFF
--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -87,7 +87,7 @@ class Article:
 
     @property
     def plaintext(self) -> Optional[str]:
-        return str(self.body) if self.body else None
+        return str(self.body) or None
 
     @property
     def lang(self) -> Optional[str]:


### PR DESCRIPTION
There is a bug in the evaluation of the `plaintext` property of `Article` so that the actual content of `ArticleBody` is not displayed unless it includes a paragraph.