### PR TITLE
Fix bug in author parsing in `TheNamibian`

### DIFF
--- a/src/fundus/publishers/na/the_namibian.py
+++ b/src/fundus/publishers/na/the_namibian.py
@@ -40,7 +40,13 @@ class TheNamibianParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["Person", "name"]))
+            authors = self.precomputed.ld.get_value_by_key_path(["Person"])
+            if isinstance(authors, list):
+                return generic_author_parsing([name for author in authors if (name := author.get("name"))])
+            elif isinstance(authors, dict):
+                return generic_author_parsing(authors.get("name"))
+            else:
+                return []
 
     class V1_1(V1):
         VALID_UNTIL = datetime.today().date()

--- a/src/fundus/publishers/na/the_namibian.py
+++ b/src/fundus/publishers/na/the_namibian.py
@@ -17,7 +17,9 @@ class TheNamibianParser(ParserProxy):
         VALID_UNTIL = datetime(year=2024, month=1, day=31).date()
         _summary_selector = XPath("//div[contains(@class, 'tdb-block-inner')]/p[position()=1]")
         _paragraph_selector = XPath("//div[contains(@class, 'tdb-block-inner')]/p[position()>1]")
+
         _title_substitution_pattern: Pattern[str] = re.compile(r" - The Namibian$")
+        _author_selector = XPath("//Person/name")
 
         @attribute
         def body(self) -> ArticleBody:
@@ -40,13 +42,7 @@ class TheNamibianParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            authors = self.precomputed.ld.get_value_by_key_path(["Person"])
-            if isinstance(authors, list):
-                return generic_author_parsing([name for author in authors if (name := author.get("name"))])
-            elif isinstance(authors, dict):
-                return generic_author_parsing(authors.get("name"))
-            else:
-                return []
+            return generic_author_parsing(self.precomputed.ld.xpath_search(self._author_selector))
 
     class V1_1(V1):
         VALID_UNTIL = datetime.today().date()


### PR DESCRIPTION
The author parsing crashed, if it encounters an article with more than author. This is caused that the element element with path Person can be of type `list`. in which case the `get()` function that is called within `get_value_by_key_path()` causes an Error, since it is not implemented for a list.