### PR TITLE
Fix publisher alias lifetime in `EventDict`

### DIFF
--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -135,6 +135,28 @@ def get_execution_context():
         return thread.name, thread.ident
 
 
+def publisher_context_wrapper(func: Callable[[Publisher], None]) -> Callable[[Publisher], None]:
+    """Wraps a callable to register an ``__EVENTS__`` alias context for the publisher argument.
+
+    The alias is entered as the very first thing the thread does and stays alive for the
+    entire call — including any exception handling in the caller — so that
+    ``__EVENTS__.get_alias`` always resolves while the thread is running.
+
+    Args:
+        func: A callable whose first positional argument is a :class:`Publisher`.
+
+    Returns:
+        The wrapped callable.
+    """
+
+    @wraps(func)
+    def wrapper(publisher: Publisher) -> None:
+        with __EVENTS__.context(publisher.name):
+            func(publisher)
+
+    return wrapper
+
+
 def queue_wrapper(
     queue: Queue[Union[_T, Exception]],
     target: Callable[_P, Iterator[_T]],
@@ -533,23 +555,20 @@ class Crawler(CrawlerBase):
             else:
                 raise TypeError("param <delay> of <Crawler.__init__>")
 
-        # we "register" the thread in the event dict as soon as possible to avoid that a thread is registered
-        # after the pool already is shutting down
-        with __EVENTS__.context(publisher.name):
-            scraper = WebScraper(
-                publisher,
-                self.restrict_sources_to,
-                build_delay(),
-                ignore_robots=self.ignore_robots,
-                ignore_crawl_delay=self.ignore_crawl_delay,
+        scraper = WebScraper(
+            publisher,
+            self.restrict_sources_to,
+            build_delay(),
+            ignore_robots=self.ignore_robots,
+            ignore_crawl_delay=self.ignore_crawl_delay,
+        )
+        if not scraper.sources and self.restrict_sources_to:
+            logger.warning(
+                f"No sources of type {[source_type.__name__ for source_type in self.restrict_sources_to]} "
+                f"found for publisher {publisher.name}. Skipping publisher."
             )
-            if not scraper.sources and self.restrict_sources_to:
-                logger.warning(
-                    f"No sources of type {[source_type.__name__ for source_type in self.restrict_sources_to]} "
-                    f"found for publisher {publisher.name}. Skipping publisher."
-                )
-                return
-            yield from scraper.scrape(error_handling, extraction_filter, url_filter, language_filter)
+            return
+        yield from scraper.scrape(error_handling, extraction_filter, url_filter, language_filter)
 
     @staticmethod
     def _single_crawl(
@@ -575,7 +594,9 @@ class Crawler(CrawlerBase):
                 logger.debug("Shutdown done")
 
         result_queue: Queue[Union[Article, Exception]] = Queue(len(publishers))
-        wrapped_article_task = queue_wrapper(result_queue, article_task, silenced_exceptions=(CrashThread,))
+        wrapped_article_task = publisher_context_wrapper(
+            queue_wrapper(result_queue, article_task, silenced_exceptions=(CrashThread,))
+        )
 
         with session_handler.context(POOL_CONNECTIONS=len(publishers)), _manage_pool(
             processes=len(publishers) or None

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -422,7 +422,7 @@ class CrawlerBase(ABC):
             callback = None
 
         try:
-            with __EVENTS__.context("main-thread"), Timeout(
+            with __EVENTS__.main_context("main-thread"), Timeout(
                 seconds=timeout, silent=True, callback=callback, disable=timeout <= 0
             ) as timer:
                 for article in self._build_article_iterator(

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -65,6 +65,8 @@ from fundus.utils.timeout import Timeout
 
 logger = create_logger(__name__)
 
+__MAIN_THREAD_ALIAS__ = "main-thread"
+
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
@@ -183,7 +185,7 @@ def queue_wrapper(
                     # and therefore the queue never will never be free.
                     queue.put_nowait(obj)
                 except Full:
-                    if __EVENTS__.is_event_set("stop"):
+                    if __EVENTS__.is_event_set("stop", __MAIN_THREAD_ALIAS__):
                         return False
                     time.sleep(0.05)
                 else:
@@ -202,14 +204,15 @@ def queue_wrapper(
         except Exception as err:
             tb_str = "".join(traceback.TracebackException.from_exception(err).format())
             context, ident = get_execution_context()
+            alias = __EVENTS__.get_alias(ident, "<unaliased>")
             queue.put(
                 RemoteException(
                     f"There was a(n) {type(err).__name__!r} occurring in {context} "
-                    f"with ident {ident} ({__EVENTS__.get_alias(ident)})\n{tb_str}"
+                    f"with ident {ident} ({alias})\n{tb_str}"
                 )
             )
 
-            logger.debug(f"Encountered remote exception in thread {ident} ({__EVENTS__.get_alias(ident)}): {err!r}")
+            logger.debug(f"Encountered remote exception in thread {ident} ({alias}): {err!r}")
 
     return wrapper
 
@@ -242,8 +245,8 @@ def pool_queue_iter(handle: MapResult[Any], queue: Queue[Union[_T, Exception]]) 
                 handle.get(timeout=0.01)
             except TimeoutError:
                 # listen for stop-event set for main-thread
-                if __EVENTS__.is_event_set("stop", "main-thread"):
-                    __EVENTS__.clear_event("stop", "main-thread")
+                if __EVENTS__.is_event_set("stop", __MAIN_THREAD_ALIAS__):
+                    __EVENTS__.clear_event("stop", __MAIN_THREAD_ALIAS__)
                     break
                 continue
 
@@ -416,13 +419,13 @@ class CrawlerBase(ABC):
         if isinstance(self, CCNewsCrawler) and self.processes > 0:
 
             def callback() -> None:
-                __EVENTS__.set_event("stop", "main-thread")
+                __EVENTS__.set_event("stop", __MAIN_THREAD_ALIAS__)
 
         else:
             callback = None
 
         try:
-            with __EVENTS__.main_context("main-thread"), Timeout(
+            with __EVENTS__.main_context(__MAIN_THREAD_ALIAS__), Timeout(
                 seconds=timeout, silent=True, callback=callback, disable=timeout <= 0
             ) as timer:
                 for article in self._build_article_iterator(

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -591,7 +591,7 @@ class Crawler(CrawlerBase):
             finally:
                 logger.debug(f"Shutting down {type(self).__name__!r} ...")
                 managed_pool.close()
-                __EVENTS__.set_for_all("stop", future=True)
+                __EVENTS__.set_for_all("stop", future=True, active_only=True)
                 managed_pool.join()
                 __EVENTS__.clear_for_all("stop")
                 logger.debug("Shutdown done")

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -1,7 +1,7 @@
 import contextlib
 import json
 import threading
-from collections import defaultdict
+
 from typing import Callable, Dict, List, Optional, TypeVar, Union, overload
 
 from bidict import bidict
@@ -40,6 +40,9 @@ class ThreadEventDict(Dict[str, threading.Event]):
         Args:
             default_events: A list of event names for which Event objects
                 should be automatically created when accessed.
+            event_factory: An optional callable used to create new Event objects.
+                Receives the event name and returns a threading.Event. If None,
+                a plain threading.Event() is used.
         """
         super().__init__()
         self._default_events = default_events or []
@@ -72,21 +75,29 @@ class ThreadEventDict(Dict[str, threading.Event]):
 
 
 class EventDict:
-    """A thread-safe event registry for managing named-entity events with optional thread association.
+    """A thread-safe event registry for named entities running in threads.
 
-    Events are stored primarily by alias (canonical, persistent key). While a thread is running,
-    ``_aliases`` maps the alias to the active thread ID so that ``key=None`` lookups inside
-    the thread resolve to the correct event dict.  When the thread exits (via :meth:`context`),
-    only the alias→thread-ID mapping is removed; ``_events[alias]`` persists so that other
-    threads can still read/write those events after the thread has finished.
+    Each named entity (identified by a string alias) gets its own
+    :class:`ThreadEventDict` holding its events.  While a thread is running,
+    ``_aliases`` maps the alias to the active thread ID so that ``key=None``
+    lookups inside the thread resolve correctly.  When the thread exits (via
+    :meth:`context`), only the alias→thread-ID mapping is removed;
+    ``_events[alias]`` persists so that other threads can still read or write
+    those events after the thread has finished (e.g. the main loop checking
+    whether a publisher was already told to stop).
+
+    Both broadcast and targeted communication are supported.  Because targeted
+    communication requires a stable identifier, all entities must be registered
+    under a string alias via :meth:`context` or :meth:`alias` before events
+    can be accessed.
 
     Attributes:
-        _events (Dict[Union[int, str], ThreadEventDict]): Mapping of canonical keys to their
-            events.  Named entities use their alias (str) as the key; anonymous threads use
-            their thread ID (int).
-        _aliases (bidict[str, int]): Bidirectional mapping of *active* aliases to thread IDs.
-            An alias is present here only while its associated thread is running.
-        _lock (threading.RLock): A re-entrant lock to ensure thread safety.
+        _events (Dict[str, ThreadEventDict]): Mapping of alias to its events.
+            Entries persist after the thread exits.
+        _aliases (bidict[str, int]): Bidirectional mapping of *active* aliases
+            to thread IDs.  An alias is present here only while its associated
+            thread is running.
+        _lock (threading.RLock): Re-entrant lock for thread safety.
     """
 
     def __init__(self, default_events: Optional[List[str]] = None):
@@ -94,8 +105,8 @@ class EventDict:
         Initialize a new EventDict.
 
         Args:
-            default_events: A list of event names that are automatically available
-                for all threads (e.g., ["stop"]).
+            default_events: Event names that are automatically available for
+                every registered alias (e.g. ``["stop"]``).
         """
 
         def event_factory(name: str) -> threading.Event:
@@ -107,157 +118,132 @@ class EventDict:
         self.default_events = default_events
         self._event_factory = event_factory
         self._futures: List[str] = []
-        self._events: Dict[Union[int, str], ThreadEventDict] = defaultdict(
-            lambda: ThreadEventDict(self.default_events, self._event_factory)
-        )
+        self._events: Dict[str, ThreadEventDict] = {}
         self._aliases: bidict[str, int] = bidict()
         self._lock = threading.RLock()
         self._main_context_lock = threading.Lock()
-        self._global_events: Dict[str, threading.Event] = {
-            "shutdown": threading.Event(),
-        }
 
     @staticmethod
     def _get_identifier() -> int:
-        """
-        Get the current thread's unique identifier.
-
-        Returns:
-            int: The current thread's identifier.
-        """
+        """Return the current thread's unique identifier."""
         return threading.get_ident()
 
-    def _resolve(self, key: Union[int, str, None]) -> Union[int, str]:
-        """Resolve a key (thread ID, alias, or None) to the canonical event-dict key.
-
-        The canonical key is the alias string for named entities (even after the thread
-        has exited) and the integer thread ID for anonymous threads.
+    def _resolve(self, key: Optional[str]) -> str:
+        """Resolve ``None`` to the calling thread's alias, or return ``key`` unchanged.
 
         Should only be called while holding the internal lock.
 
         Args:
-            key: The key to resolve. May be a thread ID, alias, or None.
+            key: An alias string, or ``None`` to use the calling thread's alias.
 
         Returns:
-            Union[int, str]: The canonical key for ``_events``.
+            The alias string used as the key in ``_events``.
 
         Raises:
-            KeyError: If a string alias is not registered and has no persisted events.
+            RuntimeError: If ``key`` is ``None`` and the current thread has no
+                active context.
         """
         if key is None:
             ident = self._get_identifier()
-            # Named thread: resolve to alias (canonical key)
             if ident in self._aliases.inv:
                 return self._aliases.inv[ident]
-            return ident
-        if isinstance(key, int):
-            if key in self._aliases.inv:
-                return self._aliases.inv[key]
-            return key
-        # String (alias) key
-        if key in self._aliases:
-            return key  # Active alias – canonical key
-        if key in self._events:
-            return key  # Thread has finished but events persist under alias key
-        raise KeyError(key)
+            raise RuntimeError(
+                "Current thread has no active context. Pass an explicit alias key."
+            )
+        return key
 
-    def _pretty_resolve(self, key: Union[int, str, None]) -> str:
-        """
-        Resolve a key to a human-readable identifier string, including alias if available.
+    def _pretty_resolve(self, key: Optional[str]) -> str:
+        """Resolve a key to a human-readable string for logging.
 
         Should only be called while holding the internal lock.
 
         Args:
-            key: Thread ID, alias, or None.
+            key: Alias string or ``None`` (current thread).
 
         Returns:
-            str: A formatted string such as ``"7740   (Sportschau)"`` or ``"(Sportschau)"``.
+            A formatted string such as ``"7740   (Sportschau)"`` or
+            ``"(Sportschau)"`` when the thread has already finished.
         """
-        resolved = self._resolve(key)
-        if isinstance(resolved, str):
-            # Named entity – show thread ID if the thread is still active
-            thread_id = self._aliases.get(resolved)
-            if thread_id is not None:
-                return f"{thread_id:<6} ({resolved})"
-            return f"({resolved})"
-        else:
-            alias = self._aliases.inv.get(resolved)
-            return f"{resolved:<6}{f' ({alias})' if alias else ''}"
+        alias = self._resolve(key)
+        thread_id = self._aliases.get(alias)
+        if thread_id is not None:
+            return f"{thread_id:<6} ({alias})"
+        return f"({alias})"
 
     def _alias(self, alias: str, key: Optional[int] = None):
-        """
-        Register an alias for a given thread identifier.
+        """Register an alias for a given thread identifier.
 
-        Events are stored under the alias (canonical key).  If the alias is being
-        registered for the first time, or is being re-registered after a previous
-        thread finished, a fresh :class:`ThreadEventDict` is created so that stale
-        state (e.g. a previously set ``"stop"`` event) is not inherited.
+        Events are stored under the alias (canonical key).  If the alias is
+        being registered for the first time, or is being re-registered after a
+        previous thread finished, a fresh :class:`ThreadEventDict` is created
+        so that stale state (e.g. a previously set ``"stop"`` event) is not
+        inherited.
 
         Should only be called while holding the internal lock.
 
         Args:
             alias: The alias to assign.
             key: The thread identifier to associate with this alias.
-                If None, the current thread's identifier is used.
+                Defaults to the current thread's identifier.
         """
-        ident = key or self._get_identifier()
+        ident = key if key is not None else self._get_identifier()
         logger.debug(f"Register alias {alias} -> {ident}")
         if alias not in self._aliases:
-            # New or re-registration: create fresh events under the alias key
+            # New or re-registration: create fresh events under the alias key.
             self._events[alias] = ThreadEventDict(self.default_events, self._event_factory)
         self._aliases[alias] = ident
-        # _events[ident] is NOT created here – the canonical key is the alias string,
-        # and _resolve(None) inside the thread will return the alias via _aliases.inv.
 
-    def register_event(self, event: str, key: Union[int, str, None] = None):
-        """
-        Register a new event for the specified thread or alias.
+    def register_event(self, event: str, key: Optional[str] = None):
+        """Register a new event for an existing alias.
 
-        If the alias does not exist, it is automatically created.
+        The alias must already be registered via :meth:`context` or
+        :meth:`alias` before calling this method.
 
         Args:
             event: The name of the event to register.
-            key: Thread ID, alias, or None (defaults to the current thread).
+            key: Alias or ``None`` (defaults to the current thread's alias).
+
+        Raises:
+            RuntimeError: If ``key`` is ``None`` and the current thread has no
+                active context.
+            KeyError: If ``key`` names an alias that has never been registered.
         """
         with self._lock:
-            if isinstance(key, str) and key not in self._aliases:
-                self._alias(key)
             if event not in self._events[(resolved := self._resolve(key))]:
                 self._events[resolved][event] = self._event_factory(event)
                 logger.debug(f"Registered event {event!r} for {self._pretty_resolve(key)}")
 
-    def set_event(self, event: str, key: Union[int, str, None] = None):
-        """
-        Set (trigger) an event for the specified thread.
+    def set_event(self, event: str, key: Optional[str] = None):
+        """Set (trigger) an event for the specified alias.
 
         Args:
             event: The name of the event to set.
-            key: Thread ID, alias, or None (defaults to the current thread).
+            key: Alias or ``None`` (defaults to the current thread's alias).
         """
         with self._lock:
             self._events[self._resolve(key)][event].set()
             logger.debug(f"Set event {event!r} for {self._pretty_resolve(key)}")
 
-    def clear_event(self, event: str, key: Union[int, str, None] = None):
-        """
-        Clear (reset) an event for the specified thread.
+    def clear_event(self, event: str, key: Optional[str] = None):
+        """Clear (reset) an event for the specified alias.
 
         Args:
             event: The name of the event to clear.
-            key: Thread ID, alias, or None (defaults to the current thread).
+            key: Alias or ``None`` (defaults to the current thread's alias).
         """
         with self._lock:
             self._events[self._resolve(key)][event].clear()
             logger.debug(f"Cleared event {event!r} for {self._pretty_resolve(key)}")
 
     def set_for_all(self, event: Optional[str] = None, future: bool = False):
-        """Set an event for all registered threads.
+        """Set an event for all registered aliases.
 
-        If `event` is None, all events for every registered thread are set.
+        If ``event`` is ``None``, every event for every registered alias is set.
 
         Args:
-            event: The event name to set. If None, all events are set.
-            future: If True, the event will be set for all future threads as well.
+            event: The event name to set. If ``None``, all events are set.
+            future: If ``True``, newly registered aliases will also have this
+                event pre-set (via the event factory).
         """
         with self._lock:
             if event is None:
@@ -272,15 +258,16 @@ class EventDict:
                     self.set_event(event, key)
 
     def clear_for_all(self, event: Optional[str] = None):
-        """Clear an event for all registered threads.
+        """Clear an event for all registered aliases.
 
-        If the event was previously set with set_for_all(..., future=True),
-        the event won't be set for future events anymore.
+        If the event was previously marked for future threads via
+        :meth:`set_for_all` with ``future=True``, that mark is also removed.
 
-        If `event` is None, all events for every registered thread are cleared.
+        If ``event`` is ``None``, every event for every registered alias is
+        cleared.
 
         Args:
-            event: The event name to clear. If None, all events are cleared.
+            event: The event name to clear. If ``None``, all events are cleared.
         """
         with self._lock:
             if event is None:
@@ -294,39 +281,39 @@ class EventDict:
                 for key in self._events:
                     self.clear_event(event, key)
 
-    def is_event_set(self, event: str, key: Union[int, str, None] = None) -> bool:
-        """
-        Check if a specific event is set for a given thread.
+    def is_event_set(self, event: str, key: Optional[str] = None) -> bool:
+        """Check whether a specific event is set for the given alias.
 
         Args:
             event: The name of the event to check.
-            key: Thread ID, alias, or None (defaults to the current thread).
+            key: Alias or ``None`` (defaults to the current thread's alias).
 
         Returns:
-            bool: True if the event is set, False otherwise.
+            ``True`` if the event is set, ``False`` otherwise.
 
         Raises:
-            KeyError: If ``key`` is a string alias that was never registered.
+            RuntimeError: If ``key`` is ``None`` and the current thread has no
+                active context.
+            KeyError: If ``key`` names an alias that has never been registered.
         """
         with self._lock:
             return self._events[self._resolve(key)][event].is_set()
 
     @contextlib.contextmanager
     def context(self, alias: str, key: Optional[int] = None):
-        """
-        Context manager that registers an alias for the duration of a block.
+        """Context manager that registers an alias for the duration of a block.
 
-        On entry, the alias is bound to the current (or given) thread ID so that
-        ``key=None`` lookups inside the thread resolve correctly.  On exit, only
-        the alias→thread-ID mapping is removed; ``_events[alias]`` is kept alive
-        so that other threads can still access those events after this thread
-        finishes.  Events are cleaned up on the next :meth:`reset` call or when
-        the alias is re-registered via a new ``context()`` invocation.
+        On entry the alias is bound to the current (or given) thread ID so that
+        ``key=None`` lookups inside the thread resolve correctly.  On exit only
+        the alias→thread-ID mapping is removed; ``_events[alias]`` is kept
+        alive so that other threads can still read those events after this
+        thread finishes.  Stale state is cleared on the next :meth:`reset` or
+        when the alias is re-registered via a new ``context()`` call.
 
         Args:
             alias: The alias name to register.
-            key: Optional thread identifier to associate with the alias.
-                Defaults to the current thread if not provided.
+            key: Thread identifier to associate with the alias. Defaults to the
+                current thread's identifier.
         """
         try:
             with self._lock:
@@ -334,18 +321,13 @@ class EventDict:
             yield
         finally:
             with self._lock:
-                # Remove the active alias→thread mapping so the thread ID can be
-                # reused by other threads without interference.  The alias-keyed
-                # events in _events[alias] are intentionally kept so that other
-                # threads (e.g. the main crawl loop) can still read them.
                 self._aliases.pop(alias, None)
 
     @contextlib.contextmanager
     def main_context(self, alias: str):
-        """Context manager that registers an alias for the main thread and resets all state on exit.
+        """Context manager for the main thread; resets all state on exit.
 
-        Only one main context may be active at a time. Attempting to enter a second one raises
-        ``RuntimeError``.
+        Only one main context may be active at a time.
 
         Args:
             alias: The alias to register for the calling thread.
@@ -363,84 +345,73 @@ class EventDict:
             self._main_context_lock.release()
 
     def alias(self, alias: str, key: Optional[int] = None):
-        """
-        Public wrapper to register an alias for a thread.
+        """Register an alias for a thread without using a context manager.
+
+        Prefer :meth:`context` for automatic cleanup on thread exit.  Use this
+        method only when the alias lifetime cannot be expressed as a ``with``
+        block (e.g. a long-lived background thread).
 
         Args:
             alias: The alias name to register.
-            key: Optional thread identifier to associate with the alias.
-                Defaults to the current thread if not provided.
+            key: Thread identifier to associate with the alias. Defaults to the
+                current thread's identifier.
         """
         with self._lock:
             self._alias(alias, key)
 
     @overload
-    def get_alias(self, ident: int) -> str:
-        ...
+    def get_alias(self, ident: int) -> str: ...
 
     @overload
-    def get_alias(self, ident: int, default: _T) -> Union[str, _T]:
-        ...
+    def get_alias(self, ident: int, default: _T) -> Union[str, _T]: ...
 
     def get_alias(self, ident: int, default=_sentinel):
-        """
-        Get the alias associated with a thread identifier.
+        """Return the alias associated with a thread identifier.
 
         Args:
             ident: The thread identifier.
-            default: Value to return if no alias is found. If omitted, raises KeyError.
+            default: Value to return if no alias is found. If omitted, raises
+                ``KeyError``.
 
         Returns:
-            str: The alias associated with the identifier, or default if not found.
+            The alias string, or ``default`` if the thread has no alias.
         """
         if default is _sentinel:
             return self._aliases.inv[ident]
         return self._aliases.inv.get(ident, default)
 
-    def remove_alias(self, alias: str):
-        """
-        Remove an alias from the alias mapping.
-
-        Args:
-            alias: The alias to remove.
-        """
-        with self._lock:
-            self._aliases.pop(alias, None)
-
-    def get(self, event: str, key: Optional[Union[int, str, None]] = None) -> threading.Event:
-        """
-        Get the event object associated with the given event name and thread.
+    def get(self, event: str, key: Optional[str] = None) -> threading.Event:
+        """Return the raw :class:`threading.Event` for the given alias and event name.
 
         Args:
             event: The name of the event to retrieve.
-            key: Thread ID, alias, or None (defaults to the current thread).
+            key: Alias or ``None`` (defaults to the current thread's alias).
 
         Returns:
-            threading.Event: The event object.
+            The :class:`threading.Event` object.
         """
         with self._lock:
             return self._events[self._resolve(key)][event]
 
     def reset(self):
+        """Clear all events, aliases, and futures.
+
+        Called automatically by :meth:`main_context` on exit.
+        """
         with self._lock:
             self._futures = []
-            self._events = defaultdict(lambda: ThreadEventDict(self.default_events, self._event_factory))
+            self._events = {}
             self._aliases = bidict()
 
     def __str__(self):
-        def _entry(key: Union[int, str]) -> str:
-            if isinstance(key, str):
-                alias = key
-                thread_id = self._aliases.get(key, "finished")
-                header = f"{alias} --> {thread_id}"
-            else:
-                alias = self._aliases.inv.get(key, "None")
-                header = f"{alias} --> {key}"
-            serialized = json.dumps(self._events[key], indent=2, ensure_ascii=False, default=lambda o: o.set())
-            return f"{header}: \n" + serialized
+        def _entry(alias: str) -> str:
+            thread_id = self._aliases.get(alias, "finished")
+            header = f"{alias} --> {thread_id}"
+            serialized = json.dumps(self._events[alias], indent=2, ensure_ascii=False, default=lambda o: o.is_set())
+            return f"{header}:\n{serialized}"
 
-        events = [_entry(key) for key in self._events]
-        return "\n".join(events) if events else "Empty Event Dictionary"
+        entries = [_entry(alias) for alias in self._events]
+        return "\n".join(entries) if entries else "Empty Event Dictionary"
 
 
 __EVENTS__: EventDict = EventDict(default_events=__DEFAULT_EVENTS__)

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -68,18 +68,20 @@ class ThreadEventDict(Dict[str, threading.Event]):
 
 
 class EventDict:
-    """A thread-safe event registry for managing thread-local events with optional aliases.
+    """A thread-safe event registry for managing named-entity events with optional thread association.
 
-    This class maintains per-thread event dictionaries, allowing threads to
-    register, set, and clear named `threading.Event` objects in an isolated
-    and synchronized manner.
-
-    Aliases can be assigned to thread identifiers for convenience. Each alias
-    maps uniquely to a thread ID, allowing event access via human-readable names.
+    Events are stored primarily by alias (canonical, persistent key). While a thread is running,
+    ``_aliases`` maps the alias to the active thread ID so that ``key=None`` lookups inside
+    the thread resolve to the correct event dict.  When the thread exits (via :meth:`context`),
+    only the alias→thread-ID mapping is removed; ``_events[alias]`` persists so that other
+    threads can still read/write those events after the thread has finished.
 
     Attributes:
-        _events (Dict[int, ThreadEventDict]): Mapping of thread IDs to their events.
-        _aliases (bidict[str, int]): Bidirectional mapping of aliases to thread IDs.
+        _events (Dict[Union[int, str], ThreadEventDict]): Mapping of canonical keys to their
+            events.  Named entities use their alias (str) as the key; anonymous threads use
+            their thread ID (int).
+        _aliases (bidict[str, int]): Bidirectional mapping of *active* aliases to thread IDs.
+            An alias is present here only while its associated thread is running.
         _lock (threading.RLock): A re-entrant lock to ensure thread safety.
     """
 
@@ -101,7 +103,7 @@ class EventDict:
         self.default_events = default_events
         self._event_factory = event_factory
         self._futures: List[str] = []
-        self._events: Dict[int, ThreadEventDict] = defaultdict(
+        self._events: Dict[Union[int, str], ThreadEventDict] = defaultdict(
             lambda: ThreadEventDict(self.default_events, self._event_factory)
         )
         self._aliases: bidict[str, int] = bidict()
@@ -120,8 +122,11 @@ class EventDict:
         """
         return threading.get_ident()
 
-    def _resolve(self, key: Union[int, str, None]) -> int:
-        """Resolve a key (thread ID, alias, or None) to a thread identifier.
+    def _resolve(self, key: Union[int, str, None]) -> Union[int, str]:
+        """Resolve a key (thread ID, alias, or None) to the canonical event-dict key.
+
+        The canonical key is the alias string for named entities (even after the thread
+        has exited) and the integer thread ID for anonymous threads.
 
         Should only be called while holding the internal lock.
 
@@ -129,13 +134,27 @@ class EventDict:
             key: The key to resolve. May be a thread ID, alias, or None.
 
         Returns:
-            int: The resolved thread identifier.
+            Union[int, str]: The canonical key for ``_events``.
+
+        Raises:
+            KeyError: If a string alias is not registered and has no persisted events.
         """
         if key is None:
-            return self._get_identifier()
+            ident = self._get_identifier()
+            # Named thread: resolve to alias (canonical key)
+            if ident in self._aliases.inv:
+                return self._aliases.inv[ident]
+            return ident
         if isinstance(key, int):
+            if key in self._aliases.inv:
+                return self._aliases.inv[key]
             return key
-        return self._aliases[key]
+        # String (alias) key
+        if key in self._aliases:
+            return key  # Active alias – canonical key
+        if key in self._events:
+            return key  # Thread has finished but events persist under alias key
+        raise KeyError(key)
 
     def _pretty_resolve(self, key: Union[int, str, None]) -> str:
         """
@@ -147,15 +166,27 @@ class EventDict:
             key: Thread ID, alias, or None.
 
         Returns:
-            str: A formatted string of the form "<thread_id> (alias)".
+            str: A formatted string such as ``"7740   (Sportschau)"`` or ``"(Sportschau)"``.
         """
         resolved = self._resolve(key)
-        alias = f" ({self._aliases.inv[resolved]})" if resolved in self._aliases.values() else ""
-        return f"{resolved:<6}{alias}"
+        if isinstance(resolved, str):
+            # Named entity – show thread ID if the thread is still active
+            thread_id = self._aliases.get(resolved)
+            if thread_id is not None:
+                return f"{thread_id:<6} ({resolved})"
+            return f"({resolved})"
+        else:
+            alias = self._aliases.inv.get(resolved)
+            return f"{resolved:<6}{f' ({alias})' if alias else ''}"
 
     def _alias(self, alias: str, key: Optional[int] = None):
         """
         Register an alias for a given thread identifier.
+
+        Events are stored under the alias (canonical key).  If the alias is being
+        registered for the first time, or is being re-registered after a previous
+        thread finished, a fresh :class:`ThreadEventDict` is created so that stale
+        state (e.g. a previously set ``"stop"`` event) is not inherited.
 
         Should only be called while holding the internal lock.
 
@@ -164,13 +195,14 @@ class EventDict:
             key: The thread identifier to associate with this alias.
                 If None, the current thread's identifier is used.
         """
-        logger.debug(f"Register alias {alias} -> {(value := key or self._get_identifier())}")
-        self._aliases[alias] = value
-        if (ident := self._resolve(alias)) not in self._events:
-            # noinspection PyStatementEffect
-            # Since defaultdict doesn't provide a direct way to create defaults,
-            # we simulate it by accessing the key.
-            self._events[ident]
+        ident = key or self._get_identifier()
+        logger.debug(f"Register alias {alias} -> {ident}")
+        if alias not in self._aliases:
+            # New or re-registration: create fresh events under the alias key
+            self._events[alias] = ThreadEventDict(self.default_events, self._event_factory)
+        self._aliases[alias] = ident
+        # _events[ident] is NOT created here – the canonical key is the alias string,
+        # and _resolve(None) inside the thread will return the alias via _aliases.inv.
 
     def register_event(self, event: str, key: Union[int, str, None] = None):
         """
@@ -224,15 +256,15 @@ class EventDict:
         """
         with self._lock:
             if event is None:
-                for ident, events in self._events.items():
+                for key, events in self._events.items():
                     for name in events:
-                        self.set_event(name, ident)
+                        self.set_event(name, key)
             else:
                 if future:
                     self._futures.append(event)
 
-                for ident in self._events:
-                    self.set_event(event, ident)
+                for key in self._events:
+                    self.set_event(event, key)
 
     def clear_for_all(self, event: Optional[str] = None):
         """Clear an event for all registered threads.
@@ -247,15 +279,15 @@ class EventDict:
         """
         with self._lock:
             if event is None:
-                for ident, events in self._events.items():
+                for key, events in self._events.items():
                     for name in events:
-                        self.clear_event(name, ident)
+                        self.clear_event(name, key)
             else:
                 if event in self._futures:
                     self._futures.remove(event)
 
-                for ident in self._events:
-                    self.clear_event(event, ident)
+                for key in self._events:
+                    self.clear_event(event, key)
 
     def is_event_set(self, event: str, key: Union[int, str, None] = None) -> bool:
         """
@@ -267,6 +299,9 @@ class EventDict:
 
         Returns:
             bool: True if the event is set, False otherwise.
+
+        Raises:
+            KeyError: If ``key`` is a string alias that was never registered.
         """
         with self._lock:
             return self._events[self._resolve(key)][event].is_set()
@@ -274,7 +309,14 @@ class EventDict:
     @contextlib.contextmanager
     def context(self, alias: str, key: Optional[int] = None):
         """
-        Public wrapper to register an alias for a thread.
+        Context manager that registers an alias for the duration of a block.
+
+        On entry, the alias is bound to the current (or given) thread ID so that
+        ``key=None`` lookups inside the thread resolve correctly.  On exit, only
+        the alias→thread-ID mapping is removed; ``_events[alias]`` is kept alive
+        so that other threads can still access those events after this thread
+        finishes.  Events are cleaned up on the next :meth:`reset` call or when
+        the alias is re-registered via a new ``context()`` invocation.
 
         Args:
             alias: The alias name to register.
@@ -286,8 +328,12 @@ class EventDict:
                 self._alias(alias, key)
             yield
         finally:
-            self._events.pop(self._resolve(alias))
-            self.remove_alias(alias)
+            with self._lock:
+                # Remove the active alias→thread mapping so the thread ID can be
+                # reused by other threads without interference.  The alias-keyed
+                # events in _events[alias] are intentionally kept so that other
+                # threads (e.g. the main crawl loop) can still read them.
+                self._aliases.pop(alias, None)
 
     def alias(self, alias: str, key: Optional[int] = None):
         """
@@ -344,12 +390,18 @@ class EventDict:
             self._aliases = bidict()
 
     def __str__(self):
-        def _entry(thread: int) -> str:
-            alias = self._aliases.inv.get(thread, None)
-            serialized = json.dumps(self._events[thread], indent=2, ensure_ascii=False, default=lambda o: o.set())
-            return f"{alias if alias else 'None'} --> {thread}: \n" + serialized
+        def _entry(key: Union[int, str]) -> str:
+            if isinstance(key, str):
+                alias = key
+                thread_id = self._aliases.get(key, "finished")
+                header = f"{alias} --> {thread_id}"
+            else:
+                alias = self._aliases.inv.get(key, "None")
+                header = f"{alias} --> {key}"
+            serialized = json.dumps(self._events[key], indent=2, ensure_ascii=False, default=lambda o: o.set())
+            return f"{header}: \n" + serialized
 
-        events = [_entry(ident) for ident in self._events]
+        events = [_entry(key) for key in self._events]
         return "\n".join(events) if events else "Empty Event Dictionary"
 
 

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -2,15 +2,19 @@ import contextlib
 import json
 import threading
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, TypeVar, Union, overload
 
 from bidict import bidict
 
 from fundus.logging import create_logger
 
+_T = TypeVar("_T")
+
 logger = create_logger(__name__)
 
 __DEFAULT_EVENTS__: List[str] = ["stop"]
+
+_sentinel = object()
 
 
 class ThreadEventDict(Dict[str, threading.Event]):
@@ -370,17 +374,28 @@ class EventDict:
         with self._lock:
             self._alias(alias, key)
 
+    @overload
     def get_alias(self, ident: int) -> str:
+        ...
+
+    @overload
+    def get_alias(self, ident: int, default: _T) -> Union[str, _T]:
+        ...
+
+    def get_alias(self, ident: int, default=_sentinel):
         """
         Get the alias associated with a thread identifier.
 
         Args:
             ident: The thread identifier.
+            default: Value to return if no alias is found. If omitted, raises KeyError.
 
         Returns:
-            str: The alias associated with the identifier.
+            str: The alias associated with the identifier, or default if not found.
         """
-        return self._aliases.inv[ident]
+        if default is _sentinel:
+            return self._aliases.inv[ident]
+        return self._aliases.inv.get(ident, default)
 
     def remove_alias(self, alias: str):
         """

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -1,7 +1,6 @@
 import contextlib
 import json
 import threading
-
 from typing import Callable, Dict, List, Optional, TypeVar, Union, overload
 
 from bidict import bidict
@@ -147,9 +146,7 @@ class EventDict:
             ident = self._get_identifier()
             if ident in self._aliases.inv:
                 return self._aliases.inv[ident]
-            raise RuntimeError(
-                "Current thread has no active context. Pass an explicit alias key."
-            )
+            raise RuntimeError("Current thread has no active context. Pass an explicit alias key.")
         return key
 
     def _pretty_resolve(self, key: Optional[str]) -> str:
@@ -367,10 +364,12 @@ class EventDict:
             self._alias(alias, key)
 
     @overload
-    def get_alias(self, ident: int) -> str: ...
+    def get_alias(self, ident: int) -> str:
+        ...
 
     @overload
-    def get_alias(self, ident: int, default: _T) -> Union[str, _T]: ...
+    def get_alias(self, ident: int, default: _T) -> Union[str, _T]:
+        ...
 
     def get_alias(self, ident: int, default=_sentinel):
         """Return the alias associated with a thread identifier.

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -108,6 +108,7 @@ class EventDict:
         )
         self._aliases: bidict[str, int] = bidict()
         self._lock = threading.RLock()
+        self._main_context_lock = threading.Lock()
         self._global_events: Dict[str, threading.Event] = {
             "shutdown": threading.Event(),
         }
@@ -334,6 +335,28 @@ class EventDict:
                 # events in _events[alias] are intentionally kept so that other
                 # threads (e.g. the main crawl loop) can still read them.
                 self._aliases.pop(alias, None)
+
+    @contextlib.contextmanager
+    def main_context(self, alias: str):
+        """Context manager that registers an alias for the main thread and resets all state on exit.
+
+        Only one main context may be active at a time. Attempting to enter a second one raises
+        ``RuntimeError``.
+
+        Args:
+            alias: The alias to register for the calling thread.
+
+        Raises:
+            RuntimeError: If a main context is already active.
+        """
+        if not self._main_context_lock.acquire(blocking=False):
+            raise RuntimeError("A main context is already active")
+        try:
+            with self.context(alias):
+                yield
+        finally:
+            self.reset()
+            self._main_context_lock.release()
 
     def alias(self, alias: str, key: Optional[int] = None):
         """

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -235,7 +235,7 @@ class EventDict:
             self._events[self._resolve(key)][event].clear()
             logger.debug(f"Cleared event {event!r} for {self._pretty_resolve(key)}")
 
-    def set_for_all(self, event: Optional[str] = None, future: bool = False):
+    def set_for_all(self, event: Optional[str] = None, future: bool = False, active_only: bool = False):
         """Set an event for all registered aliases.
 
         If ``event`` is ``None``, every event for every registered alias is set.
@@ -244,10 +244,15 @@ class EventDict:
             event: The event name to set. If ``None``, all events are set.
             future: If ``True``, newly registered aliases will also have this
                 event pre-set (via the event factory).
+            active_only: If ``True``, only aliases whose threads are currently
+                running are targeted; aliases whose threads have already finished
+                are skipped.
         """
         with self._lock:
             if event is None:
                 for key, events in self._events.items():
+                    if active_only and key not in self._aliases:
+                        continue
                     for name in events:
                         self.set_event(name, key)
             else:
@@ -255,6 +260,8 @@ class EventDict:
                     self._futures.append(event)
 
                 for key in self._events:
+                    if active_only and key not in self._aliases:
+                        continue
                     self.set_event(event, key)
 
     def clear_for_all(self, event: Optional[str] = None):

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -160,6 +160,10 @@ class EventDict:
         Returns:
             A formatted string such as ``"7740   (Sportschau)"`` or
             ``"(Sportschau)"`` when the thread has already finished.
+
+        Raises:
+            RuntimeError: If ``key`` is ``None`` and the current thread has no
+                active context.
         """
         alias = self._resolve(key)
         thread_id = self._aliases.get(alias)

--- a/tests/resources/test_events.py
+++ b/tests/resources/test_events.py
@@ -150,6 +150,29 @@ class TestEvents:
         with pytest.raises(KeyError):
             events.is_event_set("stop", "NonExistent")
 
+    def test_main_context_resets_on_exit(self):
+        """__EVENTS__ state must be fully cleared once main_context exits."""
+        events = EventDict(default_events=["stop"])
+
+        with events.main_context("main-thread"):
+            events.alias("Sportschau", 1)
+            events.set_event("stop", "Sportschau")
+            events.set_for_all("stop", future=True)
+
+        # aliases, events, and futures must all be gone
+        assert not events._aliases
+        assert not events._events
+        assert not events._futures
+
+    def test_main_context_raises_when_already_active(self):
+        """Entering a second main_context while one is active must raise RuntimeError."""
+        events = EventDict()
+
+        with events.main_context("main-thread"):
+            with pytest.raises(RuntimeError):
+                with events.main_context("other"):
+                    pass
+
     def test_reregistration_creates_fresh_events(self):
         """Re-registering an alias after its thread exits must clear stale event state."""
         events = EventDict(default_events=["stop"])

--- a/tests/resources/test_events.py
+++ b/tests/resources/test_events.py
@@ -127,3 +127,36 @@ class TestEvents:
                 events.alias("new-thread", 1)
 
         events.alias("new-thread", 1)
+
+    def test_events_accessible_after_context_exits(self):
+        """Events set inside a context should remain accessible after the thread exits.
+
+        Regression test for the KeyError crash where the main crawl loop tried to call
+        is_event_set("stop", publisher_name) after the publisher thread had already
+        finished and its context() cleaned up.
+        """
+        events = EventDict(default_events=["stop"])
+
+        with events.context("Sportschau", 1):
+            events.set_event("stop", "Sportschau")
+
+        # context has exited – alias is no longer active, but events must persist
+        assert events.is_event_set("stop", "Sportschau") is True
+
+    def test_unknown_alias_raises_key_error(self):
+        """Accessing a never-registered alias must still raise KeyError."""
+        events = EventDict(default_events=["stop"])
+
+        with pytest.raises(KeyError):
+            events.is_event_set("stop", "NonExistent")
+
+    def test_reregistration_creates_fresh_events(self):
+        """Re-registering an alias after its thread exits must clear stale event state."""
+        events = EventDict(default_events=["stop"])
+
+        with events.context("Sportschau", 1):
+            events.set_event("stop", "Sportschau")
+
+        # Re-register the same alias (simulates a second crawl)
+        with events.context("Sportschau", 2):
+            assert events.is_event_set("stop", "Sportschau") is False

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,6 +8,7 @@ class TestEvents:
     def test_default_events(self):
         events = EventDict(default_events=["success"])
 
+        events.alias("test")
         events.get("success")
 
         with pytest.raises(KeyError):
@@ -16,74 +17,64 @@ class TestEvents:
     def test_set_clear(self):
         events = EventDict(default_events=["success"])
 
+        events.alias("test")
         events.set_event("success")
-
         assert events.is_event_set("success")
 
         events.clear_event("success")
-
         assert events.is_event_set("success") == False
 
     def test_set_clear_all(self):
-        events = EventDict()
+        events = EventDict(default_events=["success"])
 
-        events.register_event("success", 1)
-        events.register_event("success", 2)
+        events.alias("thread-1", 1)
+        events.alias("thread-2", 2)
 
         events.set_for_all("success")
-
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == True
+        assert events.is_event_set("success", "thread-1") == events.is_event_set("success", "thread-2") == True
 
         events.clear_for_all("success")
+        assert events.is_event_set("success", "thread-1") == events.is_event_set("success", "thread-2") == False
 
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == False
-
-        events.register_event("failure", 1)
-        events.register_event("failure", 2)
+        events.register_event("failure", "thread-1")
+        events.register_event("failure", "thread-2")
 
         events.set_for_all()
-
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == True
-        assert events.is_event_set("failure", 1) == events.is_event_set("failure", 2) == True
+        assert events.is_event_set("success", "thread-1") == events.is_event_set("success", "thread-2") == True
+        assert events.is_event_set("failure", "thread-1") == events.is_event_set("failure", "thread-2") == True
 
         events.clear_for_all()
-
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == False
-        assert events.is_event_set("failure", 1) == events.is_event_set("failure", 2) == False
+        assert events.is_event_set("success", "thread-1") == events.is_event_set("success", "thread-2") == False
+        assert events.is_event_set("failure", "thread-1") == events.is_event_set("failure", "thread-2") == False
 
     def test_new_event_after_set_for_all(self):
-        events = EventDict()
+        events = EventDict(default_events=["success"])
 
-        events.register_event("success", 1)
-
+        events.alias("thread-1", 1)
         events.set_for_all("success")
+        events.alias("thread-2", 2)
 
-        events.register_event("success", 2)
-
-        assert events.is_event_set("success", 1) == True
-        assert events.is_event_set("success", 2) == False
+        assert events.is_event_set("success", "thread-1") == True
+        assert events.is_event_set("success", "thread-2") == False
 
     def test_set_for_all_future_true(self):
-        events = EventDict()
+        events = EventDict(default_events=["success"])
 
-        events.register_event("success", 1)
-
+        events.alias("thread-1", 1)
         events.set_for_all("success", future=True)
+        events.alias("thread-2", 2)
 
-        events.register_event("success", 2)
-
-        assert events.is_event_set("success", 1) == True
-        assert events.is_event_set("success", 2) == True
+        assert events.is_event_set("success", "thread-1") == True
+        assert events.is_event_set("success", "thread-2") == True
 
     def test_clear_for_all_resets_futures(self):
-        events = EventDict()
+        events = EventDict(default_events=["success"])
 
         events.set_for_all("success", future=True)
         events.clear_for_all("success")
 
-        events.register_event("success", 1)
-
-        assert events.is_event_set("success", 1) == False
+        events.alias("thread-1", 1)
+        assert events.is_event_set("success", "thread-1") == False
 
     def test_alias(self):
         events = EventDict(default_events=["success"])
@@ -143,6 +134,13 @@ class TestEvents:
         # context has exited – alias is no longer active, but events must persist
         assert events.is_event_set("stop", "Sportschau") is True
 
+    def test_no_context_raises_runtime_error(self):
+        """Calling with key=None from a thread with no active context must raise RuntimeError."""
+        events = EventDict(default_events=["stop"])
+
+        with pytest.raises(RuntimeError):
+            events.is_event_set("stop")
+
     def test_unknown_alias_raises_key_error(self):
         """Accessing a never-registered alias must still raise KeyError."""
         events = EventDict(default_events=["stop"])
@@ -183,3 +181,16 @@ class TestEvents:
         # Re-register the same alias (simulates a second crawl)
         with events.context("Sportschau", 2):
             assert events.is_event_set("stop", "Sportschau") is False
+
+    def test_set_for_all_active_only(self):
+        """active_only=True must skip aliases whose threads have already finished."""
+        events = EventDict(default_events=["stop"])
+
+        with events.context("inactive", 1):
+            pass  # alias removed on exit, _events["inactive"] persists
+
+        with events.context("active", 2):
+            events.set_for_all("stop", active_only=True)
+
+            assert events.is_event_set("stop", "active") is True
+            assert events.is_event_set("stop", "inactive") is False


### PR DESCRIPTION
**Problem**
Two `KeyError` crashes caused by publisher aliases being cleaned up while other parts of the code still needed them — once in the main crawl loop, once in the exception handler.

**Root cause**
`EventDict` stored events under the thread ID as the canonical key and deleted everything when `context()` exited. Aliases needed to outlive their thread.

**Fix**
Events are now stored under the alias string as a persistent key. Thread IDs are only tracked while the thread is active. `context()` removes the thread-ID mapping on exit but keeps the alias-keyed events alive. Publisher context registration is also moved out of the scraping generator and into a non-generator thread wrapper so the alias covers the thread's full lifetime.

A `main_context()` method is added for the main crawl thread: it combines `context()` with a full `reset()` on exit and enforces single-instance semantics via a non-reentrant lock, ensuring clean state between consecutive `crawl()` calls.
