### PR TITLE
Fix article serialization for `images`

### DIFF
--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -9,7 +9,7 @@ from colorama import Fore, Style
 from fundus.logging import create_logger
 from fundus.parser import ArticleBody, Image
 from fundus.scraping.html import HTML
-from fundus.utils.serialization import JSONVal
+from fundus.utils.serialization import JSONVal, is_jsonable
 
 logger = create_logger(__name__)
 
@@ -133,7 +133,9 @@ class Article:
                 return v.serialize()  # type: ignore[no-any-return]
             elif isinstance(v, datetime):
                 return str(v)
-            raise TypeError(f"Attribute {attribute!r} of type {type(v)!r} is not JSON serializable")
+            elif not is_jsonable(v):
+                raise TypeError(f"Attribute {attribute!r} of type {type(v)!r} is not JSON serializable")
+            return v  # type: ignore[no-any-return]
 
         serialization: Dict[str, JSONVal] = {}
         for attribute in attributes:
@@ -144,7 +146,7 @@ class Article:
             if isinstance(value, list):
                 serialization[attribute] = [serialize(item) for item in value]
             else:
-                serialization[attribute] = value
+                serialization[attribute] = serialize(value)
 
         return serialization
 

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -336,6 +336,9 @@ class CrawlerBase(ABC):
         finally:
             session_handler.close_current_session()
             if save_to_file is not None:
+                if isinstance(save_to_file, str):
+                    save_to_file = Path(save_to_file)
+                save_to_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(save_to_file, "w", encoding="utf-8") as file:
                     logger.info(f"Writing crawled articles to {save_to_file!r}")
                     file.write(


### PR DESCRIPTION
There was a bug when serializing the `images` attribute described in #702. This PR provides a quick fix so that the `to_json` method also works for `images`.