### PR TITLE
Remove `<br>` tags in html

### DIFF
--- a/src/fundus/publishers/na/the_namibian.py
+++ b/src/fundus/publishers/na/the_namibian.py
@@ -51,7 +51,12 @@ class TheNamibianParser(ParserProxy):
         _paragraph_selector = XPath("//div[contains(@class, 'entry-content')]/p[(text() or strong) and position()>1]")
         _summary_selector = XPath("//div[contains(@class, 'entry-content')]/p[(text() or strong) and position()=1]")
 
-        def _base_setup(self, html: str) -> None:
-            html = re.sub(r"(<br>)+", "<p>", html)
+        @attribute
+        def body(self) -> ArticleBody:
+            html = re.sub(r"(<br>)+", "<p>", self.precomputed.html)
             doc = lxml.html.document_fromstring(html)
-            self.precomputed = Precomputed(html, doc, get_meta_content(doc), get_ld_content(doc))
+            return extract_article_body_with_selector(
+                doc,
+                paragraph_selector=self._paragraph_selector,
+                summary_selector=self._summary_selector,
+            )

--- a/tests/resources/parser/test_data/na/TheNamibian.json
+++ b/tests/resources/parser/test_data/na/TheNamibian.json
@@ -86,7 +86,8 @@
             "He said he, Mbumba and Geingob planned to settle at Swakopmund and to sometimes walk barefoot by the seaside and have coffee at a nearby café.",
             "GOING HOME TO DIE",
             "Political analyst Henning Melber questions the circumstances surrounding Geingob’s departure, suggesting that if an inner circle was aware of his imminent passing, his trip to the US wouldn’t have been for medical treatment.",
-            "Melber speculates that Geingob may have realised his life was ending during his time in the US and chose to return home to die.However, Melber questions why this should be a contentious issue.",
+            "Melber speculates that Geingob may have realised his life was ending during his time in the US and chose to return home to die.",
+            "However, Melber questions why this should be a contentious issue.",
             "“This means that as of his arrival back in Namibia people may have become aware that not much time was left. But why make an issue of it?",
             "“If one could provide evidence that it was exploited for dubious arrangements, it would be another matter. But I do not see any indications pointing reliably into such a direction,” he says."
           ]


### PR DESCRIPTION
Occasionally, a `<br>` tag is used to start a new paragraph instead of the usual new `<p>` element. I have modified the `_base_setup` to replace these tags prior to processing the article. As an extreme example consider this article: https://www.namibian.com.na/namibian-disability-federation-urges-official-recognition-of-sign-language-for-deaf-inclusion/
The test case also contains one example.