### PR TITLE
add url_filter and RSSFeeds

### DIFF
--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -91,9 +91,20 @@ class US(metaclass=PublisherGroup):
         name="Fox News",
         domain="https://www.foxnews.com/",
         parser=FoxNewsParser,
+        url_filter=regex_filter(r"\/video\/"),
         sources=[
             Sitemap("https://www.foxnews.com/sitemap.xml", sitemap_filter=inverse(regex_filter("type=articles"))),
             NewsMap("https://www.foxnews.com/sitemap.xml?type=news"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/latest.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/world.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/politics.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/us.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/world.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/travel.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/opinion.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/tech.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/science.xml"),
+            RSSFeed("https://moxie.foxnews.com/google-publisher/health.xml"),
         ],
     )
 


### PR DESCRIPTION
This PR:
- adds a url_filter to remove video only pages
- adds RSSFeeds because the Sitemap and NewsMap only contain video only pages as of now