### PR TITLE
Minor Changes to Utility Functions

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -526,9 +526,7 @@
           <span>www.golem.de</span>
         </a>
       </td>
-      <td>
-        <code>images</code>
-      </td>
+      <td>&#160;</td>
       <td>&#160;</td>
     </tr>
     <tr>
@@ -558,9 +556,7 @@
           <span>www.heise.de</span>
         </a>
       </td>
-      <td>
-        <code>images</code>
-      </td>
+      <td>&#160;</td>
       <td>&#160;</td>
     </tr>
     <tr>
@@ -575,9 +571,7 @@
           <span>www.hessenschau.de</span>
         </a>
       </td>
-      <td>
-        <code>images</code>
-      </td>
+      <td>&#160;</td>
       <td>&#160;</td>
     </tr>
     <tr>
@@ -610,7 +604,6 @@
         </a>
       </td>
       <td>
-        <code>images</code>
         <code>topics</code>
       </td>
       <td>&#160;</td>
@@ -644,9 +637,7 @@
           <span>www.mz.de</span>
         </a>
       </td>
-      <td>
-        <code>images</code>
-      </td>
+      <td>&#160;</td>
       <td>&#160;</td>
     </tr>
     <tr>

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -441,7 +441,7 @@ def parse_srcset(srcset: str) -> Dict[str, str]:
         descriptor = match.group("descriptor")  # Width (w) or pixel density (x)
         urls[descriptor or "1x"] = url
     # return sorted dict based on int value of descriptor
-    return dict(sorted(urls.items(), key=lambda item: int(item[0][:-1])))
+    return dict(sorted(urls.items(), key=lambda item: float(item[0][:-1])))
 
 
 def parse_urls_from_image(node: lxml.html.HtmlElement) -> Optional[Dict[str, str]]:
@@ -481,8 +481,8 @@ def parse_image_nodes(
     for position, node, is_cover in image_nodes:
         # parse URLs
         urls = {}
-        if (parent := node.getparent()) is not None and parent.tag == "picture":
-            for source in parent.xpath("./source"):
+        if (parents := node.xpath("./ancestor::picture")) and (sources := parents.pop().xpath("./source")):
+            for source in sources:
                 urls.update(parse_urls_from_image(source) or {})
         else:
             urls.update(parse_urls_from_image(node) or {})

--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -462,7 +462,7 @@ class DE(metaclass=PublisherGroup):
             ),
             NewsMap("https://newsfeed.kicker.de/googlesitemapnews.xml"),
         ],
-        url_filter=regex_filter("/slideshow|/video"),
+        url_filter=regex_filter("/slideshow|/video|heute-live|live-konferenz|/bilder|/ticker"),
     )
 
     Krautreporter = Publisher(

--- a/src/fundus/publishers/de/freiepresse.py
+++ b/src/fundus/publishers/de/freiepresse.py
@@ -46,16 +46,18 @@ class FreiePresseParser(ParserProxy):
         def topics(self) -> List[str]:
             return generic_topic_parsing(self.precomputed.ld.bf_search("keywords"), delimiter="/")
 
-        """
-        This publisher uses relative URLs, which is not supported at of now
         @attribute
         def images(self) -> List[Image]:
             return image_extraction(
                 doc=self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,
-                image_selector=XPath("//div[@class='detail-img__image-wrapper detail-img__image-wrapper--gradient']//img"),
+                image_selector=XPath(
+                    "//div[@class='detail-img__image-wrapper detail-img__image-wrapper--gradient']//img"
+                ),
                 lower_boundary_selector=CSSSelector("a.article__copyright"),
-                caption_selector=XPath("./ancestor::div[@class='detail-img']//div[@class='detail-img__description no-transition']/div/text()"),
-                author_selector=re.compile(r"(?i)bild:(?P<credits>.*)")
+                caption_selector=XPath(
+                    "./ancestor::div[@class='detail-img']//div[@class='detail-img__description no-transition']/div/text()"
+                ),
+                author_selector=re.compile(r"(?i)bild:(?P<credits>.*)"),
+                relative_urls=True,
             )
-        """

--- a/src/fundus/publishers/de/freiepresse.py
+++ b/src/fundus/publishers/de/freiepresse.py
@@ -1,14 +1,17 @@
 import datetime
+import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
+from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
+    image_extraction,
 )
 
 
