### PR TITLE
Deprecate `TheNamibian`

### DIFF
--- a/src/fundus/publishers/na/__init__.py
+++ b/src/fundus/publishers/na/__init__.py
@@ -21,4 +21,5 @@ class NA(metaclass=PublisherGroup):
                 languages={"en", "kj"},
             ),
         ],
+        deprecated=True,
     )


### PR DESCRIPTION
The Namibian now uses CloudFlare to block bots from crawling the Sitemap