### PR TITLE
Update publisher_coverage.yaml

### DIFF
--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -29,10 +29,10 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          exec python scripts/publisher_coverage.py | tee publisher_coverage.txt
+          python scripts/publisher_coverage.py | tee publisher_coverage.txt
 
       - name: Upload Coverage Report
-        if: success() || failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: Publisher Coverage


### PR DESCRIPTION
In the past couple of days the publisher_coverage has timed out every once in a while. I tried reproducing it locally, but there it worked just fine. To make debugging easier, I propose to always upload the report, not just if failed or success. (Timeout or Cancellation do not trigger the saving process). Also, if there is no reason to use exec, I would suggest running it in the shell, because the logging runs smoother. From my understanding, if you use `exec`, you need to wait for the script to finish before the output is piped. Hence the suggestion to run the script directly.