### PR TITLE
Fix trailing whitespace issue

### DIFF
--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -171,7 +171,6 @@ class LinkedDataMapping:
                 for chunk in chain(
                     (n.text,),
                     chain(*((tostring(child, with_tail=False, encoding=str), child.tail) for child in n.getchildren())),
-                    (n.tail,),
                 )
                 if chunk
             )


### PR DESCRIPTION
I was able to reproduce the issue causing pytest to fail on GitHub. It's failing due to an update that was released for `xmttodict` (installing xmltodict 0.14.1 reproduces the error, while no errors are raised with 0.13.0), although that is not the reason for the errors. What changed with the update is that the values were not stripped anymore causing the assertion errors. 
That leads to the question, why stripping was necessary in the first place. Turns out, they are introduced by including the tail of a node into string representation of the node. Since the tail only includes the content between the closing tag of that node and the starting tag of the next node, I think it can be safely removed.