### PR TITLE
Bug Fixes - Events

### DIFF
--- a/scripts/generate_parser_test_files.py
+++ b/scripts/generate_parser_test_files.py
@@ -20,6 +20,7 @@ logger = create_logger(__name__)
 
 
 def get_test_article(publisher: Publisher, url: Optional[str] = None) -> Optional[Article]:
+    WebSource.__EVENTS__.register_event("stop", publisher.name)
     if url is not None:
         source = WebSource([url], publisher=publisher)
         scraper = BaseScraper(source, parser_mapping={publisher.name: publisher.parser})

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -147,7 +147,8 @@ class WebSource:
         def filter_url(u: str) -> bool:
             return any(f(u) for f in combined_filters)
 
-        while not self._is_stopped and (url := next(iter(self.url_source), None)) is not None:
+        url_iterator = iter(self.url_source)
+        while not self._is_stopped and (url := next(url_iterator, None)) is not None:
             if not validators.url(url):
                 logger.debug(f"Skipped requested URL {url!r} because the URL is malformed")
                 continue


### PR DESCRIPTION
This PR fixes:
- the bug, where the source iterator is recreated with every iteration resulting in a new iterator. This leads to only ever one article being crawled.
- a missing event registration causing a crash in the test file generation