### PR TITLE
Update author extraction for ˋJyllandsPostenˋ

### DIFF
--- a/src/fundus/publishers/dk/jyllands_posten.py
+++ b/src/fundus/publishers/dk/jyllands_posten.py
@@ -52,7 +52,9 @@ class JyllandsPostenParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.bf_search("author"))
+            return generic_author_parsing(
+                self.precomputed.ld.bf_search("author") or self.precomputed.meta.get("author"), split_on=["/"]
+            )
 
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:


### PR DESCRIPTION
This PR adds the meta attribute ˋauthorˋ as a fallback in author parsing for the publisher ˋJyllandsPostenˋ.