### PR TITLE
Update BBC

### DIFF
--- a/src/fundus/publishers/uk/__init__.py
+++ b/src/fundus/publishers/uk/__init__.py
@@ -156,7 +156,7 @@ class UK(metaclass=PublisherGroup):
         domain="https://www.bbc.co.uk/",
         parser=TheBBCParser,
         sources=[
-            NewsMap("https://www.bbc.co.uk/sitemaps/https-index-uk-news.xml"),
+            # NewsMap("https://www.bbc.co.uk/sitemaps/https-index-uk-news.xml"),
             Sitemap("https://www.bbc.co.uk/sitemaps/https-index-com-archive.xml", reverse=True),
         ],
         url_filter=regex_filter("video|live"),

--- a/src/fundus/publishers/uk/__init__.py
+++ b/src/fundus/publishers/uk/__init__.py
@@ -156,7 +156,7 @@ class UK(metaclass=PublisherGroup):
         domain="https://www.bbc.co.uk/",
         parser=TheBBCParser,
         sources=[
-            # NewsMap("https://www.bbc.co.uk/sitemaps/https-index-uk-news.xml"),
+            NewsMap("https://www.bbc.co.uk/sitemaps/https-index-uk-news.xml"),
             Sitemap("https://www.bbc.co.uk/sitemaps/https-index-com-archive.xml", reverse=True),
         ],
         url_filter=regex_filter("video|live"),

--- a/src/fundus/publishers/uk/the_bbc.py
+++ b/src/fundus/publishers/uk/the_bbc.py
@@ -16,7 +16,7 @@ from fundus.parser.utility import (
 class TheBBCParser(ParserProxy):
     class V1(BaseParser):
         _subheadline_selector = XPath(
-            "//div[@data-component='subheadline-block' or contains(@class, 'ebmt73l0')]//*[self::h2 or (self::p and b and position()>1)]"
+            "//div[@data-component='subheadline-block' or @data-component='text-block' or contains(@class, 'ebmt73l0')]//*[self::h2 or (self::p and b and position()>1)]"
         )
         _summary_selector = XPath(
             "(//div[@data-component='text-block' or contains(@class, 'ebmt73l0')])[1] //p[b and position()=1]"

--- a/src/fundus/publishers/uk/the_bbc.py
+++ b/src/fundus/publishers/uk/the_bbc.py
@@ -15,12 +15,16 @@ from fundus.parser.utility import (
 
 class TheBBCParser(ParserProxy):
     class V1(BaseParser):
-        _subheadline_selector = CSSSelector("div[data-component='subheadline-block']")
-        _summary_selector = XPath("//div[@data-component='text-block'][1] //p[b]")
+        _subheadline_selector = XPath(
+            "//div[@data-component='subheadline-block' or contains(@class, 'ebmt73l0')]//*[self::h2 or (self::p and b and position()>1)]"
+        )
+        _summary_selector = XPath(
+            "(//div[@data-component='text-block' or contains(@class, 'ebmt73l0')])[1] //p[b and position()=1]"
+        )
         _paragraph_selector = XPath(
-            "//div[@data-component='text-block'][1]//p[not(b) and text()] |"
-            "//div[@data-component='text-block'][position()>1] //p[text()] |"
-            "//div[@data-component='text-block'] //ul /li[text()]"
+            "//div[@data-component='text-block' or contains(@class, 'ebmt73l0')][1]//p[not(b) and text()] |"
+            "//div[@data-component='text-block' or contains(@class, 'ebmt73l0')][position()>1] //p[text()] |"
+            "//div[@data-component='text-block' or contains(@class, 'ebmt73l0')] //ul /li[text()]"
         )
 
         _topic_selector = CSSSelector(


### PR DESCRIPTION
All the articles that were not in bbc.co.uk/news/ were not parsable uptil now. It probably wasn't noticed by now, since they are only accessible via the Sitemap.

Some examples are:

[www.bbc.com/sport/football/c62391rrpm9o](https://www.bbc.com/sport/football/articles/c62391rrpm9o)
[www.bbc.com/ukrainian/articles/c9q7n1l8zpdo](https://www.bbc.com/ukrainian/articles/c9q7n1l8zpdo)
[www.bbc.com/yoruba/articles/c5ydp87p2eqo](https://www.bbc.com/yoruba/articles/c5ydp87p2eqo)