### PR TITLE
add url_filter to voa

### DIFF
--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -230,6 +230,7 @@ class US(metaclass=PublisherGroup):
         name="Voice Of America",
         domain="https://www.voanews.com/",
         parser=VOAParser,
+        url_filter=inverse(regex_filter(r"voanews\.com\/a\/[a-z-]+\/[0-9]+\.html")),
         sources=[
             NewsMap("https://www.voanews.com/sitemap_415_news.xml.gz"),
             Sitemap(

--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -232,7 +232,6 @@ class US(metaclass=PublisherGroup):
         parser=VOAParser,
         url_filter=inverse(regex_filter(r"voanews\.com\/a\/[a-z-]+\/[0-9]+\.html")),
         sources=[
-            NewsMap("https://www.voanews.com/sitemap_415_news.xml.gz"),
             Sitemap(
                 "https://www.voanews.com/sitemap.xml", sitemap_filter=inverse(regex_filter(r"sitemap_[\d_]*\.xml\.gz"))
             ),


### PR DESCRIPTION
This PR:
- removes the NewsMap that only contains irrelevant pages
- filters the irrelevant pages from the remaining sitemaps
The pages filtered are similar to this page: https://voanews.com/a/8003948.html (will be redirected)