### PR TITLE
Update lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           version: "23.1.0"
 
   isort:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: isort/isort-action@master


### PR DESCRIPTION
Apparently there is an open issue with the isort-action not working properly with the latest ubuntu release: https://github.com/isort/isort-action/issues/94 This change should fix this until the library is patched.