@@ -42,3 +45,17 @@ class FreiePresseParser(ParserProxy):
         @attribute
         def topics(self) -> List[str]:
             return generic_topic_parsing(self.precomputed.ld.bf_search("keywords"), delimiter="/")
+
+        """
+        This publisher uses relative URLs, which is not supported at of now
+        @attribute
+        def images(self) -> List[Image]:
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                image_selector=XPath("//div[@class='detail-img__image-wrapper detail-img__image-wrapper--gradient']//img"),
+                lower_boundary_selector=CSSSelector("a.article__copyright"),
+                caption_selector=XPath("./ancestor::div[@class='detail-img']//div[@class='detail-img__description no-transition']/div/text()"),
+                author_selector=re.compile(r"(?i)bild:(?P<credits>.*)")
+            )
+        """

--- a/src/fundus/publishers/de/gamestar.py
+++ b/src/fundus/publishers/de/gamestar.py
@@ -41,8 +41,6 @@ class GamestarParser(ParserProxy):
         def publishing_date(self) -> Optional[datetime]:
             return generic_date_parsing(self.precomputed.ld.bf_search("datePublished"))
 
-        """
-        This publisher uses incomplete URLs, which cannot be fixed as of now
         @attribute
         def images(self) -> List[Image]:
             return image_extraction(
@@ -52,6 +50,6 @@ class GamestarParser(ParserProxy):
                 image_selector=XPath("//picture/img"),
                 caption_selector=XPath("./ancestor::p[@class='caption ']/span[@class='bu m-t-1']"),
                 lower_boundary_selector=XPath("//div[@id='comments']"),
-                author_selector=re.compile("(?i)Bildquelle:(?P<credits>.*)")
+                author_selector=re.compile("(?i)Bildquelle:(?P<credits>.*)"),
+                relative_urls=True,
             )
-        """

--- a/src/fundus/publishers/de/gamestar.py
+++ b/src/fundus/publishers/de/gamestar.py
@@ -1,13 +1,16 @@
+import re
 from datetime import datetime
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
+from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
+    image_extraction,
 )
 
 
@@ -37,3 +40,18 @@ class GamestarParser(ParserProxy):
         @attribute
         def publishing_date(self) -> Optional[datetime]:
             return generic_date_parsing(self.precomputed.ld.bf_search("datePublished"))
+
+        """
+        This publisher uses incomplete URLs, which cannot be fixed as of now
+        @attribute
+        def images(self) -> List[Image]:
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                upper_boundary_selector=XPath("//div[@class='main waypoint']"),
+                image_selector=XPath("//picture/img"),
+                caption_selector=XPath("./ancestor::p[@class='caption ']/span[@class='bu m-t-1']"),
+                lower_boundary_selector=XPath("//div[@id='comments']"),
+                author_selector=re.compile("(?i)Bildquelle:(?P<credits>.*)")
+            )
+        """

--- a/src/fundus/publishers/de/golem.py
+++ b/src/fundus/publishers/de/golem.py
@@ -1,15 +1,17 @@
 import datetime
+import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
+    image_extraction,
 )
 
 
@@ -50,3 +52,12 @@ class GolemParser(ParserProxy):
         @attribute
         def topics(self) -> List[str]:
             return generic_topic_parsing(self.precomputed.meta.get("news_keywords"))
+
+        @attribute
+        def images(self) -> List[Image]:
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                upper_boundary_selector=XPath("//article"),
+                author_selector=re.compile(r"(?i)\(bild:(?P<credits>.*)\)"),
+            )

--- a/src/fundus/publishers/de/heise.py
+++ b/src/fundus/publishers/de/heise.py
@@ -1,14 +1,16 @@
+import re
 from datetime import datetime
 from typing import List, Optional
 
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
+    image_extraction,
 )
 
 
@@ -61,3 +63,31 @@ class HeiseParser(ParserProxy):
         @attribute
         def topics(self) -> List[str]:
             return generic_topic_parsing(self.precomputed.meta.get("keywords"))
