### PR TITLE
Bug Fix in Source Restriction

### DIFF
--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -82,7 +82,11 @@ class WebScraper(BaseScraper):
     ):
         if restrict_sources_to:
             url_sources = tuple(
-                more_itertools.flatten(publisher.source_mapping[source_type] for source_type in restrict_sources_to)
+                more_itertools.flatten(
+                    publisher.source_mapping[source_type]
+                    for source_type in restrict_sources_to
+                    if source_type in publisher.source_mapping
+                )
             )
         else:
             url_sources = tuple(more_itertools.flatten(publisher.source_mapping.values()))


### PR DESCRIPTION
This bug causes Fundus to crash, when `restrict_sources_to` contains a `URLSource` which is not supported by one of the publishers. This PR handles that case. 