### PR TITLE
Add default return values for attributes

### DIFF
--- a/docs/attribute_guidelines.md
+++ b/docs/attribute_guidelines.md
@@ -32,7 +32,7 @@ Those attributes will be validated with unit tests when used.
     <tr>
         <td>body</td>
         <td>An object of type `ArticleBody` representing the structural hierarchy of the article content.</td>
-        <td><code>ArticleBody</code></td>
+        <td><code>Optional[ArticleBody]</code></td>
         <td><code>extract_article_body_with_selector</code></td>
     </tr>
     <tr>

--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -592,7 +592,7 @@ class TheInterceptParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.entry-content > div.entry-content__content > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/parser/base_parser.py
+++ b/src/fundus/parser/base_parser.py
@@ -19,6 +19,8 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    get_args,
+    get_origin,
 )
 
 import lxml.html
@@ -70,9 +72,31 @@ class RegisteredFunction(ABC):
 
     def __repr__(self):
         if instance := self.__self__:
-            return f"bound {type(self).__name__} of {instance}: {self.__wrapped__} --> {self.__name__!r}"
+            return f"bound {type(self).__name__} {self.__name__!r} of {instance}"
         else:
-            return f"registered {type(self).__name__}: {self.__wrapped__} --> {self.__name__!r}"
+            return f"registered {type(self).__name__} {self.__name__!r}"
+
+    @functools.cached_property
+    def __default__(self):
+        annotation = self.__annotations__["return"]
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+
+        if not (origin or args):
+            try:
+                default = annotation()
+            except TypeError:
+                default = None
+        elif callable(origin):
+            default = origin()
+        elif origin == Union:
+            if type(None) in args:
+                default = None
+            else:
+                raise NotImplementedError(f"Unsupported args {args}")
+        else:
+            raise NotImplementedError(f"Unsupported origin {origin}")
+        return default
 
 
 class Attribute(RegisteredFunction):
@@ -206,9 +230,11 @@ class BaseParser(ABC):
                 try:
                     parsed_data[attribute_name] = func()
                 except Exception as err:
-                    if error_handling == "catch":
+                    if error_handling == "suppress":
+                        parsed_data[attribute_name] = func.__default__
+                    elif error_handling == "catch":
                         parsed_data[attribute_name] = err
-                    elif error_handling == "suppress" or error_handling == "raise":
+                    elif error_handling == "raise":
                         raise err
                     else:
                         raise ValueError(f"Invalid value {error_handling!r} for parameter <error_handling>")

--- a/src/fundus/parser/base_parser.py
+++ b/src/fundus/parser/base_parser.py
@@ -76,6 +76,12 @@ class RegisteredFunction(ABC):
         else:
             return f"registered {type(self).__name__} {self.__name__!r}"
 
+
+class Attribute(RegisteredFunction):
+    def __init__(self, func: Callable[[object], Any], priority: Optional[int], validate: bool):
+        self.validate = validate
+        super(Attribute, self).__init__(func=func, priority=priority)
+
     @functools.cached_property
     def __default__(self):
         annotation = self.__annotations__["return"]
@@ -97,12 +103,6 @@ class RegisteredFunction(ABC):
         else:
             raise NotImplementedError(f"Unsupported origin {origin}")
         return default
-
-
-class Attribute(RegisteredFunction):
-    def __init__(self, func: Callable[[object], Any], priority: Optional[int], validate: bool):
-        self.validate = validate
-        super(Attribute, self).__init__(func=func, priority=priority)
 
 
 class Function(RegisteredFunction):

--- a/src/fundus/publishers/at/derstandard.py
+++ b/src/fundus/publishers/at/derstandard.py
@@ -18,7 +18,7 @@ class DerStandardParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.article-body > h3")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/at/orf.py
+++ b/src/fundus/publishers/at/orf.py
@@ -18,7 +18,7 @@ class OrfParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.story-story > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/au/nine_news.py
+++ b/src/fundus/publishers/au/nine_news.py
@@ -25,7 +25,7 @@ class NineNewsParser(ParserProxy):
         _subheadline_selector = XPath("//div[@class='article__body'] //div[@class='block-content'] /div[child::h3]")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/au/west_australian.py
+++ b/src/fundus/publishers/au/west_australian.py
@@ -28,7 +28,7 @@ class WestAustralianParser(ParserProxy):
             self.precomputed.ld.add_ld(parsed_json, "windows.PAGE_DATA")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             content_blocks = self.precomputed.ld.xpath_search(XPath("//publication/content/blocks"))
             paragraphs = []
             for block in content_blocks:

--- a/src/fundus/publishers/ca/cbc_news.py
+++ b/src/fundus/publishers/ca/cbc_news.py
@@ -30,7 +30,7 @@ class CBCNewsParser(ParserProxy):
                 self.precomputed.ld.add_ld(ld, "initialStateDom")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/ca/globe_and_mail.py
+++ b/src/fundus/publishers/ca/globe_and_mail.py
@@ -18,7 +18,7 @@ class TheGlobeAndMailParser(ParserProxy):
         _paragraph_selector = CSSSelector("article > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 subheadline_selector=self._subheadline_selector,

--- a/src/fundus/publishers/ca/national_post.py
+++ b/src/fundus/publishers/ca/national_post.py
@@ -26,7 +26,7 @@ class NationalPostParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/ch/nzz.py
+++ b/src/fundus/publishers/ch/nzz.py
@@ -25,7 +25,7 @@ class NZZParser(ParserProxy):
         _author_substitution_pattern: Pattern[str] = re.compile(r"\(.+\)$")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/ch/srf.py
+++ b/src/fundus/publishers/ch/srf.py
@@ -34,7 +34,7 @@ class SRFParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/ch/ta.py
+++ b/src/fundus/publishers/ch/ta.py
@@ -23,7 +23,7 @@ class TAParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/cn/people.py
+++ b/src/fundus/publishers/cn/people.py
@@ -22,7 +22,7 @@ class PeopleParser(ParserProxy):
         _author_pattern = re.compile(r"：(.*)\)")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(self.precomputed.doc, paragraph_selector=self._paragraph_selector)
 
         @attribute

--- a/src/fundus/publishers/de/berliner_zeitung.py
+++ b/src/fundus/publishers/de/berliner_zeitung.py
@@ -19,7 +19,7 @@ class BerlinerZeitungParser(ParserProxy):
         _subheadline_selector = CSSSelector("div[id=articleBody] > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/bild.py
+++ b/src/fundus/publishers/de/bild.py
@@ -20,7 +20,7 @@ class BildParser(ParserProxy):
         _subheadline_selector = XPath("//div[@data-key = 'article']/h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/boersenzeitung.py
+++ b/src/fundus/publishers/de/boersenzeitung.py
@@ -24,7 +24,7 @@ class BoersenZeitungParser(ParserProxy):
         _title_bloat_pattern = re.compile(r"\|.*")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 subheadline_selector=self._subheadline_selector,

--- a/src/fundus/publishers/de/br.py
+++ b/src/fundus/publishers/de/br.py
@@ -40,7 +40,7 @@ class BRParser(ParserProxy):
             return generic_date_parsing(self.precomputed.ld.bf_search("datePublished"))
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/braunschweiger_zeitung.py
+++ b/src/fundus/publishers/de/braunschweiger_zeitung.py
@@ -31,7 +31,7 @@ class BSZParser(ParserProxy):
         _topics_selector = XPath("//div[@class='not-prose  mb-4 mx-5 font-sans']/ul/li")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/business_insider_de.py
+++ b/src/fundus/publishers/de/business_insider_de.py
@@ -31,7 +31,7 @@ class BusinessInsiderDEParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/die_welt.py
+++ b/src/fundus/publishers/de/die_welt.py
@@ -25,7 +25,7 @@ class DieWeltParser(ParserProxy):
         _subheadline_selector = CSSSelector(".c-article-text > h3")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/die_zeit.py
+++ b/src/fundus/publishers/de/die_zeit.py
@@ -23,7 +23,7 @@ class DieZeitParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.article-page > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/dw.py
+++ b/src/fundus/publishers/de/dw.py
@@ -34,7 +34,7 @@ class DWParser(ParserProxy):
         _author_substitution_pattern: Pattern[str] = re.compile(r"Deutsche Welle")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,
@@ -87,7 +87,7 @@ class DWParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/faz.py
+++ b/src/fundus/publishers/de/faz.py
@@ -25,7 +25,7 @@ class FAZParser(ParserProxy):
         _author_selector = CSSSelector(".atc-MetaAuthor")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,
@@ -66,7 +66,7 @@ class FAZParser(ParserProxy):
         _topic_selector = XPath("//div[text()=' Schlagworte: '] /a")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/focus.py
+++ b/src/fundus/publishers/de/focus.py
@@ -30,7 +30,7 @@ class FocusParser(ParserProxy):
         _topic_name_pattern: Pattern[str] = re.compile(r'"name":"(.*?)"', flags=re.MULTILINE)
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/frankfurter_rundschau.py
+++ b/src/fundus/publishers/de/frankfurter_rundschau.py
@@ -18,7 +18,7 @@ class FrankfurterRundschauParser(ParserProxy):
         _subheadline_selector = CSSSelector("h2.id-StoryElement-crosshead")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/freiepresse.py
+++ b/src/fundus/publishers/de/freiepresse.py
@@ -19,7 +19,7 @@ class FreiePresseParser(ParserProxy):
         _subheadline_selector = CSSSelector("#artikel-content h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/gamestar.py
+++ b/src/fundus/publishers/de/gamestar.py
@@ -22,7 +22,7 @@ class GamestarParser(ParserProxy):
             return self.precomputed.meta.get("og:title")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/golem.py
+++ b/src/fundus/publishers/de/golem.py
@@ -24,7 +24,7 @@ class GolemParser(ParserProxy):
         _subheadline_selector = CSSSelector("div > section > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/hamburger_abendblatt.py
+++ b/src/fundus/publishers/de/hamburger_abendblatt.py
@@ -22,7 +22,7 @@ class HamburgerAbendblattParser(ParserProxy):
         _topics_selector = XPath("//div[@class='not-prose  mb-4 mx-5 font-sans']/ul/li")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/heise.py
+++ b/src/fundus/publishers/de/heise.py
@@ -38,7 +38,7 @@ class HeiseParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/hessenschau.py
+++ b/src/fundus/publishers/de/hessenschau.py
@@ -28,7 +28,7 @@ class HessenschauParser(ParserProxy):
         _subheadline_selector = CSSSelector("h2[class*=head]")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/junge_welt.py
+++ b/src/fundus/publishers/de/junge_welt.py
@@ -23,7 +23,7 @@ class JungeWeltParser(ParserProxy):
         _free_access_selector = XPath("//h1[text()='Sie sind nun eingeloggt.']|//p[@class='m-1']")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/kicker.py
+++ b/src/fundus/publishers/de/kicker.py
@@ -18,7 +18,7 @@ class KickerParser(ParserProxy):
         _subheadline_selector = CSSSelector("div[class=kick__article__content__child] > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/krautreporter.py
+++ b/src/fundus/publishers/de/krautreporter.py
@@ -27,7 +27,7 @@ class KrautreporterParser(ParserProxy):
             return self.precomputed.meta.get("og:title")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             article_body = utility.extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/mdr.py
+++ b/src/fundus/publishers/de/mdr.py
@@ -30,7 +30,7 @@ class MDRParser(ParserProxy):
         _author_selector = CSSSelector(".articleMeta > .author")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/merkur.py
+++ b/src/fundus/publishers/de/merkur.py
@@ -18,7 +18,7 @@ class MerkurParser(ParserProxy):
         _subheadline_selector = CSSSelector("h2.id-StoryElement-crosshead")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/morgenpost_berlin.py
+++ b/src/fundus/publishers/de/morgenpost_berlin.py
@@ -22,7 +22,7 @@ class BerlinerMorgenpostParser(ParserProxy):
         _topics_selector = XPath("//div[@class='not-prose  mb-4 mx-5 font-sans']/ul/li")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/motorsport_magazin.py
+++ b/src/fundus/publishers/de/motorsport_magazin.py
@@ -19,7 +19,7 @@ class MotorSportMagazinParser(ParserProxy):
         _subheadline_selector: CSSSelector = CSSSelector("section.article-body > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/mz.py
+++ b/src/fundus/publishers/de/mz.py
@@ -19,7 +19,7 @@ class MitteldeutscheZeitungParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.fp-subheading > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/ndr.py
+++ b/src/fundus/publishers/de/ndr.py
@@ -23,7 +23,7 @@ class NDRParser(ParserProxy):
         _subheadline_selector = CSSSelector("article .modulepadding > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/netzpolitik_org.py
+++ b/src/fundus/publishers/de/netzpolitik_org.py
@@ -26,7 +26,7 @@ class NetzpolitikOrgParser(ParserProxy):
             return self.precomputed.meta.get("og:title") or parse_title_from_root(self.precomputed.doc)
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/ntv.py
+++ b/src/fundus/publishers/de/ntv.py
@@ -26,7 +26,7 @@ class NTVParser(ParserProxy):
         _subheadline_selector = CSSSelector(".article__text > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/postillon.py
+++ b/src/fundus/publishers/de/postillon.py
@@ -16,7 +16,7 @@ class PostillonParser(ParserProxy):
         _postscript_selector = CSSSelector("div[id=post-body] > span")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/rbb24.py
+++ b/src/fundus/publishers/de/rbb24.py
@@ -21,7 +21,7 @@ class RBB24Parser(ParserProxy):
         _date_selector = CSSSelector("div.lineinfo")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             article_body = extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/rheinische_post.py
+++ b/src/fundus/publishers/de/rheinische_post.py
@@ -19,7 +19,7 @@ class RheinischePostParser(ParserProxy):
         _subheadline_selector = CSSSelector("div[data-cy='article-content'] h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/rn.py
+++ b/src/fundus/publishers/de/rn.py
@@ -19,7 +19,7 @@ class RuhrNachrichtenParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.article__content > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/spon.py
+++ b/src/fundus/publishers/de/spon.py
@@ -19,7 +19,7 @@ class SPONParser(ParserProxy):
         _subheadline_selector = CSSSelector("main .word-wrap > h3")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/sportschau.py
+++ b/src/fundus/publishers/de/sportschau.py
@@ -21,7 +21,7 @@ class SportSchauParser(ParserProxy):
         _subheadline_selector = CSSSelector("article >h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/stern.py
+++ b/src/fundus/publishers/de/stern.py
@@ -18,7 +18,7 @@ class SternParser(ParserProxy):
         _subheadline_selector = CSSSelector(".subheadline-element")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/sz.py
+++ b/src/fundus/publishers/de/sz.py
@@ -21,7 +21,7 @@ class SZParser(ParserProxy):
         _subheadline_selector: XPath = CSSSelector("main [itemprop='articleBody'] > h3")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/tagesschau.py
+++ b/src/fundus/publishers/de/tagesschau.py
@@ -22,7 +22,7 @@ class TagesschauParser(ParserProxy):
         _topic_selector = CSSSelector("div.meldungsfooter .taglist a")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/tagesspiegel.py
+++ b/src/fundus/publishers/de/tagesspiegel.py
@@ -19,7 +19,7 @@ class TagesspiegelParser(ParserProxy):
         _subheadline_selector = CSSSelector("div[id=story-elements] > h3")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             article_body = extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/taz.py
+++ b/src/fundus/publishers/de/taz.py
@@ -19,7 +19,7 @@ class TazParser(ParserProxy):
         _subheadline_selector = CSSSelector(".sectbody > h6")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/vogue_de.py
+++ b/src/fundus/publishers/de/vogue_de.py
@@ -20,7 +20,7 @@ class VogueDEParser(ParserProxy):
         _summary_selector = XPath("//div[contains(@class, 'ContentHeaderDek')]")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/waz.py
+++ b/src/fundus/publishers/de/waz.py
@@ -23,7 +23,7 @@ class WAZParser(ParserProxy):
         _topics_selector = XPath("//div[@class='not-prose  mb-4 mx-5 font-sans']/ul/li")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/de/wdr.py
+++ b/src/fundus/publishers/de/wdr.py
@@ -21,7 +21,7 @@ class WDRParser(ParserProxy):
         _subheadline_selector = XPath("//article//h2[@class='subtitle small']")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/de/winfuture.py
+++ b/src/fundus/publishers/de/winfuture.py
@@ -25,7 +25,7 @@ class WinfutureParser(ParserProxy):
             return self.precomputed.meta.get("og:title")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             html_as_string = tostring(self.precomputed.doc).decode("utf-8")
             # Most paragraphs are separated by two <br>> tags, depending on if there is text
             # around those tags you need either opending or closing tags or both.

--- a/src/fundus/publishers/de/zdf.py
+++ b/src/fundus/publishers/de/zdf.py
@@ -18,7 +18,7 @@ class ZDFParser(ParserProxy):
         _subheadlines_selector = CSSSelector("h2.t1rbo974.hhhtovw")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._div_selector,

--- a/src/fundus/publishers/fr/le_figaro.py
+++ b/src/fundus/publishers/fr/le_figaro.py
@@ -19,7 +19,7 @@ class LeFigaroParser(ParserProxy):
         _subheadline_selector: CSSSelector = CSSSelector("div.fig-content-body > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/fr/le_monde.py
+++ b/src/fundus/publishers/fr/le_monde.py
@@ -19,7 +19,7 @@ class LeMondeParser(ParserProxy):
         _subheadline_selector: XPath = XPath("//h2[@class = 'article__sub-title']")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/fr/les_echos.py
+++ b/src/fundus/publishers/fr/les_echos.py
@@ -29,7 +29,7 @@ class LesEchosParser(ParserProxy):
         _topic_selector = CSSSelector("header div.sc-108qdzy-3 div.sc-108qdzy-2 > div")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/ind/bhaskar.py
+++ b/src/fundus/publishers/ind/bhaskar.py
@@ -20,7 +20,7 @@ class BhaskarParser(ParserProxy):
         _topic_bloat_pattern: Pattern[str] = re.compile(r"news", flags=re.IGNORECASE)
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 doc=self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/ind/times_of_india.py
+++ b/src/fundus/publishers/ind/times_of_india.py
@@ -26,7 +26,7 @@ class TimesOfIndiaParser(ParserProxy):
         _summary_selector = XPath("//div[@class='M1rHh undefined']")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             html_as_string = tostring(self.precomputed.doc).decode("utf-8")
             html_as_string = re.sub(r"(</div>)((\r\n|\r|\n)<br>)", "</div><p>", html_as_string)
             html_as_string = re.sub(r"</div>\s*</div>(?!<)", "</div></div><p>", html_as_string)

--- a/src/fundus/publishers/lt/lrt.py
+++ b/src/fundus/publishers/lt/lrt.py
@@ -25,7 +25,7 @@ class LRTParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/my/malay_mail.py
+++ b/src/fundus/publishers/my/malay_mail.py
@@ -19,7 +19,7 @@ class MalayMailParser(ParserProxy):
         _subheadline_selector = XPath("//div[@class='article-body']/p[not(text()) and b]")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/na/the_namibian.py
+++ b/src/fundus/publishers/na/the_namibian.py
@@ -23,7 +23,7 @@ class TheNamibianParser(ParserProxy):
         _author_selector = XPath("//Person/name")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,
@@ -51,7 +51,7 @@ class TheNamibianParser(ParserProxy):
         _summary_selector = XPath("//div[contains(@class, 'entry-content')]/p[(text() or strong) and position()=1]")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             html = re.sub(r"(<br>)+", "<p>", self.precomputed.html)
             doc = lxml.html.document_fromstring(html)
             return extract_article_body_with_selector(

--- a/src/fundus/publishers/no/dagbladet.py
+++ b/src/fundus/publishers/no/dagbladet.py
@@ -21,7 +21,7 @@ class DagbladetParser(ParserProxy):
         _author_selector = CSSSelector("section.meta div[itemtype='http://schema.org/Person'] address.name")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/no/nettavisen.py
+++ b/src/fundus/publishers/no/nettavisen.py
@@ -25,7 +25,7 @@ class NettavisenParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/no/nrk.py
+++ b/src/fundus/publishers/no/nrk.py
@@ -18,7 +18,7 @@ class NRKParser(ParserProxy):
         _summary_selector = CSSSelector("div.article-lead")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/no/verdensgang.py
+++ b/src/fundus/publishers/no/verdensgang.py
@@ -27,7 +27,7 @@ class VerdensGangParser(ParserProxy):
         _paywall_selector = CSSSelector("#paywall-login-link")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/shared/euronews.py
+++ b/src/fundus/publishers/shared/euronews.py
@@ -17,7 +17,7 @@ class EuronewsParser(ParserProxy):
             return self.precomputed.meta.get("og:title")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             article_body = utility.extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/tr/haberturk.py
+++ b/src/fundus/publishers/tr/haberturk.py
@@ -20,7 +20,7 @@ class HaberturkParser(ParserProxy):
         _subheadline_Selector = XPath("//article//h2[not(preceding-sibling::h1)]")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/tr/ntvtr.py
+++ b/src/fundus/publishers/tr/ntvtr.py
@@ -18,7 +18,7 @@ class NTVTRParser(ParserProxy):
         _summary_selector = CSSSelector("h2.category-detail-sub-title")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/uk/daily_mail.py
+++ b/src/fundus/publishers/uk/daily_mail.py
@@ -18,7 +18,7 @@ class DailyMailParser(ParserProxy):
         _summary_selector = CSSSelector("#js-article-text > h1")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/uk/daily_star.py
+++ b/src/fundus/publishers/uk/daily_star.py
@@ -19,7 +19,7 @@ class DailyStarParser(ParserProxy):
         _paragraph_selector = XPath("//div[@class='article-body'] /p[text()]")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/evening_standard.py
+++ b/src/fundus/publishers/uk/evening_standard.py
@@ -19,7 +19,7 @@ class EveningStandardParser(ParserProxy):
         _summary_selector = CSSSelector("div.sc-wkolL.dWZJhQ")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,
@@ -49,7 +49,7 @@ class EveningStandardParser(ParserProxy):
         _paragraph_selector = CSSSelector("div#main > div.sc-gEvEer p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/express.py
+++ b/src/fundus/publishers/uk/express.py
@@ -22,7 +22,7 @@ class ExpressParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/i_news.py
+++ b/src/fundus/publishers/uk/i_news.py
@@ -18,7 +18,7 @@ class INewsParser(ParserProxy):
         _paragraph_selector = CSSSelector("article div.article-content p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body = extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/metro.py
+++ b/src/fundus/publishers/uk/metro.py
@@ -39,7 +39,7 @@ class MetroParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body = extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/the_bbc.py
+++ b/src/fundus/publishers/uk/the_bbc.py
@@ -28,7 +28,7 @@ class TheBBCParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 subheadline_selector=self._subheadline_selector,

--- a/src/fundus/publishers/uk/the_guardian.py
+++ b/src/fundus/publishers/uk/the_guardian.py
@@ -18,7 +18,7 @@ class TheGuardianParser(ParserProxy):
         _paragraph_selector = CSSSelector(".article-body-viewer-selector > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/the_independent.py
+++ b/src/fundus/publishers/uk/the_independent.py
@@ -17,7 +17,7 @@ class TheIndependentParser(ParserProxy):
         _paragraph_selector = CSSSelector("article div[id='main'] > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body = extract_article_body_with_selector(self.precomputed.doc, paragraph_selector=self._paragraph_selector)
             return body
 

--- a/src/fundus/publishers/uk/the_mirror.py
+++ b/src/fundus/publishers/uk/the_mirror.py
@@ -25,7 +25,7 @@ class TheMirrorParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body = extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/the_sun.py
+++ b/src/fundus/publishers/uk/the_sun.py
@@ -20,7 +20,7 @@ class TheSunParser(ParserProxy):
         _sub_headline_selector = CSSSelector("div.article__content > h2.wp-block-heading")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/uk/the_telegraph.py
+++ b/src/fundus/publishers/uk/the_telegraph.py
@@ -21,7 +21,7 @@ class TheTelegraphParser(ParserProxy):
         _datetime_selector = CSSSelector("time[itemprop='datePublished']")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body = extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/us/ap_news.py
+++ b/src/fundus/publishers/us/ap_news.py
@@ -25,7 +25,7 @@ class APNewsParser(ParserProxy):
         _topic_bloat_pattern: Pattern[str] = re.compile(r"state wire| news|^.{1}$", flags=re.IGNORECASE)
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/business_insider.py
+++ b/src/fundus/publishers/us/business_insider.py
@@ -32,7 +32,7 @@ class BusinessInsiderParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/us/cnbc.py
+++ b/src/fundus/publishers/us/cnbc.py
@@ -20,7 +20,7 @@ class CNBCParser(ParserProxy):
         _key_points_selector: CSSSelector = CSSSelector("div.RenderKeyPoints-list li")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body: ArticleBody = extract_article_body_with_selector(
                 self.precomputed.doc,
                 subheadline_selector=self._subheadline_selector,

--- a/src/fundus/publishers/us/fox_news.py
+++ b/src/fundus/publishers/us/fox_news.py
@@ -22,7 +22,7 @@ class FoxNewsParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/free_beacon.py
+++ b/src/fundus/publishers/us/free_beacon.py
@@ -17,7 +17,7 @@ class FreeBeaconParser(ParserProxy):
         _paragraph_selector = CSSSelector(".article-content > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/us/la_times.py
+++ b/src/fundus/publishers/us/la_times.py
@@ -19,7 +19,7 @@ class LATimesParser(ParserProxy):
         _paragraph_selector = CSSSelector("div[data-element*=story-body] > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/occupy_democrats.py
+++ b/src/fundus/publishers/us/occupy_democrats.py
@@ -19,7 +19,7 @@ class OccupyDemocratsParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body: ArticleBody = extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/reuters.py
+++ b/src/fundus/publishers/us/reuters.py
@@ -21,7 +21,7 @@ class ReutersParser(ParserProxy):
         _subheadline_selector = XPath("//div[contains(@class, 'article-body')] /h2[@data-testid='Heading']")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/us/rolling_stone.py
+++ b/src/fundus/publishers/us/rolling_stone.py
@@ -22,7 +22,7 @@ class RollingStoneParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.a-content h2.heading," "div.a-content div#pmc-gallery-vertical h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/techcrunch.py
+++ b/src/fundus/publishers/us/techcrunch.py
@@ -23,7 +23,7 @@ class TechCrunchParser(ParserProxy):
         _subheadline_selector: CSSSelector = CSSSelector("div.article-content > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body: ArticleBody = extract_article_body_with_selector(
                 self.precomputed.doc,
                 subheadline_selector=self._subheadline_selector,
@@ -62,7 +62,7 @@ class TechCrunchParser(ParserProxy):
         _subheadline_selector: CSSSelector = CSSSelector("div.entry-content > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             body: ArticleBody = extract_article_body_with_selector(
                 self.precomputed.doc,
                 subheadline_selector=self._subheadline_selector,

--- a/src/fundus/publishers/us/the_gateway_pundit.py
+++ b/src/fundus/publishers/us/the_gateway_pundit.py
@@ -21,7 +21,7 @@ class TheGatewayPunditParser(ParserProxy):
         )
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/the_intercept.py
+++ b/src/fundus/publishers/us/the_intercept.py
@@ -24,7 +24,7 @@ class TheInterceptParser(ParserProxy):
         _subheadline_selector: XPath = CSSSelector("div.PostContent > div > h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/us/the_nation.py
+++ b/src/fundus/publishers/us/the_nation.py
@@ -55,7 +55,7 @@ class TheNationParser(ParserProxy):
                     parent.remove(aside)
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/us/the_new_yorker.py
+++ b/src/fundus/publishers/us/the_new_yorker.py
@@ -19,7 +19,7 @@ class TheNewYorkerParser(ParserProxy):
         _paragraph_selector = CSSSelector("div.body__inner-container > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 summary_selector=self._summary_selector,

--- a/src/fundus/publishers/us/voice_of_america.py
+++ b/src/fundus/publishers/us/voice_of_america.py
@@ -17,7 +17,7 @@ class VOAParser(ParserProxy):
         _paragraph_selector = CSSSelector("#article-content > div > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(self.precomputed.doc, paragraph_selector=self._paragraph_selector)
 
         @attribute

--- a/src/fundus/publishers/us/washington_post.py
+++ b/src/fundus/publishers/us/washington_post.py
@@ -18,7 +18,7 @@ class WashingtonPostParser(ParserProxy):
         _subheadline_selector = CSSSelector("div[data-qa='article-body'] > h3[data-qa='article-header']> div")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/washington_times.py
+++ b/src/fundus/publishers/us/washington_times.py
@@ -16,7 +16,7 @@ class WashingtonTimesParser(ParserProxy):
         _paragraph_selector = CSSSelector(".bigtext > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/wired.py
+++ b/src/fundus/publishers/us/wired.py
@@ -20,7 +20,7 @@ class WiredParser(ParserProxy):
         _subheadline_selector = CSSSelector(".body__inner-container h2")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,

--- a/src/fundus/publishers/us/world_truth.py
+++ b/src/fundus/publishers/us/world_truth.py
@@ -15,7 +15,7 @@ class WorldTruthParser(ParserProxy):
         _paragraph_selector = CSSSelector(".td-post-content > p")
 
         @attribute
-        def body(self) -> ArticleBody:
+        def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,


### PR DESCRIPTION
There was a long-lasting bug when using `suppress` as error handling, disabling its functionality. Because of the lack of default values for `Attribute`s, whenever an error occurred during the parsing of a specific attribute the exception was passed to the scraper, skipping the entire article.

This PR adds a property `__default__` to the attribute. The property returns a default value for the specific attribute based on its annotation, thus enabling us to use default values in case of an exception.

Further, I changed the type of `body` in the guidelines to `Optional[ArticleBody]` to be more in tune with `Article`.

The only review-relevant file here is `base_parser.py`