### PR TITLE
Add logging for source restriction

### DIFF
--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -488,6 +488,12 @@ class Crawler(CrawlerBase):
             ignore_robots=self.ignore_robots,
             ignore_crawl_delay=self.ignore_crawl_delay,
         )
+        if not scraper.sources and self.restrict_sources_to:
+            logger.warning(
+                f"No sources of type {[source_type.__name__ for source_type in self.restrict_sources_to]} found for publisher {publisher.name}. "
+                f"Skipping publisher."
+            )
+            return
         yield from scraper.scrape(error_handling, extraction_filter, url_filter, language_filter)
 
     @staticmethod


### PR DESCRIPTION
```
from fundus import PublisherCollection, Crawler
crawler = Crawler(PublisherCollection.us.FreeBeacon, restrict_sources_to=[NewsMap, RSSFeed])
for article in crawler.crawl(max_articles=10, only_complete=False):
    print(article)
```
The code above will exit without any output with the current Fundus version. This leads to quite a headache, when debugging, which is why I propose adding a warning-level log if a publisher is found to not have any sources that fit the specified filters.