### PR TITLE
Properly release resources  

### DIFF
--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -95,6 +95,9 @@ class WebScraper(BaseScraper):
         parser_mapping: Dict[str, ParserProxy] = {publisher.name: publisher.parser}
         super().__init__(*html_sources, parser_mapping=parser_mapping)
 
+        WebSource.__EVENTS__.register_event("stop", publisher.name)
+        WebSource.__EVENTS__.register_event("bridge", publisher.name)
+
 
 class CCNewsScraper(BaseScraper):
     def __init__(self, source: CCNewsSource):

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -1,0 +1,80 @@
+import threading
+from collections import defaultdict
+from typing import Any, Dict, Optional, Union
+
+from fundus.logging import create_logger
+
+logger = create_logger(__name__)
+
+
+class EventDict:
+    """A threadsafe event dictionary"""
+
+    def __init__(self):
+        self._events: Dict[int, Dict[str, threading.Event]] = defaultdict(dict)
+        self._aliases: Dict[Any, int] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _get_identifier() -> int:
+        return threading.get_ident()
+
+    def _resolve(self, key: Union[int, str, None]) -> int:
+        """Resolves a given key to a thread identifier
+
+        Should only be used within a Lock!
+
+        Args:
+            key: Key to resolve
+
+        Returns:
+            Resolved thread identifier
+        """
+        if key is None:
+            return self._get_identifier()
+        if isinstance(key, int):
+            return key
+        return self._aliases[key]
+
+    def _alias(self, alias: str, key: Optional[int] = None):
+        self._aliases[alias] = key if key else self._get_identifier()
+        logger.debug(f"Registered alias {alias} -> {self._aliases[alias]}")
+
+    def register_event(self, event: str, key: Union[int, str, None] = None):
+        with self._lock:
+            if isinstance(key, str) and key not in self._aliases:
+                self._alias(key)
+            if (resolved := self._resolve(key)) not in self._events:
+                self._events[resolved][event] = threading.Event()
+            logger.debug(f"Registered event {event!r} for {resolved}")
+
+    def set_event(self, event: str, key: Union[int, str, None] = None):
+        with self._lock:
+            self._events[self._resolve(key)][event].set()
+            logger.debug(f"Set event {event!r} for {self._resolve(key)}")
+
+    def set_all(self, event: Optional[str] = None):
+        with self._lock:
+            for events in self._events.values():
+                if event is not None and event not in events:
+                    events[event].set()
+                else:
+                    for flag in events.values():
+                        flag.set()
+
+    def clear_all(self, event: Optional[str] = None):
+        with self._lock:
+            for events in self._events.values():
+                if event is not None and event not in events:
+                    events[event].set()
+                else:
+                    for flag in events.values():
+                        flag.clear()
+
+    def is_event_set(self, event: str, key: Union[int, str, None] = None) -> bool:
+        with self._lock:
+            return self._events[self._resolve(key)][event].is_set()
+
+    def alias(self, alias: str, key: Optional[int] = None):
+        with self._lock:
+            self._alias(alias, key)


### PR DESCRIPTION
This PR addresses a longstanding issue with the Crawler class. Previously, when exiting the ThreadPool, individual publisher threads were not properly closed. As a result, joining the pool required waiting for every URLSource to fully exhaust. This update introduces an event-based system, allowing events to be registered in a thread-safe dictionary and checked within threads. Additionally, the WebSource class now includes EventDict as a class attribute, allowing the main thread to terminate individual web sources more effectively.