### PR TITLE
Deprecate ˋNikkeiˋ

### DIFF
--- a/src/fundus/publishers/jp/__init__.py
+++ b/src/fundus/publishers/jp/__init__.py
@@ -85,7 +85,7 @@ class JP(metaclass=PublisherGroup):
                 sitemap_filter=inverse(regex_filter(r"[a-z]*\.sitemap\.xml$")),
             )
         ],
-        deprecated=True
+        deprecated=True,
     )
 
     SankeiShimbun = Publisher(

--- a/src/fundus/publishers/jp/__init__.py
+++ b/src/fundus/publishers/jp/__init__.py
@@ -85,6 +85,7 @@ class JP(metaclass=PublisherGroup):
                 sitemap_filter=inverse(regex_filter(r"[a-z]*\.sitemap\.xml$")),
             )
         ],
+        deprecated=True
     )
 
     SankeiShimbun = Publisher(

--- a/src/fundus/publishers/jp/nikkei.py
+++ b/src/fundus/publishers/jp/nikkei.py
@@ -18,7 +18,7 @@ from fundus.parser.utility import (
 class NikkeiParser(ParserProxy):
     class V1(BaseParser):
         _summary_selector = XPath(
-            "//section[@class='container_campx13']//*[self::div and @class='container_c1tzahnc' and position()=1] "
+            "//section[@class='container_campx13']//*[self::div and @class='container_c1tzahnc' and position()=1]"
         )
         _paragraph_selector = CSSSelector("section[data-track-article-content] > p")
         _subheadline_selector = CSSSelector("section[data-track-article-content] > div > h2")

--- a/src/fundus/publishers/jp/nikkei.py
+++ b/src/fundus/publishers/jp/nikkei.py
@@ -18,7 +18,7 @@ from fundus.parser.utility import (
 class NikkeiParser(ParserProxy):
     class V1(BaseParser):
         _summary_selector = XPath(
-            "//section[@class='container_campx13']//*[self::div and @class='container_c1tzahnc' and position()=1]"
+            "//section[@class='container_campx13']//*[self::div and @class='container_c1tzahnc' and position()=1] "
         )
         _paragraph_selector = CSSSelector("section[data-track-article-content] > p")
         _subheadline_selector = CSSSelector("section[data-track-article-content] > div > h2")


### PR DESCRIPTION
As it seems, there no longer a sitemap available, that we can use. Also no RSSFeeds and NewsMaps available anymore. Please double-check whether you can find anything, I was unable to. There are some for subdomains, such as asia.nikkei.com, but they have a completely different layout, which would require a completely new parser.