### PR TITLE
Deprecate `TheTelegraph`

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -1968,7 +1968,9 @@
         <code>TheTelegraph</code>
       </td>
       <td>
-        <div>The Telegraph</div>
+        <div>
+          <strike>The Telegraph</strike>
+        </div>
       </td>
       <td>
         <a href="https://www.telegraph.co.uk/">

--- a/src/fundus/publishers/uk/__init__.py
+++ b/src/fundus/publishers/uk/__init__.py
@@ -59,6 +59,7 @@ class UK(metaclass=PublisherGroup):
             Sitemap("https://www.telegraph.co.uk/sitemap.xml"),
             NewsMap("https://www.telegraph.co.uk/custom/daily-news/sitemap.xml"),
         ],
+        deprecated=True,
     )
 
     iNews = Publisher(


### PR DESCRIPTION
The sitemaps of `TheTelegraph` are no longer reachable by `Fundus`