### PR TITLE
Fix pickling problem in `LinkedDataMapping`

### DIFF
--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -22,7 +22,7 @@ import lxml.etree
 import more_itertools
 import xmltodict
 from dict2xml import dict2xml
-from lxml.etree import XPath, tostring
+from lxml.etree import XPath, fromstring, tostring
 from typing_extensions import Self, TypeAlias, deprecated
 
 from fundus.utils.serialization import JSONVal, replace_keys_in_nested_dict
@@ -60,6 +60,17 @@ class LinkedDataMapping:
             else:
                 self.add_ld(ld)
         self.__xml: Optional[lxml.etree._Element] = None
+
+    def __getstate__(self):
+        picklable_dict = self.__dict__.copy()
+        if (xml_element := picklable_dict.get("_LinkedDataMapping__xml")) is not None:
+            picklable_dict["_LinkedDataMapping__xml"] = tostring(xml_element)
+        return picklable_dict
+
+    def __setstate__(self, state):
+        if (xml_element := state.get("_LinkedDataMapping__xml")) is not None:
+            state["_LinkedDataMapping__xml"] = fromstring(xml_element)
+        self.__dict__ = state
 
     def serialize(self) -> Dict[str, Any]:
         return {attribute: value for attribute, value in self.__dict__.items() if "__" not in attribute}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,7 @@
+from pickle import dumps, loads
 from typing import Any, Dict, List
 
-from lxml.etree import XPath
+from lxml.etree import XPath, tostring
 
 from fundus.parser.data import LinkedDataMapping
 
@@ -22,3 +23,14 @@ class TestLinkedDataMapping:
         assert ld.xpath_search(XPath("//_U003AU002AU0040")) == ["Howdy"]
         assert ld.xpath_search(XPath("//dict")) == ["True"]
         assert ld.xpath_search(XPath("//Example2")) == [{"@type": "Example2", "value": "2", "_:*@": "Howdy"}]
+
+    def test_pickle(self):
+        ld = LinkedDataMapping(lds)
+        ld.__as_xml__()
+        ld_pickled = loads(dumps(ld))
+        assert ld_pickled.__getattribute__("Example1") == ld.__getattribute__("Example1")
+        assert ld_pickled.__getattribute__("Example2") == ld.__getattribute__("Example2")
+        assert ld_pickled.__getattribute__("UNKNOWN_TYPE") == ld.__getattribute__("UNKNOWN_TYPE")
+        assert tostring(ld_pickled.__getattribute__("_LinkedDataMapping__xml")) == tostring(
+            ld.__getattribute__("_LinkedDataMapping__xml")
+        )


### PR DESCRIPTION
As of now CC-Crawling is crashing due to a pickling error, with a message along the lines of `cannot pickle lxml.etree._Element`. I traced the error back to this article: https://de.euronews.com/2023/02/17/chinas-botschaft-in-paris-twittert-falsche-behauptungen-uber-das-erdbeben-in-der-turkei where the issue seems to be the use of the `__as_xml__()` function, which creates an attribute in the `LinkedDataMapping` object of type `lxml.etree._Element`. To avoid crashing, I suggest overwriting the `__getstate__()` and `__setstate__()` functions converting the Elements to a string before pickling.