+
+        @attribute
+        def images(self) -> List[Image]:
+            # There some (rare) cases there are some images that are not being extracted with this, because they are
+            # referenced by relative URLs. e.g.
+            # https://www.heise.de/hintergrund/Zahlen-bitte-136199-Eris-Der-Grund-warum-Pluto-kein-Planet-mehr-ist-9993800.html
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                upper_boundary_selector=XPath(
+                    "//h1[@class='article-headline ' or contains(@class, 'a-article-header__title')]"
+                ),
+                image_selector=XPath(
+                    "//div[@class='article-image__gallery-container']//img|"
+                    "//div[@class='image-container']//img|"
+                    "//div[@class='article-layout__content']//figure[not(@class)]//noscript//img"
+                ),
+                caption_selector=XPath(
+                    "./ancestor::figure//p[@class='a-caption__text']|"
+                    "./ancestor::figure//div[@class='text']|"
+                    "./ancestor::div[@class='article-gallery ']//span[@class='caption']"
+                ),
+                author_selector=XPath(
+                    "./ancestor::figure//p[@class='a-caption__source']|"
+                    "./ancestor::div[@class='article-gallery ']//span[@class='copyright']"
+                ),
+                author_filter=re.compile(r"(?i)\(|bild:|\)"),
+            )

--- a/src/fundus/publishers/de/hessenschau.py
+++ b/src/fundus/publishers/de/hessenschau.py
@@ -1,25 +1,33 @@
+import re
 from datetime import datetime
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
+    image_extraction,
 )
 
 
 class HessenschauParser(ParserProxy):
     class V1(BaseParser):
-        _summary_selector = XPath("//p[@class='copytext__text text__copytext' and position()=1] /strong")
-        _paragraph_selector = XPath(
-            "//p[@class='copytext__text text__copytext' and not(child::strong and position()=1)]"
+        _summary_selector = XPath(
+            "//p[(@class='copytext__text text__copytext'"
+            " or contains(@class, 'copytext__paragraph'))"
+            " and position()=1] /strong"
         )
-        _subheadline_selector = CSSSelector("h2.text__headline.copytext__headline")
+        _paragraph_selector = XPath(
+            "//p[(@class='copytext__text text__copytext' or contains(@class, 'copytext__paragraph'))"
+            " and not(child::strong and position()=1)] | "
+            "//ul[contains(@class, 'copytext__paragraph')]/li"
+        )
+        _subheadline_selector = CSSSelector("h2[class*=head]")
 
         @attribute
         def body(self) -> ArticleBody:
@@ -45,3 +53,14 @@ class HessenschauParser(ParserProxy):
         @attribute
         def topics(self) -> List[str]:
             return generic_topic_parsing(self.precomputed.meta.get("news_keywords"))
+
+        @attribute
+        def images(self) -> List[Image]:
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                image_selector=XPath("//figure[not(@class='ar-1-1')]//*[not(self::noscript)]/img"),
+                caption_selector=XPath("./ancestor::figure//span[@class='pr-3']"),
+                author_selector=XPath("./ancestor::figure//span[@class='text-gray-scorpion dark:text-text-dark']"),
+                author_filter=re.compile(r"(?i)bild\s*©"),
+            )

--- a/src/fundus/publishers/de/junge_welt.py
+++ b/src/fundus/publishers/de/junge_welt.py
@@ -4,13 +4,12 @@ from typing import List, Optional
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
-    image_extraction,
 )
 
 
@@ -51,5 +50,3 @@ class JungeWeltParser(ParserProxy):
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:
             return generic_date_parsing(self.precomputed.ld.bf_search("datePublished"))
-
-        # As of now this publisher only supports relative URLs for images, which are currently not yet supported

--- a/src/fundus/publishers/de/junge_welt.py
+++ b/src/fundus/publishers/de/junge_welt.py
@@ -4,12 +4,13 @@ from typing import List, Optional
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
+    image_extraction,
 )
 
 
@@ -50,3 +51,5 @@ class JungeWeltParser(ParserProxy):
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:
             return generic_date_parsing(self.precomputed.ld.bf_search("datePublished"))
