### PR TITLE
Deprecate `get_value_by_key_path` and replace with `xpath_search`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,9 @@ target-version = ['py38']
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error"
+]
+

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -120,7 +120,7 @@ class LinkedDataMapping:
         ...
 
     @overload
-    def xpath_search(self, query: Union[XPath, str], scalar: Literal[True] = True) -> Any:
+    def xpath_search(self, query: Union[XPath, str], scalar: Literal[True] = True) -> Optional[Any]:
         ...
 
     def xpath_search(self, query: Union[XPath, str], scalar: bool = False) -> Union[Any, List[Any]]:
@@ -190,10 +190,12 @@ class LinkedDataMapping:
         values = list(results.values())
 
         if scalar:
-            if len(values) != 1:
-                raise ValueError(f"Got multiple values when expecting a single scalar value")
-            else:
+            if not values:
+                return None
+            elif len(values) == 1:
                 return values.pop()
+            else:
+                raise ValueError(f"Got multiple values when expecting a single scalar value")
         else:
             return values
 

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -22,7 +22,7 @@ import more_itertools
 import xmltodict
 from dict2xml import dict2xml
 from lxml.etree import XPath, tostring
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self, TypeAlias, deprecated
 
 from fundus.utils.serialization import replace_keys_in_nested_dict
 
@@ -81,6 +81,7 @@ class LinkedDataMapping:
                 self.__dict__[self.__UNKNOWN_TYPE__] = []
             self.__dict__[self.__UNKNOWN_TYPE__].append(ld)
 
+    @deprecated("Use xpath_search() instead")
     def get_value_by_key_path(self, key_path: List[str], default: Any = None) -> Optional[Any]:
         """
         Works like get() except this one assumes a path is given as list of keys (str).

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -123,7 +123,7 @@ class LinkedDataMapping:
     def xpath_search(self, query: Union[XPath, str], scalar: Literal[True] = True) -> Optional[Any]:
         ...
 
-    def xpath_search(self, query: Union[XPath, str], scalar: bool = False) -> Union[Any, List[Any]]:
+    def xpath_search(self, query: Union[XPath, str], scalar: bool = False):
         """Search through LD using XPath expressions
 
         Internally, the content of the LinkedDataMapping is converted to XML and then
@@ -152,10 +152,12 @@ class LinkedDataMapping:
         >> [value1]
 
         Args:
-            query: A XPath expression
+            query: A XPath expression either as string or XPath object.
+            scalar: If True, return an optional "scalar" value and raise a ValueError if there are more
+                than one result to return; if False, return a list of results. Defaults to False.
 
         Returns:
-            An ordered list of search results
+            An ordered list of search results or an optional "scalar" result
         """
 
         if isinstance(query, str):

--- a/src/fundus/publishers/de/freiepresse.py
+++ b/src/fundus/publishers/de/freiepresse.py
@@ -33,7 +33,7 @@ class FreiePresseParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "author"]))
+            return generic_author_parsing(self.precomputed.ld.xpath_search("NewsArticle/author"))
 
         @attribute
         def title(self) -> Optional[str]:

--- a/src/fundus/publishers/de/krautreporter.py
+++ b/src/fundus/publishers/de/krautreporter.py
@@ -43,8 +43,7 @@ class KrautreporterParser(ParserProxy):
 
         @attribute
         def publishing_date(self) -> Optional[datetime]:
-            key_path = ["NewsArticle", "datePublished"]
-            date_string = self.precomputed.ld.get_value_by_key_path(key_path)
+            date_string = self.precomputed.ld.xpath_search("NewsArticle/datePublished", scalar=True)
             return utility.generic_date_parsing(date_string)
 
         @attribute

--- a/src/fundus/publishers/no/__init__.py
+++ b/src/fundus/publishers/no/__init__.py
@@ -16,7 +16,7 @@ class NO(metaclass=PublisherGroup):
         sources=[
             Sitemap(
                 "https://www.vg.no/sitemap.xml",
-                sitemap_filter=inverse(regex_filter("vg\.no\/sitemaps/\d{4}\-\d{2}-articles.xml")),
+                sitemap_filter=inverse(regex_filter(r"vg\.no\/sitemaps/\d{4}\-\d{2}-articles.xml")),
                 reverse=True,
             ),
             NewsMap("https://www.vg.no/sitemap/files/articles-48hrs.xml"),

--- a/src/fundus/publishers/shared/euronews.py
+++ b/src/fundus/publishers/shared/euronews.py
@@ -28,7 +28,7 @@ class EuronewsParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            author_string = self.precomputed.ld.xpath_search("NewsArticle/author/name", scalar=True)
+            author_string = self.precomputed.ld.xpath_search("NewsArticle/author/name")
             return utility.generic_author_parsing(author_string)
 
         @attribute

--- a/src/fundus/publishers/shared/euronews.py
+++ b/src/fundus/publishers/shared/euronews.py
@@ -28,8 +28,7 @@ class EuronewsParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            key_path = ["NewsArticle", "author", "name"]
-            author_string = self.precomputed.ld.get_value_by_key_path(key_path)
+            author_string = self.precomputed.ld.xpath_search("NewsArticle/author/name", scalar=True)
             return utility.generic_author_parsing(author_string)
 
         @attribute

--- a/src/fundus/publishers/us/ap_news.py
+++ b/src/fundus/publishers/us/ap_news.py
@@ -42,17 +42,17 @@ class APNewsParser(ParserProxy):
                 author_string = re.sub(r"^By ", "", author_string)
             except IndexError:
                 # Fallback to the generic author parsing from the linked data.
-                return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "author"]))
+                return generic_author_parsing(self.precomputed.ld.xpath_search("NewsArticle/author"))
 
             return generic_author_parsing(author_string)
 
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:
-            return generic_date_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "datePublished"]))
+            return generic_date_parsing(self.precomputed.ld.xpath_search("NewsArticle/datePublished", scalar=True))
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.get_value_by_key_path(["NewsArticle", "headline"])
+            return self.precomputed.ld.xpath_search("NewsArticle/headline", scalar=True)
 
         @attribute
         def topics(self) -> List[str]:

--- a/src/fundus/publishers/us/cnbc.py
+++ b/src/fundus/publishers/us/cnbc.py
@@ -30,16 +30,15 @@ class CNBCParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "author"]))
+            return generic_author_parsing(self.precomputed.ld.xpath_search("NewsArticle/author"))
 
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:
-            return generic_date_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "datePublished"]))
+            return generic_date_parsing(self.precomputed.ld.xpath_search("NewsArticle/datePublished", scalar=True))
 
         @attribute
         def title(self) -> Optional[str]:
-            title: Optional[str] = self.precomputed.ld.get_value_by_key_path(["NewsArticle", "headline"])
-            return title
+            return self.precomputed.ld.xpath_search("NewsArticle/headline", scalar=True)
 
         @attribute
         def topics(self) -> List[str]:

--- a/src/fundus/publishers/us/occupy_democrats.py
+++ b/src/fundus/publishers/us/occupy_democrats.py
@@ -41,7 +41,7 @@ class OccupyDemocratsParser(ParserProxy):
 
         @attribute
         def topics(self) -> List[str]:
-            return generic_topic_parsing(self.precomputed.ld.get_value_by_key_path(["Article", "keywords"]))
+            return generic_topic_parsing(self.precomputed.ld.xpath_search("Article/keywords", scalar=True))
 
         @attribute(validate=False)
         def description(self) -> Optional[str]:

--- a/src/fundus/publishers/us/reuters.py
+++ b/src/fundus/publishers/us/reuters.py
@@ -38,11 +38,11 @@ class ReutersParser(ParserProxy):
 
         @attribute
         def publishing_date(self) -> Optional[datetime]:
-            return generic_date_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "datePublished"]))
+            return generic_date_parsing(self.precomputed.ld.xpath_search("NewsArticle/datePublished", scalar=True))
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.get_value_by_key_path(["NewsArticle", "headline"])
+            return self.precomputed.ld.xpath_search("NewsArticle/headline", scalar=True)
 
         @attribute
         def topics(self) -> List[str]:

--- a/src/fundus/publishers/us/the_gateway_pundit.py
+++ b/src/fundus/publishers/us/the_gateway_pundit.py
@@ -29,7 +29,7 @@ class TheGatewayPunditParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["Article", "author"]))
+            return generic_author_parsing(self.precomputed.ld.xpath_search("Article/author"))
 
         @attribute
         def publishing_date(self) -> Optional[datetime]:

--- a/src/fundus/publishers/us/the_intercept.py
+++ b/src/fundus/publishers/us/the_intercept.py
@@ -54,9 +54,6 @@ class TheInterceptParser(ParserProxy):
             # inside the "keywords" linked data indicated by a "Subject: " prefix.
             # Example keywords: ["Day: Saturday", ..., "Subject: World", ...]
             keywords: List[str] = self.precomputed.ld.xpath_search("NewsArticle/keywords")
-            if keywords is None:
-                return []
-
             return [keyword[9:] for keyword in keywords if keyword.startswith("Subject: ")]
 
     class V1_1(V1):

--- a/src/fundus/publishers/us/the_intercept.py
+++ b/src/fundus/publishers/us/the_intercept.py
@@ -38,22 +38,22 @@ class TheInterceptParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "author"]))
+            return generic_author_parsing(self.precomputed.ld.xpath_search("NewsArticle/author"))
 
         @attribute
         def publishing_date(self) -> Optional[datetime]:
-            return generic_date_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "datePublished"]))
+            return generic_date_parsing(self.precomputed.ld.xpath_search("NewsArticle/datePublished", scalar=True))
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.get_value_by_key_path(["NewsArticle", "headline"])
+            return self.precomputed.ld.xpath_search("NewsArticle/headline", scalar=True)
 
         @attribute
         def topics(self) -> List[str]:
             # The Intercept specifies the article's topics, including other metadata,
             # inside the "keywords" linked data indicated by a "Subject: " prefix.
             # Example keywords: ["Day: Saturday", ..., "Subject: World", ...]
-            keywords: Optional[List[str]] = self.precomputed.ld.get_value_by_key_path(["NewsArticle", "keywords"])
+            keywords: List[str] = self.precomputed.ld.xpath_search("NewsArticle/keywords")
             if keywords is None:
                 return []
 

--- a/src/fundus/publishers/us/the_new_yorker.py
+++ b/src/fundus/publishers/us/the_new_yorker.py
@@ -32,23 +32,23 @@ class TheNewYorkerParser(ParserProxy):
 
         @attribute(validate=False)
         def alternative_description(self) -> Optional[str]:
-            return self.precomputed.ld.get_value_by_key_path(["NewsArticle", "description"])
+            return self.precomputed.ld.xpath_search("NewsArticle/description", scalar=True)
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "author"]))
+            return generic_author_parsing(self.precomputed.ld.xpath_search("NewsArticle/author"))
 
         @attribute
         def publishing_date(self) -> Optional[datetime]:
-            return generic_date_parsing(self.precomputed.ld.get_value_by_key_path(["NewsArticle", "datePublished"]))
+            return generic_date_parsing(self.precomputed.ld.xpath_search("NewsArticle/datePublished", scalar=True))
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.get_value_by_key_path(["NewsArticle", "headline"])
+            return self.precomputed.ld.xpath_search("NewsArticle/headline", scalar=True)
 
         @attribute(validate=False)
         def alternative_title(self) -> Optional[str]:
-            return self.precomputed.ld.get_value_by_key_path(["NewsArticle", "alternativeHeadline"])
+            return self.precomputed.ld.xpath_search("NewsArticle/alternativeHeadline", scalar=True)
 
         @attribute
         def topics(self) -> List[str]:
@@ -61,4 +61,4 @@ class TheNewYorkerParser(ParserProxy):
 
         @attribute(validate=False)
         def section(self) -> Optional[str]:
-            return self.precomputed.ld.get_value_by_key_path(["NewsArticle", "articleSection"])
+            return self.precomputed.ld.xpath_search("NewsArticle/articleSection", scalar=True)


### PR DESCRIPTION
This PR deprecates `get_value_by_key_path` class method of `LinkedDataMapping` and replaces all existing occasions with `xpath_search`.

To talk about efficiency I provide some additional runtime comparison and a script to reproduce.
The script loads one article for `The West Australian`, since it by far includes the largest `LD` and loads a specific value (or key path) 100000 times. For more details click on `Script`.

<details>
  <summary>Script</summary>
  
  ```python
from timeit import timeit

setup = '''
from timeit import timeit

from fundus import PublisherCollection, Crawler
from lxml.etree import XPath

test_xpath = XPath("NewsArticle/datePublished")

crawler = Crawler(PublisherCollection.au.WestAustralian)

for article in crawler.crawl(max_articles=1):
    ld = article.ld
'''

stmt1 = 'ld.get_value_by_key_path(["NewsArticle", "datePublished"])'
stmt2 = 'ld.xpath_search("NewsArticle/datePublished")'
stmt3 = 'ld.xpath_search(test_xpath)'

length = 100000

time1 = timeit(setup=setup, stmt=stmt1, number=length)
time2 = timeit(setup=setup, stmt=stmt2, number=length)
time3 = timeit(setup=setup, stmt=stmt3, number=length)

print(f"Loading a value {length} times")
print(f"key_path took {time1:.2f} seconds, with an avg of {time1/length:.2e}")
print(f"xpath_search without pre-compiled XPath took {time2:.2f} seconds, with an avg. of {time2/length:.2e}")
print(f"xpath_search with pre-compiled XPath took {time3:.2f} seconds, with an avg. of {time3/length:.2e}")
print(f"using pre compiled xpath is {time2/time3:.2f} times faster")
print(f"using key_path is {time3/time1:.2f} times faster than xpath_search")
  ```
</details>

### Output
```
Loading a value 100000 times
key_path took 0.07 seconds, with an avg of 6.98e-07
xpath_search without pre-compiled XPath took 2.42 seconds, with an avg. of 2.42e-05
xpath_search with pre-compiled XPath took 1.51 seconds, with an avg. of 1.51e-05
using pre-compiled XPath is 1.60 times faster
using key_path is 21.65 times faster than xpath_search
```

For better typing, this PR adds a `scalar` parameter to `xpath_search`, indicating that one expects an optional scalar value in return.