### PR TITLE
Bug Fixes from Publisher Coverage

### DIFF
--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -30,7 +30,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          python scripts/publisher_coverage.py | tee publisher_coverage.txt
+          timeout 25m python -u scripts/publisher_coverage.py | tee publisher_coverage.txt
 
       - name: Upload Coverage Report
         if: always()

--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -28,9 +28,11 @@ jobs:
       - name: Validate Crawlers
         env:
           PYTHONPATH: .
+        # Set up a timeout to avoid long-running tests
+        # We skip the Kicker APNews publishers, because they are IP-blocked
         run: |
           set -o pipefail
-          timeout 25m python -u scripts/publisher_coverage.py --skip | tee publisher_coverage.txt
+          timeout 25m python -u scripts/publisher_coverage.py --skip Kicker APNews | tee publisher_coverage.txt
 
       - name: Upload Coverage Report
         if: always()

--- a/.github/workflows/publisher_coverage.yaml
+++ b/.github/workflows/publisher_coverage.yaml
@@ -30,7 +30,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          timeout 25m python -u scripts/publisher_coverage.py | tee publisher_coverage.txt
+          timeout 25m python -u scripts/publisher_coverage.py --skip | tee publisher_coverage.txt
 
       - name: Upload Coverage Report
         if: always()

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -13,6 +13,7 @@ from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.scraping.article import Article
 from fundus.scraping.session import socket_timeout
 
+_blocked_publishers: List[str] = ["Associated Press News", "Kicker"]
 
 def main() -> None:
     failed: int = 0
@@ -37,6 +38,9 @@ def main() -> None:
                     continue
                 if publisher.deprecated:  # type: ignore[attr-defined]
                     print(f"⏩  SKIPPED: {publisher_name!r} - Deprecated")
+                    continue
+                if publisher_name in _blocked_publishers:
+                    print(f"⏩  SKIPPED: {publisher_name!r} - Blocked")
                     continue
                 crawler: Crawler = Crawler(publisher, delay=0.4, ignore_robots=True)
 

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -15,6 +15,7 @@ from fundus.scraping.session import socket_timeout
 
 _blocked_publishers: List[str] = ["Associated Press News", "Kicker"]
 
+
 def main() -> None:
     failed: int = 0
     timeout_in_seconds: int = 30

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -15,7 +15,6 @@ from fundus.scraping.article import Article
 from fundus.scraping.session import socket_timeout
 
 
