### PR TITLE
Adjust `ZDFParser` to be more suitable for live tickers

### DIFF
--- a/src/fundus/publishers/de/zdf.py
+++ b/src/fundus/publishers/de/zdf.py
@@ -16,8 +16,8 @@ from fundus.parser.utility import (
 class ZDFParser(ParserProxy):
     class V1(BaseParser):
         _paragraph_selector = CSSSelector("div.r1nj4qn5")
-        _summary_selector = CSSSelector("p.ikh9v7p.c1bdz7f4")
-        _subheadlines_selector = CSSSelector("h2.t1rbo974.hhhtovw")
+        _summary_selector = CSSSelector("p.c1bdz7f4")
+        _subheadlines_selector = CSSSelector("h2.hhhtovw")
 
         @attribute
         def body(self) -> Optional[ArticleBody]:


### PR DESCRIPTION
The previous selectors couldn't parse the `summary` and `subheadline` nodes for articles like [this](https://www.zdf.de/nachrichten/politik/ausland/ukraine-russland-konflikt-blog-102.html).