### PR TITLE
Implement XPath queries for LDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ dependencies = [
     "tqdm>=4.66, <5",
     "fastwarc>=0.14, <1",
     "chardet>=5.2, <6",
-    "dill>=0.3, <1"
+    "dill>=0.3, <1",
+    "dict2xml>=1.7.6, <2",
+    "xmltodict>=0.13.0, <1",
 ]
 
 [project.urls]

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -116,11 +116,12 @@ class LinkedDataMapping:
     def xpath_search(self, query: XPath) -> List[Any]:
         """Search through LD using XPath expressions
 
-        Internally, the content of the LinkedDataMapping is converted to XPath and then searched with <query>.
+        Internally, the content of the LinkedDataMapping is converted to XML and then
+        evaluated with an XPath expression <query>.
 
-        To search for keys including invalid XML characters, use unicode representation instead:
+        To search for keys including invalid XML characters, use Unicode representations instead:
         I.e. to search for the key "_16:9" write "//_16U003A9"
-        For all available transformation see LinkedDataMapping.__xml_transformation_table__
+        For all available transformations see LinkedDataMapping.__xml_transformation_table__
 
         Note that values will be converted to strings, i.e. True -> 'True', 1 -> '1'
 
@@ -141,10 +142,10 @@ class LinkedDataMapping:
         >> [value1]
 
         Args:
-            query: An XPath expression
+            query: A XPath expression
 
         Returns:
-            A ordered list of search results
+            An ordered list of search results
         """
 
         pattern = re.compile("|".join(map(re.escape, self.__xml_transformation_table__.values())))
@@ -160,10 +161,10 @@ class LinkedDataMapping:
                 if chunk
             )
 
-        revered_table = {v: k for k, v in self.__xml_transformation_table__.items()}
+        reversed_table = {v: k for k, v in self.__xml_transformation_table__.items()}
 
         def to_original_characters(text: str) -> str:
-            return pattern.sub(lambda match: revered_table[match.group(0)], text)
+            return pattern.sub(lambda match: reversed_table[match.group(0)], text)
 
         nodes = query(self.__as_xml__())
 

--- a/src/fundus/utils/serialization.py
+++ b/src/fundus/utils/serialization.py
@@ -1,9 +1,11 @@
 import json
-from typing import Dict, Sequence, Union
+from typing import Any, Callable, Dict, Sequence, TypeVar, Union
 
 from typing_extensions import TypeAlias
 
 JSONVal: TypeAlias = Union[None, bool, str, float, int, Sequence["JSONVal"], Dict[str, "JSONVal"]]
+
+_T = TypeVar("_T")
 
 
 def is_jsonable(x):
@@ -12,3 +14,28 @@ def is_jsonable(x):
         return True
     except (TypeError, OverflowError):
         return False
+
+
+def replace_keys_in_nested_dict(data: Dict[str, _T], transformation: Callable[[str], str]) -> Dict[str, _T]:
+    """Recursively replace all keys in a nested dictionary with <transformation>.
+
+    Args:
+        data: The dictionary to transform
+        transformation: The transformation to use
+
+    Returns:
+        The transformed dictionary
+    """
+
+    def process(element) -> Any:
+        if isinstance(element, dict):
+            # Apply transformation to keys and recurse into values
+            return {transformation(k): process(v) for k, v in element.items()}
+        elif isinstance(element, list):
+            # Recursively apply to elements in a list
+            return [process(i) for i in element]
+        else:
+            # Base case: return the value as is if it's not a dict or list
+            return element
+
+    return {transformation(k): process(v) for k, v in data.items()}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,24 @@
+from typing import Any, Dict, List
+
+from lxml.etree import XPath
+
+from fundus.parser.data import LinkedDataMapping
+
+lds: List[Dict[str, Any]] = [
+    {"@type": "Example1", "value": 1, "data": {"inner": "value", "nested": {"dict": True}}},
+    {"@type": "Example2", "value": 2, "_:*@": "Howdy"},
+    {"this": "should", "be": {"of": "type", "__UNKNOWN_TYPE__": True, "value": 3}},
+]
+
+
+class TestLinkedDataMapping:
+    def test_constructor(self):
+        LinkedDataMapping(lds)
+
+    def test_xpath_search(self):
+        ld = LinkedDataMapping(lds)
+        assert ld.xpath_search(XPath("//value")) == ["1", "2", "3"]
+        assert ld.xpath_search(XPath("//UNKNOWN_TYPE//value")) == ["3"]
+        assert ld.xpath_search(XPath("//_U003AU002AU0040")) == ["Howdy"]
+        assert ld.xpath_search(XPath("//dict")) == ["True"]
+        assert ld.xpath_search(XPath("//Example2")) == [{"@type": "Example2", "value": "2", "_:*@": "Howdy"}]


### PR DESCRIPTION
This PR enables developers to query a `LinkedDataMapping` using XPath expressions by adding a method called `xpath_search` to `LinkedDataMapping`.

For an example, please take a look at the [test cases](https://github.com/flairNLP/fundus/pull/614/files#diff-60fb0a496fe1cd67d38a04f3cfde59201fe9bff091439e2d07eb834e1ba62f3a).