+
+        # As of now this publisher only supports relative URLs for images, which are currently not yet supported

--- a/src/fundus/publishers/de/kicker.py
+++ b/src/fundus/publishers/de/kicker.py
@@ -47,15 +47,8 @@ class KickerParser(ParserProxy):
                 paragraph_selector=self._paragraph_selector,
                 upper_boundary_selector=XPath("//article"),
                 image_selector=XPath(
-                    "//div[@class='kick__article__content']//div[contains(@class,'kick__article__picture ')]/picture[not(@class)]//img|"
-                    "//a[contains(@class,'kick__article__picture')]//img"
+                    "//*[contains(@class,'kick__article__picture') and not(contains(@class, 'medias'))]//img"
                 ),
-                caption_selector=XPath(
-                    "./ancestor::div[contains(@class, 'kick__article__picture')]//p/text()|"
-                    "./ancestor::a[contains(@class, 'kick__article__picture')]//p/text()"
-                ),
-                author_selector=XPath(
-                    "./ancestor::div[contains(@class, 'kick__article__picture')]//p/span|"
-                    "./ancestor::a[contains(@class, 'kick__article__picture')]//p/span"
-                ),
+                caption_selector=XPath("./ancestor::*[contains(@class, 'kick__article__picture ')]//p/text()"),
+                author_selector=XPath("./ancestor::*[contains(@class, 'kick__article__picture ')]//p/span"),
             )

--- a/src/fundus/publishers/de/krautreporter.py
+++ b/src/fundus/publishers/de/krautreporter.py
@@ -59,15 +59,18 @@ class KrautreporterParser(ParserProxy):
         def topics(self) -> List[str]:
             return utility.generic_topic_parsing(self._topic_selector(self.precomputed.doc))
 
-        """
-        This publisher uses data:image/gif;base64 values in their non-cover images
         @attribute
         def images(self) -> List[Image]:
             return image_extraction(
                 doc=self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,
-                image_selector=XPath("//section[@class='article-headers-shared-teaser-image']//img|"
-                                     "//figure[contains(@class, 'image--default')]//img"),
-                author_selector=XPath("./ancestor::section[@class='article-headers-shared-teaser-image']//p[@class='article-headers-shared-teaser-image__credits']")
+                image_selector=XPath(
+                    "//section[@class='article-headers-shared-teaser-image']//img|"
+                    "//figure[contains(@class, 'image--default')]//img"
+                ),
+                author_selector=XPath(
+                    "./ancestor::section[@class='article-headers-shared-teaser-image']"
+                    "//p[@class='article-headers-shared-teaser-image__credits']"
+                ),
+                relative_urls=True,
             )
-        """

--- a/src/fundus/publishers/de/krautreporter.py
+++ b/src/fundus/publishers/de/krautreporter.py
@@ -4,7 +4,15 @@ from typing import List, Optional
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute, utility
+from fundus.parser import (
+    ArticleBody,
+    BaseParser,
+    Image,
+    ParserProxy,
+    attribute,
+    utility,
+)
+from fundus.parser.utility import image_extraction
 
 
 class KrautreporterParser(ParserProxy):
@@ -50,3 +58,16 @@ class KrautreporterParser(ParserProxy):
         @attribute
         def topics(self) -> List[str]:
             return utility.generic_topic_parsing(self._topic_selector(self.precomputed.doc))
+
+        """
+        This publisher uses data:image/gif;base64 values in their non-cover images
+        @attribute
+        def images(self) -> List[Image]:
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                image_selector=XPath("//section[@class='article-headers-shared-teaser-image']//img|"
+                                     "//figure[contains(@class, 'image--default')]//img"),
+                author_selector=XPath("./ancestor::section[@class='article-headers-shared-teaser-image']//p[@class='article-headers-shared-teaser-image__credits']")
+            )
+        """

--- a/src/fundus/publishers/de/mz.py
+++ b/src/fundus/publishers/de/mz.py
@@ -2,13 +2,15 @@ import datetime
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
+from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
+    image_extraction,
 )
 
 
@@ -42,3 +44,16 @@ class MitteldeutscheZeitungParser(ParserProxy):
         @attribute
         def topics(self) -> List[str]:
             return generic_topic_parsing(self.precomputed.meta.get("keywords"))
