### PR TITLE
Remove unsued imports

### DIFF
--- a/src/fundus/publishers/au/west_australian.py
+++ b/src/fundus/publishers/au/west_australian.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/src/fundus/publishers/be/__init__.py
+++ b/src/fundus/publishers/be/__init__.py
@@ -1,6 +1,6 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.publishers.be.nieuwsblad import NieuwsbladParser
-from fundus.scraping.url import RSSFeed, Sitemap
+from fundus.scraping.url import RSSFeed
 
 
 class BE(metaclass=PublisherGroup):

--- a/src/fundus/publishers/cz/seznamzpravy.py
+++ b/src/fundus/publishers/cz/seznamzpravy.py
@@ -2,7 +2,6 @@ import datetime
 import re
 from typing import List, Optional, Pattern
 
-from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute

--- a/src/fundus/publishers/de/br.py
+++ b/src/fundus/publishers/de/br.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/src/fundus/publishers/de/dw.py
+++ b/src/fundus/publishers/de/dw.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Pattern
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import (
     apply_substitution_pattern_over_list,
     extract_article_body_with_selector,
@@ -13,7 +13,6 @@ from fundus.parser.utility import (
     generic_date_parsing,
     generic_text_extraction_with_css,
     generic_topic_parsing,
-    image_extraction,
     strip_nodes_to_text,
 )
 

--- a/src/fundus/publishers/de/heise.py
+++ b/src/fundus/publishers/de/heise.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from typing import List, Optional
 

--- a/src/fundus/publishers/de/hessenschau.py
+++ b/src/fundus/publishers/de/hessenschau.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from typing import List, Optional
 

--- a/src/fundus/publishers/de/netzpolitik_org.py
+++ b/src/fundus/publishers/de/netzpolitik_org.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/src/fundus/publishers/de/sz.py
+++ b/src/fundus/publishers/de/sz.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/src/fundus/publishers/es/abc.py
+++ b/src/fundus/publishers/es/abc.py
@@ -8,7 +8,6 @@ from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
-    generic_topic_parsing,
     image_extraction,
 )
 

--- a/src/fundus/publishers/ind/__init__.py
+++ b/src/fundus/publishers/ind/__init__.py
@@ -1,7 +1,7 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.publishers.ind.bhaskar import BhaskarParser
 from fundus.publishers.ind.times_of_india import TimesOfIndiaParser
-from fundus.scraping.url import NewsMap, RSSFeed, Sitemap
+from fundus.scraping.url import NewsMap, RSSFeed
 
 
 class IND(metaclass=PublisherGroup):

--- a/src/fundus/publishers/it/__init__.py
+++ b/src/fundus/publishers/it/__init__.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Optional
 
 from dateutil.rrule import MONTHLY, rrule
 

--- a/src/fundus/publishers/it/il_giornale.py
+++ b/src/fundus/publishers/it/il_giornale.py
@@ -4,10 +4,9 @@ from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath, tostring
-from lxml.html import HtmlElement, document_fromstring
+from lxml.html import document_fromstring
 
 from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
-from fundus.parser.data import ImageVersion
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,

--- a/src/fundus/publishers/no/dagbladet.py
+++ b/src/fundus/publishers/no/dagbladet.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath

--- a/src/fundus/publishers/no/nettavisen.py
+++ b/src/fundus/publishers/no/nettavisen.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/src/fundus/publishers/pl/rzeczpospolita.py
+++ b/src/fundus/publishers/pl/rzeczpospolita.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.etree import XPath

--- a/src/fundus/publishers/shared/euronews.py
+++ b/src/fundus/publishers/shared/euronews.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from typing import List, Optional
 

--- a/src/fundus/publishers/tz/__init__.py
+++ b/src/fundus/publishers/tz/__init__.py
@@ -1,6 +1,6 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.scraping.filter import inverse, regex_filter
-from fundus.scraping.url import NewsMap, RSSFeed, Sitemap
+from fundus.scraping.url import Sitemap
 
 from .daily_news_tz import DailyNewsTZParser
 

--- a/src/fundus/publishers/us/cnbc.py
+++ b/src/fundus/publishers/us/cnbc.py
@@ -4,13 +4,12 @@ from typing import List, Optional
 from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
-from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
+from fundus.parser import ArticleBody, BaseParser, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
     generic_topic_parsing,
-    image_extraction,
 )
 
 

--- a/src/fundus/publishers/us/fox_news.py
+++ b/src/fundus/publishers/us/fox_news.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/src/fundus/publishers/us/free_beacon.py
+++ b/src/fundus/publishers/us/free_beacon.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector
-from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (

--- a/src/fundus/publishers/us/la_times.py
+++ b/src/fundus/publishers/us/la_times.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/src/fundus/publishers/us/the_gateway_pundit.py
+++ b/src/fundus/publishers/us/the_gateway_pundit.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from typing import List, Optional
 

--- a/src/fundus/publishers/us/the_new_yorker.py
+++ b/src/fundus/publishers/us/the_new_yorker.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from typing import List, Optional
 

--- a/src/fundus/publishers/us/wired.py
+++ b/src/fundus/publishers/us/wired.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from typing import List, Optional
 
 from lxml.cssselect import CSSSelector

--- a/tests/test_publisher_collection.py
+++ b/tests/test_publisher_collection.py
@@ -1,7 +1,7 @@
 import pytest
 
 from fundus import PublisherCollection
-from fundus.publishers import Publisher, PublisherGroup
+from fundus.publishers import PublisherGroup
 
 
 @pytest.mark.parametrize(

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -3,7 +3,7 @@ import gzip
 import json
 import os
 import subprocess
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar
 


### PR DESCRIPTION
A minor clean up of the code base removing unused imports from `./src`, `./tests`, and `./scripts`