### PR TITLE
Fix author parsing for `NDR`

### DIFF
--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -60,7 +60,8 @@ class LinkedDataMapping:
     """
 
     __UNKNOWN_TYPE__ = "UNKNOWN_TYPE"
-    __xml_transformation_table__ = {":": "U003A", "*": "U002A", "@": "U0040"}
+    __to_transform__ = [":", "*", "@"]
+    __xml_transformation_table__ = {char: f"U{ord(char):04X}" for char in __to_transform__}
 
     def __init__(self, lds: Iterable[Dict[str, Any]] = ()):
         for ld in lds:

--- a/src/fundus/publishers/de/ndr.py
+++ b/src/fundus/publishers/de/ndr.py
@@ -70,7 +70,7 @@ class NDRParser(ParserProxy):
         _subheadline_selector = XPath("//article/h2")
         _summary_selector = XPath("//header/p[@class='preface']")
 
-        _bloat_keywords = ["hh", "regionalmeldungen", "News", "kurzmeldungen"]
+        _bloat_keywords = ["hh", "regionalmeldungen", "News", "kurzmeldungen", "Nachrichten", "aktuell"]
 
         @attribute
         def topics(self) -> List[str]:

--- a/src/fundus/publishers/de/ndr.py
+++ b/src/fundus/publishers/de/ndr.py
@@ -45,7 +45,7 @@ class NDRParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.ld.bf_search("author"))
+            return generic_author_parsing(self.precomputed.ld.xpath_search("(//Article | //NewsArticle) /author"))
 
         @attribute
         def title(self) -> Optional[str]:


### PR DESCRIPTION
Fix author parsing for articles that contain nested lists as authors [[1]](https://www.ndr.de/geschichte/koepfe/lydia-und-josef-russnak-das-musikkonservatorium-oder-ich,russnak-100.html).