### PR TITLE
Extend timeout in publisher coverage

### DIFF
--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -15,7 +15,7 @@ from fundus.scraping.article import Article
 
 def main() -> None:
     failed: int = 0
-    timeout_in_seconds: int = 20
+    timeout_in_seconds: int = 30
 
     publisher_regions: List[PublisherGroup] = sorted(
         PublisherCollection.get_subgroup_mapping().values(), key=lambda region: region.__name__


### PR DESCRIPTION
The Tanzanian publishers at least need a larger timeout. They fail, because the Sitemaps take too long to load. Since this may also apply to other publishers, I would suggest bumping up the timout.