### PR TITLE
Fix a bug returning `None` for empty values in `xpath_search`

### DIFF
--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -201,7 +201,7 @@ class LinkedDataMapping:
             xml = f"<result{i}>" + node2string(node) + f"</result{i}>"
             results.update(replace_keys_in_nested_dict(xmltodict.parse(xml), to_original_characters))
 
-        values = list(results.values())
+        values = list(filter(bool, results.values()))
 
         if scalar:
             if not values:


### PR DESCRIPTION
Previously, when parsing LDs including "empty" entries (i.e., `'authors': []`), `xpath_search` would return actual None values.
This PR fixes that behavior by filtering values on a boolean condition beforehand.