### PR TITLE
Fix `BoersenZeitung`

### DIFF
--- a/src/fundus/publishers/de/boersenzeitung.py
+++ b/src/fundus/publishers/de/boersenzeitung.py
@@ -3,6 +3,7 @@ import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
+from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import (
@@ -15,7 +16,7 @@ from fundus.parser.utility import (
 class BoersenZeitungParser(ParserProxy):
     class V1(BaseParser):
         _paragraph_selector = CSSSelector("storefront-content-body .no-tts p")
-        _subheadline_selector = CSSSelector("p.wp-block-ppi-interline")
+        _subheadline_selector = XPath("//p[contains(@class, 'interline')]")
         _summary_selector = CSSSelector("storefront-html.excerpt > div")
 
         _topic_selector = CSSSelector("a[href^='/thema'] > span")
@@ -27,6 +28,7 @@ class BoersenZeitungParser(ParserProxy):
         def body(self) -> Optional[ArticleBody]:
             return extract_article_body_with_selector(
                 self.precomputed.doc,
+                summary_selector=self._summary_selector,
                 subheadline_selector=self._subheadline_selector,
                 paragraph_selector=self._paragraph_selector,
             )

--- a/tests/resources/parser/test_data/de/BoersenZeitung.json
+++ b/tests/resources/parser/test_data/de/BoersenZeitung.json
@@ -4,7 +4,9 @@
       "Thilo Schäfer"
     ],
     "body": {
-      "summary": [],
+      "summary": [
+        "Nach dem Einstieg bei Telefónica mischt Madrid auch bei Übernahmen von Naturgy und Talgo kräftig mit, unterstützt von der Stiftung La Caixa."
+      ],
       "sections": [
         {
           "headline": [],


### PR DESCRIPTION
The former version could not parse subheadlines from some articles, e.g. https://www.boersen-zeitung.de/kapitalmaerkte/steigende-us-zinsen-setzen-dax-zu 
Furthermore, it slipped our view that the summary_selector was unused