### PR TITLE
Update error message

### DIFF
--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -844,7 +844,7 @@ def parse_image_nodes(
                 position=position,
             )
         except ImageURLError:
-            logger.debug(f"Skipping lazy loading image")
+            logger.debug(f"Skipping lazy loading image. Does publisher use relative URLs?")
         else:
             yield image
 

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -843,8 +843,11 @@ def parse_image_nodes(
                 is_cover=is_cover,
                 position=position,
             )
-        except ImageURLError:
-            logger.debug(f"Skipping lazy loading image. Does publisher use relative URLs?")
+        except ImageURLError as error:
+            if node.attrib.get("loading") == "lazy":
+                logger.debug(f"Skipping lazy loading image")
+            else:
+                logger.debug(error)
         else:
             yield image
 


### PR DESCRIPTION
This PR updates the error message to also hint at a possible alternative issue causing the exception to be raised. This is particularly relevant to the process of adding/updating publishers. If a publisher unexpectedly used relative URLs, then the exception will be handled with this misleading error message leaving contributers unsure of why the image_extraction is not working.