+
+        @attribute
+        def images(self) -> List[Image]:
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                caption_selector=XPath(
+                    "./ancestor::div[@class='key-visual-image-wrapper']//span[@data-fp-flag='main-image-caption']"
+                ),
+                author_selector=XPath(
+                    "./ancestor::div[@class='key-visual-image-wrapper']//span[@data-fp-flag='main-image-source']"
+                ),
+            )

--- a/tests/resources/parser/test_data/ca/NationalPost.json
+++ b/tests/resources/parser/test_data/ca/NationalPost.json
@@ -75,8 +75,8 @@
     "images": [
       {
         "urls": {
-          "1x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=288&h=216&sig=Ljg4qX5ZA5CJ_zgkeUwCGg,",
-          "2x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=576&h=432&sig=MJddUrXGOuvx0T5L0eSY1A"
+          "1x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=tjU1vhPSQI8zy3tLPltvAQ,",
+          "2x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=1128&h=846&type=webp&sig=0p80GzjMQzu56FKKjtUrng"
         },
         "is_cover": true,
         "description": "Kamala Harris with high school classmates.",
@@ -88,8 +88,8 @@
       },
       {
         "urls": {
-          "1x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=288&sig=OCI8kk7ttdb6U7lfUnsBbg,",
-          "2x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=576&sig=yl0MqIc0LAM4f1p7z317uQ"
+          "1x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=564&type=webp&sig=5NYrqJxhwP2DuUNLEqM0qQ,",
+          "2x": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=1128&type=webp&sig=xhgJqUJ6A5dHmzNM4tTYmQ"
         },
         "is_cover": false,
         "description": "Kamala Harris.",

--- a/tests/resources/parser/test_data/ch/SRF.json
+++ b/tests/resources/parser/test_data/ch/SRF.json
@@ -28,12 +28,12 @@
     "images": [
       {
         "urls": {
-          "160w": "https://www.srf.ch/static/cms/images/160w/d09eab.jpg",
-          "320w": "https://www.srf.ch/static/cms/images/320w/d09eab.jpg",
-          "480w": "https://www.srf.ch/static/cms/images/480w/d09eab.jpg",
-          "640w": "https://www.srf.ch/static/cms/images/640w/d09eab.jpg",
-          "960w": "https://www.srf.ch/static/cms/images/960w/d09eab.jpg",
-          "1280w": "https://www.srf.ch/static/cms/images/1280w/d09eab.jpg"
+          "160w": "https://www.srf.ch/static/cms/images/160w/d09eab.webp",
+          "320w": "https://www.srf.ch/static/cms/images/320w/d09eab.webp",
+          "480w": "https://www.srf.ch/static/cms/images/480w/d09eab.webp",
+          "640w": "https://www.srf.ch/static/cms/images/640w/d09eab.webp",
+          "960w": "https://www.srf.ch/static/cms/images/960w/d09eab.webp",
+          "1280w": "https://www.srf.ch/static/cms/images/1280w/d09eab.webp"
         },
         "is_cover": false,
         "description": "Menschen in Raum.",

--- a/tests/resources/parser/test_data/de/DieWelt.json
+++ b/tests/resources/parser/test_data/de/DieWelt.json
@@ -37,7 +37,7 @@
     "images": [
       {
         "urls": {
-          "1x": "https://img.welt.de/img/wirtschaft/mobile245057420/9712506227-ci102l-w1024/DWO-Teaser-BIP-mki.jpg"
+          "1.0x": "https://img.welt.de/img/wirtschaft/mobile245057420/9711626227-ci23x11-w1136/DWO-Teaser-BIP-mki.jpg"
         },
         "is_cover": true,
         "description": null,
@@ -47,7 +47,7 @@
       },
       {
         "urls": {
-          "1x": "https://img.welt.de/img/wirtschaft/mobile245057420/9712506227-ci102l-w1024/DWO-Teaser-BIP-mki.jpg"
+          "1.0x": "https://img.welt.de/img/wirtschaft/mobile245057420/9711626227-ci23x11-w100/DWO-Teaser-BIP-mki.jpg"
         },
         "is_cover": true,
         "description": null,
@@ -57,7 +57,7 @@
       },
       {
         "urls": {
-          "1x": "https://img.welt.de/img/wirtschaft/mobile245056202/1892507437-ci102l-w1024/DW-WI-Wirtschaftsraum-Deutschland-jb-Wirtschaftswachstum-jpg.jpg"
+          "1.0x": "https://img.welt.de/img/wirtschaft/mobile245056202/1890247437-ci3x2l-w780/DW-WI-Wirtschaftsraum-Deutschland-jb-Wirtschaftswachstum-jpg.jpg"
         },
         "is_cover": false,
         "description": null,
@@ -67,7 +67,7 @@
       },
       {
         "urls": {
-          "1x": "https://img.welt.de/img/wirtschaft/mobile245056200/6922501617-ci102l-w1024/DW-WI-Wirtschaftsraum-Deutschland-jb-Wirtschaftsentwicklung-jpg.jpg"
+          "1.0x": "https://img.welt.de/img/wirtschaft/mobile245056200/6920241617-ci3x2l-w780/DW-WI-Wirtschaftsraum-Deutschland-jb-Wirtschaftsentwicklung-jpg.jpg"
         },
         "is_cover": false,
         "description": null,

--- a/tests/resources/parser/test_data/de/FAZ.json
+++ b/tests/resources/parser/test_data/de/FAZ.json
@@ -106,7 +106,8 @@
     "images": [
       {
         "urls": {
-          "1240w": "https://media0.faz.net/ppmedia/w1240/aktuell/4099641140/1.9655246/16x9/streng-abgeschirmter-komplex.jpg.webp"
+          "1000w": "https://media0.faz.net/ppmedia/w1000/aktuell/4099641140/1.9655246/1900x850/streng-abgeschirmter-komplex.jpg.webp",
+          "1240w": "https://media0.faz.net/ppmedia/w1240/aktuell/4099641140/1.9655246/1900x850/streng-abgeschirmter-komplex.jpg.webp"
         },
         "is_cover": true,
         "description": "Streng abgeschirmter Komplex: Russlands Vertretung bei den Vereinten Nationen in Genf",

--- a/tests/resources/parser/test_data/de/Golem.json
+++ b/tests/resources/parser/test_data/de/Golem.json
@@ -27,6 +27,21 @@
         }
       ]
     },
+    "images": [
+      {
+        "urls": {
+          "1x": "https://www.golem.de/2404/184627-442864-442863_rc.jpg",
+          "1.5x": "https://www.golem.de/2404/184627-442866-442863.jpg"
+        },
+        "is_cover": true,
+        "description": "Samsung hat Probleme vor Gericht.",
+        "caption": "Samsung hat Probleme vor Gericht.",
+        "authors": [
+          "Tobias Költzsch/Golem.de"
+        ],
+        "position": 385
+      }
+    ],
     "publishing_date": "2024-04-28 14:26:01+00:00",
     "title": "LTE-Patent: Samsung soll wegen Patentklage Smartphones zerstören",
     "topics": [

--- a/tests/resources/parser/test_data/de/Heise.json
+++ b/tests/resources/parser/test_data/de/Heise.json
@@ -28,6 +28,23 @@
         }
       ]
     },
+    "images": [
+      {
+        "urls": {
+          "336w": "https://heise.cloudimg.io/width/336/q70.png-lossy-70.webp-lossy-70.foil1/_www-heise-de_/imgs/18/4/5/7/5/8/7/7/2024-03-12-Bing_Designer-Phishing-2-3840px-82adf0aebe8ed409.png",
+          "610w": "https://heise.cloudimg.io/width/610/q70.png-lossy-70.webp-lossy-70.foil1/_www-heise-de_/imgs/18/4/5/7/5/8/7/7/2024-03-12-Bing_Designer-Phishing-2-3840px-82adf0aebe8ed409.png",
+          "1008w": "https://heise.cloudimg.io/width/1008/q70.png-lossy-70.webp-lossy-70.foil1/_www-heise-de_/imgs/18/4/5/7/5/8/7/7/2024-03-12-Bing_Designer-Phishing-2-3840px-82adf0aebe8ed409.png",
+          "1220w": "https://heise.cloudimg.io/width/1220/q70.png-lossy-70.webp-lossy-70.foil1/_www-heise-de_/imgs/18/4/5/7/5/8/7/7/2024-03-12-Bing_Designer-Phishing-2-3840px-82adf0aebe8ed409.png"
+        },
+        "is_cover": true,
+        "description": "Krimineller angelt Kreditkartendaten",
+        "caption": "Online-Kriminelle phishen nach monetarisierbaren Informationen.",
+        "authors": [
+          "Bild erstellt mit KI in Bing Designer durch heise online / dmk"
+        ],
+        "position": 640
+      }
+    ],
     "publishing_date": "2024-04-19 13:37:00+02:00",
     "title": "Ionos-Phishing: Masche mit neuen EU-Richtlinien soll Opfer überzeugen",
     "topics": [

--- a/tests/resources/parser/test_data/de/Hessenschau.json
+++ b/tests/resources/parser/test_data/de/Hessenschau.json
@@ -54,6 +54,35 @@
         }
       ]
     },
+    "images": [
+      {
+        "urls": {
+          "320w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-102~_t-1714196357123_v-16to9__small.jpg",
+          "480w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-102~_t-1714196357123_v-16to9__medium.jpg",
+          "640w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-102~_t-1714196357123_v-16to9__medium__extended.jpg",
+          "960w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-102~_t-1714196357123_v-16to9.jpg",
+          "1920w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-102~_t-1714196357123_v-16to9__retina.jpg"
+        },
+        "is_cover": true,
+        "description": "Eine junge Frau steht in einem Warenlager.",
+        "caption": null,
+        "authors": [],
+        "position": 464
+      },
+      {
+        "urls": {
+          "320w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-100~_t-1714196355723_v-16toX__small.jpg",
+          "480w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-100~_t-1714196355723_v-16toX__medium.jpg",
+          "960w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-100~_t-1714196355723_v-16toX.jpg",
+          "1920w": "https://www.hessenschau.de/wirtschaft/ukrainerin-arbeitsmarkt-100~_t-1714196355723_v-16toX__retina.jpg"
+        },
+        "is_cover": false,
+        "description": "Eine junge Frau sitzt an einem Schreibtisch, neben ihr steht eine Frau in blauem Hosenanzug.",
+        "caption": null,
+        "authors": [],
+        "position": 488
+      }
+    ],
     "publishing_date": "2024-04-27 07:39:00+02:00",
     "title": "Schnellere Integration: \"Job-Turbo\" hilft Geflüchteten auf dem Arbeitsmarkt",
     "topics": [

--- a/tests/resources/parser/test_data/de/Kicker.json
+++ b/tests/resources/parser/test_data/de/Kicker.json
@@ -20,6 +20,20 @@
         }
       ]
     },