-
 def main() -> None:
     failed: int = 0
     timeout_in_seconds: int = 30

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -6,6 +6,7 @@ Note that this script does not check the attributes' correctness, only their pre
 """
 import sys
 import traceback
+from argparse import ArgumentParser
 from typing import Any, Callable, List, Optional, Union
 
 from fundus import Crawler, PublisherCollection
@@ -19,6 +20,15 @@ _blocked_publishers: List[str] = ["Associated Press News", "Kicker"]
 def main() -> None:
     failed: int = 0
     timeout_in_seconds: int = 30
+
+    argument_parser = ArgumentParser()
+    argument_parser.add_argument(
+        "-s",
+        "--skip",
+        default=False,
+        action="store_true",
+    )
+    parsed_arguments = argument_parser.parse_args()
 
     publisher_regions: List[PublisherGroup] = sorted(
         PublisherCollection.get_subgroup_mapping().values(), key=lambda region: region.__name__
@@ -40,7 +50,7 @@ def main() -> None:
                 if publisher.deprecated:  # type: ignore[attr-defined]
                     print(f"⏩  SKIPPED: {publisher_name!r} - Deprecated")
                     continue
-                if publisher_name in _blocked_publishers:
+                if publisher_name in _blocked_publishers and parsed_arguments.skip:
                     print(f"⏩  SKIPPED: {publisher_name!r} - Blocked")
                     continue
                 crawler: Crawler = Crawler(publisher, delay=0.4, ignore_robots=True)

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -14,7 +14,6 @@ from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.scraping.article import Article
 from fundus.scraping.session import socket_timeout
 
-_blocked_publishers: List[str] = ["Associated Press News", "Kicker"]
 
 
 def main() -> None:
@@ -25,8 +24,9 @@ def main() -> None:
     argument_parser.add_argument(
         "-s",
         "--skip",
-        default=False,
-        action="store_true",
+        default=[],
+        nargs="*",
+        help="List of publishers to skip. Expects Fundus attribute names.",
     )
     parsed_arguments = argument_parser.parse_args()
 
@@ -50,7 +50,7 @@ def main() -> None:
                 if publisher.deprecated:  # type: ignore[attr-defined]
                     print(f"⏩  SKIPPED: {publisher_name!r} - Deprecated")
                     continue
-                if publisher_name in _blocked_publishers and parsed_arguments.skip:
+                if publisher.__name__ in parsed_arguments.skip:
                     print(f"⏩  SKIPPED: {publisher_name!r} - Blocked")
                     continue
                 crawler: Crawler = Crawler(publisher, delay=0.4, ignore_robots=True)

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -189,7 +189,7 @@ def sanitize_json(text: str) -> Optional[str]:
 
     # substitute "bad" values
     sanitized = re.sub(_json_undefined, r"\g<key>:null", sanitized)
-    sanitized = re.sub(r"[\n\t]+", "", sanitized)
+    sanitized = re.sub(r"[\r\n\t]+", "", sanitized)
     return sanitized
 
 

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -189,7 +189,7 @@ def sanitize_json(text: str) -> Optional[str]:
 
     # substitute "bad" values
     sanitized = re.sub(_json_undefined, r"\g<key>:null", sanitized)
-
+    sanitized = re.sub(r"[\n\t]+", "", sanitized)
     return sanitized
 
 

--- a/src/fundus/scraping/session.py
+++ b/src/fundus/scraping/session.py
@@ -56,6 +56,7 @@ class InterruptableSession(requests.Session):
             except Empty:
                 if __EVENTS__.is_event_set("stop"):
                     logger.debug(f"Interrupt request for {url!r}")
+                    response_queue.task_done()
                     exit(1)
             else:
                 if isinstance(response, Exception):

--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -185,7 +185,7 @@ class Sitemap(URLSource):
                 )
                 return
 
-            content = response.content
+            content = response.content.strip()
             if (content_type := response.headers.get("content-type")) in self._decompressor.supported_file_formats:
                 try:
                     content = self._decompressor.decompress(content, content_type)

--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Callable, ClassVar, Dict, Iterable, Iterator, List, Optional, Set
+from urllib.parse import unquote
 
 import feedparser
 import lxml.html
@@ -90,6 +91,10 @@ class _ArchiveDecompressor:
         return list(self.archive_mapping.keys())
 
 
+def clean_url(url: str) -> str:
+    return unquote(url)
+
+
 @dataclass
 class URLSource(Iterable[str], ABC):
     url: str
@@ -147,7 +152,9 @@ class RSSFeed(URLSource):
             logger.warning(f"Warning! Couldn't parse rss feed {self.url!r} because of {exception}")
             return
         else:
-            yield from filter(bool, (entry.get("link") for entry in rss_feed["entries"]))
+            urls = filter(bool, (entry.get("link") for entry in rss_feed["entries"]))
+            for url in urls:
+                yield clean_url(url)
 
 
 @dataclass
@@ -192,7 +199,7 @@ class Sitemap(URLSource):
             urls = generic_nodes_to_text(self._url_selector(tree), normalize=True)
             if urls:
                 for new_url in reversed(urls) if self.reverse else urls:
-                    yield new_url
+                    yield clean_url(new_url)
             elif self.recursive:
                 sitemap_locs = [node.text_content() for node in self._sitemap_selector(tree)]
                 filtered_locs = list(filter(inverse(self.sitemap_filter), sitemap_locs))


### PR DESCRIPTION
During the debugging of the publisher coverage, several issues arose:
- We spend unnecessary amount of time crawling publishers in the publisher coverage, where the action bot is blocked
- We cannot deal with urls that are of the form `www.test.de%2Fthis-is-the-site.html` 
- We cannot properly parse JSON with line breaks within strings (occurs when crawling `FreiePresse`).
This PR adresses these three issues.

Update:

The final commit adds the following further changes:
- Call `task_done()` on `response_queue` solving the main deadlock issue
- Fixes a bug, where if a sitemap only contains a newline character, it is not detected as an empty sitemap, causing Fundus to crash
- Moves the `pool` out of the context manager setup, because the later call of `pool.join()` can cause unexpected behavior, since it is implicitly called when exiting the context manager. To maintain control, I decided to handle it manually
- Modifies the `publisher_coverage.yaml` to let the shell timeout the program before it is killed by GitHub allowing the output of the program to still be recorded and accessible at a later point