### PR TITLE
Fix `Focus` sources

### DIFF
--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -151,7 +151,9 @@ class DE(metaclass=PublisherGroup):
         name="Focus Online",
         domain="https://www.focus.de/",
         parser=FocusParser,
-        sources=[RSSFeed("https://rss.focus.de/fol/XML/rss_folnews.xml")],
+        sources=[
+            NewsMap("https://www.focus.de/sitemap_news_ressorts.xml"),
+        ],
         request_header={"user-agent": "Fundus"},
     )
 


### PR DESCRIPTION
@addie9800 Just to add—since this publisher no longer supports `topics`, it might be worth implementing a way to expire specific attributes instead of creating a new version. Maybe you'd like to give it a try?