### PR TITLE
Update publisher_coverage.yaml

### DIFF
--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   validate_crawlers:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Set up Git repository


### PR DESCRIPTION
Usually the publisher coverage needs ~10 minutes to run. If it runs for 30 minutes, it will most likely not finish. By manually setting a timeout, we avoid GitHub killing the action and will get the output of the script in any case.