### PR TITLE
Docs: Fix date_filter example

### DIFF
--- a/docs/4_how_to_filter_articles.md
+++ b/docs/4_how_to_filter_articles.md
@@ -70,10 +70,10 @@ If a filter returns True on a specific element the element will be dropped.
 #### Some more extraction filter examples:
 
 ````python
-# only select articles from the past seven days
+# only select articles that are >= 1 week old but <= 3 weeks old
 def date_filter(extracted: Dict[str, Any]) -> bool:
     end_date = datetime.date.today() - datetime.timedelta(weeks=1)
-    start_date = end_date - datetime.timedelta(weeks=1)
+    start_date = end_date - datetime.timedelta(weeks=2)
     if publishing_date := extracted.get("publishing_date"):
         return not (start_date <= publishing_date.date() <= end_date)
     return True


### PR DESCRIPTION
When this updated `date_filter` example is run on 2025-03-09, the window of time that will be included is 2025-02-16 to 2025-03-02 (inclusive). The previous example code included 2025-02-23 to 2025-03-02, but the comment described it in such a way that it sounded like it would be 2025-03-02 to 2025-03-09.

- Updates comment describing what the `date_filter` example does
- Changes one of the provided numbers in the `date_filter` example for clarity
