### PR TITLE
Fix `Frankfurter Rundschau`

### DIFF
--- a/src/fundus/publishers/de/frankfurter_rundschau.py
+++ b/src/fundus/publishers/de/frankfurter_rundschau.py
@@ -14,11 +14,14 @@ from fundus.parser.utility import (
 
 class FrankfurterRundschauParser(ParserProxy):
     class V1(BaseParser):
-        _paragraph_selector = XPath("//p[@class='id-StoryElement-paragraph'] | "
-              "//p[contains(@class,'id-Article-content-item-paragraph') and text()] |"
-              "//div[@class='id-Article-body']//ul/li[not(@class='id-AuthorList-item ')]")
-        _summary_selector = CSSSelector("p.id-StoryElement-leadText, "
-                                        "p[class='id-Article-content-item id-Article-content-item-summary']")
+        _paragraph_selector = XPath(
+            "//p[@class='id-StoryElement-paragraph'] | "
+            "//p[contains(@class,'id-Article-content-item-paragraph') and text()] |"
+            "//div[@class='id-Article-body']//ul/li[not(@class='id-AuthorList-item ')]"
+        )
+        _summary_selector = CSSSelector(
+            "p.id-StoryElement-leadText, " "p[class='id-Article-content-item id-Article-content-item-summary']"
+        )
         _subheadline_selector = CSSSelector("h2.id-StoryElement-crosshead, span.id-Article-content-item-headline-text")
 
         @attribute

--- a/src/fundus/publishers/de/frankfurter_rundschau.py
+++ b/src/fundus/publishers/de/frankfurter_rundschau.py
@@ -20,7 +20,7 @@ class FrankfurterRundschauParser(ParserProxy):
             "//div[@class='id-Article-body']//ul/li[not(@class='id-AuthorList-item ')]"
         )
         _summary_selector = CSSSelector(
-            "p.id-StoryElement-leadText, " "p[class='id-Article-content-item id-Article-content-item-summary']"
+            "p.id-StoryElement-leadText, p[class='id-Article-content-item id-Article-content-item-summary']"
         )
         _subheadline_selector = CSSSelector("h2.id-StoryElement-crosshead, span.id-Article-content-item-headline-text")
 

--- a/src/fundus/publishers/de/frankfurter_rundschau.py
+++ b/src/fundus/publishers/de/frankfurter_rundschau.py
@@ -2,6 +2,7 @@ import datetime
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
+from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import (
@@ -13,9 +14,12 @@ from fundus.parser.utility import (
 
 class FrankfurterRundschauParser(ParserProxy):
     class V1(BaseParser):
-        _paragraph_selector = CSSSelector("p.id-StoryElement-paragraph, article > ul > li")
-        _summary_selector = CSSSelector("p.id-StoryElement-leadText")
-        _subheadline_selector = CSSSelector("h2.id-StoryElement-crosshead")
+        _paragraph_selector = XPath("//p[@class='id-StoryElement-paragraph'] | "
+              "//p[contains(@class,'id-Article-content-item-paragraph') and text()] |"
+              "//div[@class='id-Article-body']//ul/li[not(@class='id-AuthorList-item ')]")
+        _summary_selector = CSSSelector("p.id-StoryElement-leadText, "
+                                        "p[class='id-Article-content-item id-Article-content-item-summary']")
+        _subheadline_selector = CSSSelector("h2.id-StoryElement-crosshead, span.id-Article-content-item-headline-text")
 
         @attribute
         def body(self) -> Optional[ArticleBody]:


### PR DESCRIPTION
This PR adds parsing for this article: https://www.fr.de/ratgeber/tiere/zeitumstellung-tiere-haustiere-hunde-katzen-wildtier-landwirtschaft-tagesrhythmus-zr-93379931.html 