### PR TITLE
Fix `Focus`

### DIFF
--- a/src/fundus/publishers/de/focus.py
+++ b/src/fundus/publishers/de/focus.py
@@ -19,7 +19,7 @@ class FocusParser(ParserProxy):
         _summary_selector = CSSSelector("div.leadIn > p, div.Article-Description ")
         _subheadline_selector = CSSSelector("div.textBlock > h2, div[data-qa-article-content-text] > h2")
         _snippet_selector = XPath(
-            'string(//script[@type="text/javascript"][contains(text(), "window.bf__bfa_metadata") or contains(text(), "pageAdKeyword")])'
+            'string(//script[@type="text/javascript"][contains(text(), "window.bf__bfa_metadata")])'
         )
 
         # regex patterns

--- a/src/fundus/publishers/de/focus.py
+++ b/src/fundus/publishers/de/focus.py
@@ -27,7 +27,6 @@ class FocusParser(ParserProxy):
             r"Von FOCUS-online-(Redakteur|Autorin|Reporter|Redakteurin|Gastautor)\s"
         )
         _topic_pattern: Pattern[str] = re.compile(r'"keywords":\[{(.*?)}\]')
-        _fallback_topic_pattern: Pattern[str] = re.compile(r"(keyword: '|\"pageAdKeyword\": ?\[)(.*?)(['\]])")
         _topic_name_pattern: Pattern[str] = re.compile(r'"name":"(.*?)"', flags=re.MULTILINE)
 
         @attribute
@@ -62,20 +61,7 @@ class FocusParser(ParserProxy):
 
             match: Optional[Match[str]] = re.search(self._topic_pattern, snippet)
             if not match:
-                fallback: Optional[Match[str]] = re.search(self._fallback_topic_pattern, snippet)
-                if not fallback:
-                    return []
-                else:
-                    categories: List[str] = fallback.group(2).split(",")
-                    topics: List[str] = list()
-                    for category in categories:
-                        category = category.replace('"', "")
-                        category = re.sub("^fol", "", category)
-                        for topic in reversed(topics):
-                            category = re.sub(f"(?i)_{topic}(_|$)", "_", category)
-                        if topic := category.replace("_", " ").strip():
-                            topics.append(topic.title())
-                    return topics
+                return []
             topic_names: List[str] = re.findall(self._topic_name_pattern, match.group(1))
 
             return topic_names


### PR DESCRIPTION
This PR adresses two issues:
- Some articles such as this one: https://www.focus.de/finanzen/karriere/gen-z-in-den-usa-zieht-handwerkliche-berufe-hochbezahlten-buerojobs-vor_eaf8f700-90ab-45ec-a1f3-8d1ac74faa86.html are not extracted at all, due to the layout being slightly different
- QSE is having trouble using the focus articles, due to topics being rarely used. I implemented a rough fallback, to use section keywords, what in my opinion is somewhat satisfactory, but perhaps @MaxDall you can also check, if it's worth adding them.