### PR TITLE
Remove Whitespace Normalization in image source parsing

### DIFF
--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -62,6 +62,7 @@ _ws_pattern: Pattern[str] = re.compile(rf'[{"".join(_space_characters.values())}
 
 
 def normalize_whitespace(text: str) -> str:
+    text = re.sub(r"\u202f", "", text)
     return re.sub(_ws_pattern, " ", text).strip()
 
 

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -62,7 +62,6 @@ _ws_pattern: Pattern[str] = re.compile(rf'[{"".join(_space_characters.values())}
 
 
 def normalize_whitespace(text: str) -> str:
-    text = re.sub(r"\u202f", "", text)
     return re.sub(_ws_pattern, " ", text).strip()
 
 
@@ -504,9 +503,9 @@ def parse_urls(node: lxml.html.HtmlElement) -> Optional[Dict[str, str]]:
         return sorted(strings, key=len)[-1]
 
     if srcset := cast(List[str], _srcset_selector(node)):
-        return parse_srcset(normalize_whitespace(get_longest_string(srcset)))
+        return parse_srcset(get_longest_string(srcset))
     elif src := cast(List[str], _src_selector(node)):
-        return {"1x": normalize_whitespace(get_longest_string(src))}
+        return {"1x": get_longest_string(src)}
     else:
         return None
 


### PR DESCRIPTION
The Publisher Coverage caught an error for this article: https://freebeacon.com/trump-administration/trump-slaps-tariffs-on-colombia-after-its-israel-bashing-marxist-president-rejects-us-deportation-flights/. It turns out that the reason is that the unicode symbol `\u202f` is embedded in the links of the second image, which for some implementations of regex (also apparently of the `re` package) is covered under `\s`, where as for others it is not leading to unpredictable behavior. I'm not really sure, whether to fix it or let this article slide. Then again, not sure how common the issue is. You can observe the issue here: https://regex101.com/r/rv9Zxp/1 You see this matcher does not find any matches (at least in Chrome), if you then go to regexr.com and use the pattern `\s` on this string: `  ` You will find that it will match 2 characters.