+    "images": [
+      {
+        "urls": {
+          "1x": "https://derivates.kicker.de/image/upload/f_webp/c_crop%2Cx_0%2Cy_91%2Cw_2651%2Ch_1491/w_1000%2Cq_auto%2Ch_563/v1/2024/04/26/83e0240d-b792-412d-bb42-3ce71a5b6ca0.jpeg"
+        },
+        "is_cover": true,
+        "description": "Uwe Schubert möchte mit dem MSV Duisburg noch so viele Punkte wie möglich sammeln.",
+        "caption": "Uwe Schubert möchte mit dem MSV Duisburg noch so viele Punkte wie möglich sammeln.",
+        "authors": [
+          "IMAGO/Nico Herbertz"
+        ],
+        "position": 684
+      }
+    ],
     "publishing_date": "2024-04-26 15:24:10+02:00",
     "title": "Interimstrainer Schubert: \"Nicht mehr viel zu verlieren\""
   }

--- a/tests/resources/parser/test_data/de/MitteldeutscheZeitung.json
+++ b/tests/resources/parser/test_data/de/MitteldeutscheZeitung.json
@@ -28,6 +28,24 @@
         }
       ]
     },
+    "images": [
+      {
+        "urls": {
+          "160w": "https://bmg-images.forward-publishing.io/2024/04/30/b3c40bdd-3f8c-4a16-ba06-f95c78d9b083.jpeg?w=160&auto=format",
+          "320w": "https://bmg-images.forward-publishing.io/2024/04/30/b3c40bdd-3f8c-4a16-ba06-f95c78d9b083.jpeg?w=320&auto=format",
+          "640w": "https://bmg-images.forward-publishing.io/2024/04/30/b3c40bdd-3f8c-4a16-ba06-f95c78d9b083.jpeg?w=640&auto=format",
+          "1024w": "https://bmg-images.forward-publishing.io/2024/04/30/b3c40bdd-3f8c-4a16-ba06-f95c78d9b083.jpeg?w=1024&auto=format",
+          "2048w": "https://bmg-images.forward-publishing.io/2024/04/30/b3c40bdd-3f8c-4a16-ba06-f95c78d9b083.jpeg?w=2048&auto=format"
+        },
+        "is_cover": true,
+        "description": "Demonstration im September 2022 nach dem Tod der 22-jährigen Mahsa Amini.",
+        "caption": "Demonstration im September 2022 nach dem Tod der 22-jährigen Mahsa Amini.",
+        "authors": [
+          "Uncredited/AP/dpa"
+        ],
+        "position": 562
+      }
+    ],
     "publishing_date": "2024-04-30 16:58:00+00:00",
     "title": "Bei Protesten 2022: Bericht: Aktivistin getötet - Irans Justiz dementiert",
     "topics": [

--- a/tests/resources/parser/test_data/no/Dagbladet.json
+++ b/tests/resources/parser/test_data/no/Dagbladet.json
@@ -92,7 +92,7 @@
     "images": [
       {
         "urls": {
-          "1x": "https://www.dagbladet.no/images/81343798.jpg?imageId=81343798&x=0&y=0&cropw=100&croph=100&width=993&height=552&compression=80"
+          "1x": "https://www.dagbladet.no/images/81343798.jpg?imageId=81343798&x=2.564102564102564&y=0&cropw=96.93877551020408&croph=99.54337899543378&width=760&height=436&compression=70"
         },
         "is_cover": true,
         "description": "KNIV: Denne kniven ble ifølge Metropolitan Police brukt til de ulovlige kastreringene. Foto: Metropolitan Police",
@@ -104,7 +104,7 @@
       },
       {
         "urls": {
-          "1x": "https://www.dagbladet.no/images/78341581.jpg?imageId=78341581&x=0&y=7.3417721518987&cropw=97.643097643098&croph=89.367088607595&width=581&height=354&compression=80"
+          "1x": "https://www.dagbladet.no/images/78341581.jpg?imageId=78341581&x=5.3908355795148255&y=1.6260162601626018&cropw=94.60916442048517&croph=98.3739837398374&width=702&height=484&compression=70"
         },
         "is_cover": false,
         "description": "DØMT: Nordmannen i 40-åra ble dømt i den sentrale straffesaksdomstolen i London, Old Bailey. Foto: AP",
@@ -116,7 +116,7 @@
       },
       {
         "urls": {
-          "1x": "https://www.dagbladet.no/images/81345120.jpg?imageId=81345120&x=0&y=0&cropw=47.269763651182&croph=88.311688311688&width=581&height=545&compression=80"
+          "1x": "https://www.dagbladet.no/images/81345120.jpg?imageId=81345120&x=0&y=0&cropw=35.670731707317074&croph=87.2210953346856&width=702&height=860&compression=70"
         },
         "is_cover": false,
         "description": "VIA NETT: Mannen livestreamet ifølge påtalemyndighetene de ulovlige operasjonene via dette nettstedet. Foto: Skjermdump / Way Back Machine",


### PR DESCRIPTION
I suggest the following changes:
- sort by float value (I had a case using 1.5x)
- use the ancestor function of XPath to get the parent picture element, should it exist. This has the advantage that if it exist, it will actually be found. In the previous version, `.getParent()` would select the predecessor, which is not necessarily the parent, as one would expect it to be (thinking of a tree structure).

_Only the utility.py should be worth going through. If you look at the commit with the changes to utility, you will see the difference the second bullet point causes._