### PR TITLE
Handle author dict Bug

### DIFF
--- a/src/fundus/publishers/de/braunschweiger_zeitung.py
+++ b/src/fundus/publishers/de/braunschweiger_zeitung.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import Any, Dict, List, Optional, Pattern, Union
+from typing import List, Optional, Pattern
 
 from lxml.etree import XPath
 
@@ -57,7 +57,9 @@ class BSZParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.bf_search("author", default=[]))
+            return apply_substitution_pattern_over_list(
+                generic_author_parsing(self.precomputed.ld.bf_search("author")), self._author_substitution_pattern
+            )
 
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:


### PR DESCRIPTION
When crawling Braunschweiger Zeitung I have encountered a rather odd bug. Take this article for example: https://www.braunschweiger-zeitung.de/article238597927/Von-Natur-aus-Harzer-Honig-aus-Willensen-ist-Typisch-Harz.html with the author element of its ld_json

`"author":[{"@type":"Organization","name":"FUNKE Mediengruppe","url":"https://www.harzkurier.de/autoren"}]`

The previous code would throw an attribute error, that str does not have an attribute get. Going through the ld element, I could see that the author element is of type dict. After some more searching, I found that in the HTML Fundus receives, we have this: 

`"author":{"@type": "Person","name": "hn","url": "https://www.braunschweiger-zeitung.de/autoren/"}`

I am not entirely sure, why this is happening, my guess is that it's some kind of redirection issue. Nevertheless, this PR fixes it.