### PR TITLE
Replace `black` and `isort ` with `ruff`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,17 +7,13 @@ on:
   workflow_call:
 
 jobs:
-  black:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
-        with:
-          options: "--check"
-          version: "23.1.0"
 
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: isort/isort-action@master
+      - uses: astral-sh/ruff-action@v3
+
+      - run: ruff check
+
+      - run: ruff format --check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,14 +7,14 @@ on:
   workflow_call:
 
 jobs:
-  ruff-lint:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
       - run: ruff check
 
-  ruff-format:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,4 @@
-name: lint
+name: ruff
 
 on:
   push:
@@ -7,13 +7,16 @@ on:
   workflow_call:
 
 jobs:
-  ruff:
+  ruff-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: astral-sh/ruff-action@v3
-
       - run: ruff check
 
+  ruff-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
       - run: ruff format --check

--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -756,20 +756,21 @@ pytest
 ## 7. Opening a Pull Request
 
 1. Make sure you tested your parser using `pytest`.
-2. Run `black src`, `isort src`, and `mypy src` with no errors.
+2. Run `ruff format src`, `ruff check --fix src`, and `mypy src` with no errors.
 3. Push and open a new PR
 4. Congratulation and thank you very much.
 
 ## 8. Maintaining publishers
 
-If you encounter an issue with a publisher, feel free to correct it and submit a PR.  
-Please follow this general guideline when making such changes.  
+Website layouts change over time, so we may occasionally need to update a publisher's parser.
+If you run into an issue, feel free to correct it and submit a pull request (PR).
+Please follow these guidelines when making such changes:
 
-- If the parser can no longer extract articles properly, create a new parser version to implement the fix.  
-- Use a minor version bump (e.g., from `V1` to `V1_1(V1)`) if the update only involves adjusting selectors.  
-- If the change introduces new attributes or substantially modifies several existing ones, consider moving to a new major version (e.g., from `V1` to `V2`).  
+- If the layout of the publisher changes and the corresponding parser can no longer extract articles properly, create a new parser version with updated selectors.
+- Use a minor version bump (e.g., from `V1` to `V1_1(V1)`) if the update only involves adjusting selectors.
+- If the change introduces new attributes or substantially modifies several existing ones, consider moving to a new major version (e.g., from `V1` to `V2`).
 
 > [!NOTE]
-> You will now need to set the `VALID_UNTIL` attribute for the previous version to a `datetime.date` pointing to the day before the layout change.
+> Set the `VALID_UNTIL` attribute on the previous version to a `datetime.date` for the day before the layout change.
 > You can estimate this date using the logs or the Wayback Machine.
-> The Attribute is not inherited from previous versions. Every subclass of `BaseParser` by default has `VALID_UNTIL` set to `date.max`.
+> Note that `VALID_UNTIL` is not inherited from previous versions — every subclass of `BaseParser` defaults to `date.max`.

--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -3941,6 +3941,31 @@
       <td>&#160;</td>
       <td>&#160;</td>
     </tr>
+    <tr>
+      <td>
+        <code>WorldTruth</code>
+      </td>
+      <td>
+        <div>
+          <strike>World Truth</strike>
+        </div>
+      </td>
+      <td>
+        <a href="https://www.worldtruth.tv/">
+          <span>www.worldtruth.tv</span>
+        </a>
+      </td>
+      <td>
+        <code>en</code>
+      </td>
+      <td>
+        <code>authors</code>
+        <code>images</code>
+        <code>topics</code>
+      </td>
+      <td>&#160;</td>
+      <td>&#160;</td>
+    </tr>
   </tbody>
 </table>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+ignore = ["E501"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,7 @@ dependencies = [
 dev = [
     "pytest~=7.2.2",
     "mypy==1.9.0",
-    "isort==5.12.0",
-    "black==23.1.0",
+    "ruff==0.15.6",
     # type stubs
     "types-lxml",
     "types-python-dateutil>=2.8, <3",
@@ -73,12 +72,15 @@ warn_unreachable = true
 warn_unused_configs = true
 no_implicit_reexport = true
 
-[tool.black]
+[tool.ruff]
 line-length = 120
-target-version = ['py38']
+target-version = "py38"
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.format]
+quote-style = "double"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -143,7 +143,7 @@ def download_artifact_zip(run: WorkflowRun, use_cache: bool = True) -> Optional[
         if a.name == __ARTIFACT_NAME__:
             if a.expired:
                 if __VERBOSE__:
-                    tqdm.write(f"Artifact has expired")
+                    tqdm.write("Artifact has expired")
                 return None
             zip_url = a.archive_download_url
             r = requests.get(zip_url, headers={"Authorization": f"token {__TOKEN__}"})

--- a/scripts/generate_tables.py
+++ b/scripts/generate_tables.py
@@ -30,15 +30,14 @@ supported_publishers_markdown_path: Path = root_path / "docs" / "supported_publi
 
 
 class ColumnFactory(Protocol):
-    def __call__(self, publisher: Publisher) -> lxml.html.HtmlElement:
-        ...
+    def __call__(self, publisher: Publisher) -> lxml.html.HtmlElement: ...
 
 
 column_mapping: Dict[str, ColumnFactory] = {
     "Class": lambda publisher: TD(CODE(publisher.__name__)),
-    "Name": lambda publisher: TD(DIV(f"{publisher.name}"))
-    if not publisher.deprecated
-    else TD(DIV(STRIKE(f"{publisher.name}"))),
+    "Name": lambda publisher: (
+        TD(DIV(f"{publisher.name}")) if not publisher.deprecated else TD(DIV(STRIKE(f"{publisher.name}")))
+    ),
     "URL": lambda publisher: TD(A(SPAN(urlparse(publisher.domain).netloc), href=publisher.domain)),
     "Languages": lambda publisher: TD(*[CODE(lang) for lang in sorted(publisher.languages)]),
     "Missing Attributes": lambda publisher: (
@@ -91,7 +90,8 @@ def align_tables(tables: Sequence[lxml.html.HtmlElement]) -> None:
         raise ValueError("The tables do not have the same number of columns.")
 
     for column_index, colum_heads in enumerate(
-        more_itertools.transpose(table_heads), start=1  # type: ignore[attr-defined]
+        more_itertools.transpose(table_heads),
+        start=1,  # type: ignore[attr-defined]
     ):
         column_texts: List[str] = [
             text for table in tables for text in table.xpath(f"/table/tbody/tr/td[{column_index}]//text()")
@@ -100,8 +100,8 @@ def align_tables(tables: Sequence[lxml.html.HtmlElement]) -> None:
 
         for head in colum_heads:
             assert head.text is not None
-            text: str = head.text.replace(" ", "\u00A0")
-            padding: str = "\u00A0" * (2 * (max_column_length - len(head.text)))
+            text: str = head.text.replace(" ", "\u00a0")
+            padding: str = "\u00a0" * (2 * (max_column_length - len(head.text)))
             head.text = f"{text}{padding}"
 
 

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -4,6 +4,7 @@ The tests include a real-time crawl for each publisher's news map and RSS Feed
 checking the received articles for attribute completeness.
 Note that this script does not check the attributes' correctness, only their presence.
 """
+
 import sys
 import traceback
 from argparse import ArgumentParser

--- a/src/fundus/logging.py
+++ b/src/fundus/logging.py
@@ -57,7 +57,7 @@ def add_handler(handler: logging.Handler):
         handler: The new handler to add.
     """
     if handler.name is None:
-        raise ValueError(f"Handlers to add must have a name set")
+        raise ValueError("Handlers to add must have a name set")
 
     if handlers.get(handler.name) is not None:
         raise ValueError(f"Handler with name {handler.name} already exists")

--- a/src/fundus/parser/base_parser.py
+++ b/src/fundus/parser/base_parser.py
@@ -359,7 +359,9 @@ class _ParserCache:
 
 class ParserProxy(ABC):
     def __init__(self):
-        predicate: Callable[[object], bool] = lambda x: inspect.isclass(x) and issubclass(x, BaseParser)
+        def predicate(x: object) -> bool:
+            return inspect.isclass(x) and issubclass(x, BaseParser)
+
         included_parsers: List[Type[BaseParser]] = [
             parser for name, parser in inspect.getmembers(type(self), predicate=predicate)
         ]

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -216,7 +216,7 @@ class LinkedDataMapping:
             elif len(values) == 1:
                 return values.pop()
             else:
-                raise ValueError(f"Got multiple values when expecting a single scalar value")
+                raise ValueError("Got multiple values when expecting a single scalar value")
         else:
             return values
 

--- a/src/fundus/parser/data.py
+++ b/src/fundus/parser/data.py
@@ -142,12 +142,10 @@ class LinkedDataMapping:
     __value_regex__ = re.compile("^<[^<]*>(?P<value>.*)</[^<]*>$", flags=re.DOTALL)
 
     @overload
-    def xpath_search(self, query: Union[XPath, str], scalar: Literal[False] = False) -> List[Any]:
-        ...
+    def xpath_search(self, query: Union[XPath, str], scalar: Literal[False] = False) -> List[Any]: ...
 
     @overload
-    def xpath_search(self, query: Union[XPath, str], scalar: Literal[True] = True) -> Optional[Any]:
-        ...
+    def xpath_search(self, query: Union[XPath, str], scalar: Literal[True] = True) -> Optional[Any]: ...
 
     def xpath_search(self, query: Union[XPath, str], scalar: bool = False):
         """Search through LD using XPath expressions
@@ -298,12 +296,10 @@ class TextSequence(Sequence[str]):
         self._data: Tuple[str, ...] = tuple(texts)
 
     @overload
-    def __getitem__(self, i: int) -> str:
-        ...
+    def __getitem__(self, i: int) -> str: ...
 
     @overload
-    def __getitem__(self, s: slice) -> "TextSequence":
-        ...
+    def __getitem__(self, s: slice) -> "TextSequence": ...
 
     def __getitem__(self, i):
         return self._data[i] if isinstance(i, int) else type(self)(self._data[i])
@@ -528,8 +524,7 @@ class ImageVersion(DataclassSerializationMixin):
         raise NotImplementedError(f"'<' is not defined between {type(self).__name__!r} and {type(other).__name__!r}")
 
 
-class ImageURLError(Exception):
-    ...
+class ImageURLError(Exception): ...
 
 
 @dataclass(frozen=False)

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -172,7 +172,7 @@ def extract_article_body_with_selector(
         # return empty body if no text is present
         return ArticleBody(TextSequence([]), [])
 
-    instructions = more_itertools.split_when(nodes, pred=lambda x, y: type(x) != type(y))
+    instructions = more_itertools.split_when(nodes, pred=lambda x, y: type(x) is not type(y))
 
     if not summary_nodes:
         instructions = more_itertools.prepend([], instructions)

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -60,7 +60,7 @@ _space_characters = {
     "zero-width-joiner": r"\u200D",
     "zero-width-no-break_space": r"\uFEFF",
 }
-_ws_pattern: Pattern[str] = re.compile(rf'[{"".join(_space_characters.values())}]+')
+_ws_pattern: Pattern[str] = re.compile(rf"[{''.join(_space_characters.values())}]+")
 
 
 def normalize_whitespace(text: str) -> str:

--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -177,7 +177,7 @@ def extract_article_body_with_selector(
     if not summary_nodes:
         instructions = more_itertools.prepend([], instructions)
     elif not nodes[: len(summary_nodes)] == summary_nodes:
-        raise ValueError(f"All summary nodes should be at the beginning of the article")
+        raise ValueError("All summary nodes should be at the beginning of the article")
 
     if not subhead_nodes or (paragraph_nodes and subhead_nodes[0] > paragraph_nodes[0]):
         first = next(instructions)
@@ -874,7 +874,7 @@ def parse_image_nodes(
             )
         except ImageURLError as error:
             if node.attrib.get("loading") == "lazy":
-                logger.debug(f"Skipping lazy loading image")
+                logger.debug("Skipping lazy loading image")
             else:
                 logger.debug(error)
         else:

--- a/src/fundus/publishers/__init__.py
+++ b/src/fundus/publishers/__init__.py
@@ -58,7 +58,7 @@ class PublisherCollectionMeta(PublisherGroup):
                 new_publishers: Set[str] = {publisher.__name__ for publisher in value}
                 if duplicate_publishers := publishers & new_publishers:
                     raise ValueError(
-                        f"Publisher(s) {', '.join(duplicate_publishers)!r} " f"already exists in collection {name!r}."
+                        f"Publisher(s) {', '.join(duplicate_publishers)!r} already exists in collection {name!r}."
                     )
                 publishers.update(new_publishers)
             elif isinstance(value, Publisher):

--- a/src/fundus/publishers/at/orf.py
+++ b/src/fundus/publishers/at/orf.py
@@ -14,7 +14,7 @@ from fundus.parser.utility import (
 
 class OrfParser(ParserProxy):
     class V1(BaseParser):
-        _paragraph_selector = CSSSelector("div.story-story > " "p:not(.caption.tvthek.stripe-credits)")
+        _paragraph_selector = CSSSelector("div.story-story > p:not(.caption.tvthek.stripe-credits)")
         _summary_selector = CSSSelector("div.story-lead > p")
         _subheadline_selector = CSSSelector("div.story-story > h2")
 

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -370,7 +370,6 @@ class PublisherGroup(type):
 
         matched: Union[List[FilteredPublisher], List[Publisher]] = []
         unique_attributes = set(attributes)
-        spec: Publisher
         for publisher in cls:
             if unique_attributes.issubset(
                 set(publisher.parser().attributes().names)

--- a/src/fundus/publishers/be/nieuwsblad.py
+++ b/src/fundus/publishers/be/nieuwsblad.py
@@ -20,7 +20,7 @@ class NieuwsbladParser(ParserProxy):
         _summary_selector = XPath("//*[@data-testid='article-intro']")
         _paragraph_selector = XPath("//*[@data-testid='article-body']/p[text()]")
         _subheadline_selector = XPath(
-            "//*[@data-testid='article-body']/p/span[@class='bold'] | " "//*[@data-testid='article-body']/h3"
+            "//*[@data-testid='article-body']/p/span[@class='bold'] | //*[@data-testid='article-body']/h3"
         )
 
         _topic_selector = XPath("//ul[contains(@class, 'taglist')]/li|//div[contains(@class, 'tag-list')]/a")

--- a/src/fundus/publishers/ch/srf.py
+++ b/src/fundus/publishers/ch/srf.py
@@ -85,10 +85,10 @@ class SRFParser(ParserProxy):
         _title_selector = XPath("//span[@class='article-title__text']")
         _author_selector = XPath("//span[@itemprop='author']")
         _summary_selector = XPath(
-            "//p[@class='article-lead'] |" "//ul[@class='article-list' and not(preceding-sibling::*)]/li"
+            "//p[@class='article-lead'] |//ul[@class='article-list' and not(preceding-sibling::*)]/li"
         )
         _paragraph_selector = XPath(
-            "//p[@class='article-paragraph'] |" "//ul[@class='article-list' and preceding-sibling::*]/li"
+            "//p[@class='article-paragraph'] |//ul[@class='article-list' and preceding-sibling::*]/li"
         )
         _subheadline_selector = XPath("//h2[@class='article-heading']|//h3[@class='article-subheading']")
 

--- a/src/fundus/publishers/de/dw.py
+++ b/src/fundus/publishers/de/dw.py
@@ -81,11 +81,9 @@ class DWParser(ParserProxy):
         _subheadline_selector = CSSSelector("div.longText > h2")
         _title_selector = CSSSelector(".col3 h1")
         _author_selector = XPath(
-            "normalize-space(" '//ul[@class="smallList"]' '/li[strong[contains(text(), "Auto")]]' "/text()[last()]" ")"
+            'normalize-space(//ul[@class="smallList"]/li[strong[contains(text(), "Auto")]]/text()[last()])'
         )
-        _date_selector = XPath(
-            "normalize-space(" '//ul[@class="smallList"]' '/li[strong[contains(text(), "Datum")]]' "/text())"
-        )
+        _date_selector = XPath('normalize-space(//ul[@class="smallList"]/li[strong[contains(text(), "Datum")]]/text())')
 
         @attribute
         def body(self) -> Optional[ArticleBody]:

--- a/src/fundus/publishers/de/klassegegenklasse.py
+++ b/src/fundus/publishers/de/klassegegenklasse.py
@@ -2,7 +2,6 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from lxml.cssselect import CSSSelector
 from lxml.etree import XPath
 
 from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute

--- a/src/fundus/publishers/de/ntv.py
+++ b/src/fundus/publishers/de/ntv.py
@@ -22,7 +22,7 @@ class NTVParser(ParserProxy):
         _author_substitution_pattern: Pattern[str] = re.compile(r"n-tv NACHRICHTEN")
         _summary_selector = XPath("//div[@class='article__text']/p[not(last()) and strong][1]")
         _paragraph_selector = XPath(
-            "//div[@class='article__text']" "/p[not(strong) or (strong and (position() > 1 or last()))]"
+            "//div[@class='article__text']/p[not(strong) or (strong and (position() > 1 or last()))]"
         )
         _subheadline_selector: XPath = CSSSelector(".article__text > h2")
 

--- a/src/fundus/publishers/de/spon.py
+++ b/src/fundus/publishers/de/spon.py
@@ -53,7 +53,7 @@ class SPONParser(ParserProxy):
                 lower_boundary_selector=XPath("//footer"),
                 image_selector=XPath("//figure//picture//img"),
                 caption_selector=XPath(
-                    "./ancestor::figure/following-sibling::figcaption[1]//p|" "./ancestor::figure/figcaption[1]//p"
+                    "./ancestor::figure/following-sibling::figcaption[1]//p|./ancestor::figure/figcaption[1]//p"
                 ),
                 author_selector=XPath(
                     "./ancestor::figure/following-sibling::figcaption[1]/span|"

--- a/src/fundus/publishers/de/sportschau.py
+++ b/src/fundus/publishers/de/sportschau.py
@@ -18,7 +18,7 @@ from fundus.parser.utility import (
 class SportSchauParser(ParserProxy):
     class V1(BaseParser):
         _summary_selector = CSSSelector(
-            "p[class='textabsatz columns twelve  m-ten  m-offset-one l-eight l-offset-two']" " > strong"
+            "p[class='textabsatz columns twelve  m-ten  m-offset-one l-eight l-offset-two'] > strong"
         )
         _paragraph_selector = CSSSelector("article >p.textabsatz:not(p.textabsatz:nth-of-type(1))")
         _subheadline_selector = CSSSelector("article >h2")

--- a/src/fundus/publishers/es/mallorca_magazin.py
+++ b/src/fundus/publishers/es/mallorca_magazin.py
@@ -53,8 +53,7 @@ class MallorcaMagazinParser(ParserProxy):
                 image_selector=XPath("//figure//img|//div[@id='post-text']//p/img"),
                 paragraph_selector=self._paragraph_selector,
                 caption_selector=XPath(
-                    "./ancestor::div[@class='col-sm-12']//p[@class='img-description'] | "
-                    "./ancestor::figure//figcaption"
+                    "./ancestor::div[@class='col-sm-12']//p[@class='img-description'] | ./ancestor::figure//figcaption"
                 ),
                 author_selector=re.compile(r"\|(?P<credits>.+)"),
             )

--- a/src/fundus/publishers/gl/sermitsiaq.py
+++ b/src/fundus/publishers/gl/sermitsiaq.py
@@ -16,7 +16,7 @@ from fundus.parser.utility import (
 class SermitsiaqParser(ParserProxy):
     class V1(BaseParser):
         _paragraph_selector = XPath(
-            f"//div[contains(@class, 'bodytext')]//p[not(@class='offer-description' or re:test(text(), '^/.*/$'))]",
+            "//div[contains(@class, 'bodytext')]//p[not(@class='offer-description' or re:test(text(), '^/.*/$'))]",
             namespaces={"re": "http://exslt.org/regular-expressions"},
         )
         _summary_selector = XPath("//h2[@class='subtitle '] ")

--- a/src/fundus/publishers/isl/morgunbladid.py
+++ b/src/fundus/publishers/isl/morgunbladid.py
@@ -16,7 +16,7 @@ class MorgunbladidParser(ParserProxy):
     class V1(BaseParser):
         _summary_selector = XPath("//div[@class='main-layout']//div[@class='is-merking']/p")
         _paragraph_selector = XPath(
-            "//div[@class='main-layout' or @data-element-type='body-facts']" "/p[not(a and not(text()))]"
+            "//div[@class='main-layout' or @data-element-type='body-facts']/p[not(a and not(text()))]"
         )
         _subheadline_selector = XPath("//div[@class='main-layout' or @class='et_pb_text_inner']/h3")
 

--- a/src/fundus/publishers/jp/nikkan_geadai.py
+++ b/src/fundus/publishers/jp/nikkan_geadai.py
@@ -37,7 +37,7 @@ class NikkanGeadaiParser(ParserProxy):
         def _transform_br_element(self):
             if nodes := self._full_text_selector(self.precomputed.doc):
                 if len(nodes) != 1:
-                    raise ValueError(f"Expected exactly one node")
+                    raise ValueError("Expected exactly one node")
                 else:
                     transform_breaks_to_tag(nodes[0], __class__="br-wrap")
 

--- a/src/fundus/publishers/jp/sankei_shimbun.py
+++ b/src/fundus/publishers/jp/sankei_shimbun.py
@@ -41,7 +41,9 @@ class SankeiShimbunParser(ParserProxy):
         @attribute
         def authors(self) -> List[str]:
             return [
-                author for author in generic_author_parsing(self.precomputed.meta.get("author")) if "産経新聞" not in author
+                author
+                for author in generic_author_parsing(self.precomputed.meta.get("author"))
+                if "産経新聞" not in author
             ]
 
         @attribute

--- a/src/fundus/publishers/kr/hankook_ilbo.py
+++ b/src/fundus/publishers/kr/hankook_ilbo.py
@@ -98,9 +98,7 @@ class HankookIlboParser(ParserProxy):
                 content_node = lxml.html.fromstring(cleaned_content_html)
 
                 # parse summary node and add to content node
-                summary_html = (
-                    f"<h2>" f"{self.precomputed.ld.xpath_search('//page-data//subTitle', scalar=True)}" f"</h2>"
-                )
+                summary_html = f"<h2>{self.precomputed.ld.xpath_search('//page-data//subTitle', scalar=True)}</h2>"
                 summary__node = lxml.html.fromstring(summary_html)
                 content_node.insert(0, summary__node)
                 transform_breaks_to_tag(summary__node, tag="h2", replace=True)

--- a/src/fundus/publishers/lb/__init__.py
+++ b/src/fundus/publishers/lb/__init__.py
@@ -1,6 +1,6 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.publishers.lb.lbc_group import LBCGroupParser
-from fundus.scraping.url import NewsMap, RSSFeed, Sitemap
+from fundus.scraping.url import NewsMap, RSSFeed
 
 
 class LB(metaclass=PublisherGroup):

--- a/src/fundus/publishers/lt/lrt.py
+++ b/src/fundus/publishers/lt/lrt.py
@@ -18,12 +18,11 @@ from fundus.parser.utility import (
 class LRTParser(ParserProxy):
     class V1(BaseParser):
         _paragraph_selector = XPath(
-            "//div[@class='article-content js-text-selection']/"
-            "p[not((strong and not(text())) or @class='text-lead')]"
+            "//div[@class='article-content js-text-selection']/p[not((strong and not(text())) or @class='text-lead')]"
         )
         _summary_selector = CSSSelector("p.text-lead")
         _subheadline_selector = XPath(
-            "//div[@class='article-content js-text-selection']/" "p[strong and not(@class='text-lead') and not(text())]"
+            "//div[@class='article-content js-text-selection']/p[strong and not(@class='text-lead') and not(text())]"
         )
 
         @attribute

--- a/src/fundus/publishers/lu/__init__.py
+++ b/src/fundus/publishers/lu/__init__.py
@@ -1,5 +1,5 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
-from fundus.scraping.filter import inverse, regex_filter
+from fundus.scraping.filter import regex_filter
 from fundus.scraping.url import NewsMap, RSSFeed, Sitemap
 
 from .luxemburger_wort import LuxemburgerWortParser

--- a/src/fundus/publishers/no/verdensgang.py
+++ b/src/fundus/publishers/no/verdensgang.py
@@ -18,7 +18,7 @@ from fundus.parser.utility import (
 
 class VerdensGangParser(ParserProxy):
     class V1(BaseParser):
-        _bloat_pattern: str = "Les også:|" "Vil du lese mer"
+        _bloat_pattern: str = "Les også:|Vil du lese mer"
 
         _summary_selector = CSSSelector("header.article-intro p")
         _subheadline_selector = CSSSelector("section.article-body > h2")

--- a/src/fundus/publishers/shared/euronews.py
+++ b/src/fundus/publishers/shared/euronews.py
@@ -57,7 +57,7 @@ class EuronewsParser(ParserProxy):
                 doc=self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,
                 image_selector=XPath(
-                    "//img[contains(@class, 'c-article-media__img')" " or contains(@class, 'widgetImage__image')]"
+                    "//img[contains(@class, 'c-article-media__img') or contains(@class, 'widgetImage__image')]"
                 ),
                 caption_selector=XPath(
                     "./ancestor::div[contains(@class, 'c-article-image-video')]"

--- a/src/fundus/publishers/tr/anadolu_ajansi.py
+++ b/src/fundus/publishers/tr/anadolu_ajansi.py
@@ -76,6 +76,6 @@ class AnadoluAjansiParser(ParserProxy):
             return image_extraction(
                 doc=self.precomputed.doc,
                 paragraph_selector=self._paragraph_selector,
-                image_selector=CSSSelector("div.row.detay.container > div.col-md-10 > img," "div img[alt='']"),
+                image_selector=CSSSelector("div.row.detay.container > div.col-md-10 > img,div img[alt='']"),
                 relative_urls=True,
             )

--- a/src/fundus/publishers/uk/__init__.py
+++ b/src/fundus/publishers/uk/__init__.py
@@ -39,7 +39,7 @@ class UK(metaclass=PublisherGroup):
         sources=[
             Sitemap(
                 "https://www.independent.co.uk/sitemap.xml",
-                sitemap_filter=inverse(regex_filter(f"sitemap-articles")),
+                sitemap_filter=inverse(regex_filter("sitemap-articles")),
             ),
             NewsMap("https://www.independent.co.uk/sitemaps/googlenews"),
         ],

--- a/src/fundus/publishers/uk/metro.py
+++ b/src/fundus/publishers/uk/metro.py
@@ -35,9 +35,7 @@ class MetroParser(ParserProxy):
             r"^Do you have a story to share?"
         )
         _paragraph_selector = XPath(
-            f"//article "
-            f"/div[@class='article-body'] "
-            f"/p[position()>1 and not(re:test(string(), '{_bloat_regex_}'))]",
+            f"//article /div[@class='article-body'] /p[position()>1 and not(re:test(string(), '{_bloat_regex_}'))]",
             namespaces={"re": "http://exslt.org/regular-expressions"},
         )
 

--- a/src/fundus/publishers/uk/nature.py
+++ b/src/fundus/publishers/uk/nature.py
@@ -31,7 +31,7 @@ class NatureParser(ParserProxy):
         )
 
         _subheadline_selector = XPath(
-            "//div[@data-test='access-teaser']//h2" "[not(ancestor::article[contains(@class, 'recommended')])]"
+            "//div[@data-test='access-teaser']//h2[not(ancestor::article[contains(@class, 'recommended')])]"
         )
 
         _lower_boundary_selector = XPath(

--- a/src/fundus/publishers/uk/the_bbc.py
+++ b/src/fundus/publishers/uk/the_bbc.py
@@ -29,7 +29,7 @@ class TheBBCParser(ParserProxy):
         )
 
         _topic_selector = CSSSelector(
-            "div[data-component='topic-list'] > div > div > ul > li ," "div[data-component='tags'] a"
+            "div[data-component='topic-list'] > div > div > ul > li ,div[data-component='tags'] a"
         )
 
         @attribute

--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -132,12 +132,13 @@ class US(metaclass=PublisherGroup):
         ],
     )
 
-    # WorldTruth = Publisher(
-    #     name="World Truth",
-    #     domain="https://www.worldtruth.tv/",
-    #     sources=[RSSFeed("https://feeds.feedburner.com/ConsciousnessTv")],
-    #     parser=WorldTruthParser,
-    # )
+    WorldTruth = Publisher(
+        name="World Truth",
+        domain="https://www.worldtruth.tv/",
+        sources=[RSSFeed("https://feeds.feedburner.com/ConsciousnessTv")],
+        parser=WorldTruthParser,
+        deprecated=True,
+    )
 
     FreeBeacon = Publisher(
         name="The Washington Free Beacon",

--- a/src/fundus/publishers/us/ap_news.py
+++ b/src/fundus/publishers/us/ap_news.py
@@ -65,8 +65,7 @@ class APNewsParser(ParserProxy):
         _author_selector = CSSSelector("div.Page-authors")
         _subheadline_selector = XPath("//div[contains(@class, 'RichTextStoryBody')] /h2[not(text()='___')]")
         _paragraph_selector = XPath(
-            "//div[contains(@class, 'RichTextStoryBody')] "
-            "/p[not(preceding-sibling::*[1][self::h2 and text()='___'])]"
+            "//div[contains(@class, 'RichTextStoryBody')] /p[not(preceding-sibling::*[1][self::h2 and text()='___'])]"
             # only p-elements not directly following h2 elements with text() = '___'
         )
 

--- a/src/fundus/publishers/us/rolling_stone.py
+++ b/src/fundus/publishers/us/rolling_stone.py
@@ -21,7 +21,7 @@ class RollingStoneParser(ParserProxy):
 
         _paragraph_selector = CSSSelector("div.a-content p.paragraph")
         _summary_selector = CSSSelector("div.article-excerpt")
-        _subheadline_selector = CSSSelector("div.a-content h2.heading," "div.a-content div#pmc-gallery-vertical h2")
+        _subheadline_selector = CSSSelector("div.a-content h2.heading,div.a-content div#pmc-gallery-vertical h2")
 
         @attribute
         def body(self) -> Optional[ArticleBody]:

--- a/src/fundus/publishers/vn/__init__.py
+++ b/src/fundus/publishers/vn/__init__.py
@@ -1,7 +1,6 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.publishers.vn.vnexpress import VnExpressIntlParser
-from fundus.scraping.filter import inverse, regex_filter
-from fundus.scraping.url import NewsMap, RSSFeed, Sitemap
+from fundus.scraping.url import RSSFeed
 
 
 class VN(metaclass=PublisherGroup):

--- a/src/fundus/publishers/za/ilanga.py
+++ b/src/fundus/publishers/za/ilanga.py
@@ -9,7 +9,6 @@ from fundus.parser.utility import (
     extract_article_body_with_selector,
     generic_author_parsing,
     generic_date_parsing,
-    generic_topic_parsing,
     image_extraction,
     strip_nodes_to_text,
 )

--- a/src/fundus/scraping/article.py
+++ b/src/fundus/scraping/article.py
@@ -172,7 +172,7 @@ class Article:
             f'\n- Text:  "{wrapped_plaintext}"'
             f"\n- URL:    {self.html.requested_url}"
             f"\n- From:   {self.publisher}"
-            f'{" (" + self.publishing_date.strftime("%Y-%m-%d %H:%M") + ")" if self.publishing_date else ""}'
+            f"{' (' + self.publishing_date.strftime('%Y-%m-%d %H:%M') + ')' if self.publishing_date else ''}"
         )
 
         return dedent(text)

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -514,8 +514,8 @@ class Crawler(CrawlerBase):
         fitting_publishers = list(filter(filter_publishers, more_itertools.collapse(publishers)))
         if not fitting_publishers:
             raise ValueError(
-                f"All given publishers are deprecated. Either set <ignore_deprecated> to `False` or "
-                f"include at least one publisher that isn't deprecated."
+                "All given publishers are deprecated. Either set <ignore_deprecated> to `False` or "
+                "include at least one publisher that isn't deprecated."
             )
 
         super().__init__(*fitting_publishers)

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -341,8 +341,7 @@ class CrawlerBase(ABC):
         if max_articles_per_publisher:
             if timeout < 120:
                 print(
-                    "It is recommended to set a minimum <timeout> of 120 seconds when using "
-                    "max_articles_per_publisher."
+                    "It is recommended to set a minimum <timeout> of 120 seconds when using max_articles_per_publisher."
                 )
             max_articles = -1
 

--- a/src/fundus/scraping/filter.py
+++ b/src/fundus/scraping/filter.py
@@ -83,8 +83,7 @@ def regex_filter(regex: str) -> URLFilter:
 
 
 class SupportsBool(Protocol):
-    def __bool__(self) -> bool:
-        ...
+    def __bool__(self) -> bool: ...
 
 
 class ExtractionFilter(Protocol):

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -170,7 +170,9 @@ class WebSource:
                         f"Found crawl-delay of {robots_delay} seconds in robots.txt for {self.publisher.name}. "
                         f"Overwriting existing delay."
                     )
-                    delay = lambda: robots_delay
+
+                    def delay() -> float:
+                        return robots_delay
 
         self.clock = _Clock(delay=delay, sleep=self._sleep)
 

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -91,8 +91,7 @@ class WebSourceInfo(SourceInfo):
 
 
 class HTMLSource(Protocol):
-    def fetch(self, url_filter: Optional[URLFilter] = None) -> Iterator[HTML]:
-        ...
+    def fetch(self, url_filter: Optional[URLFilter] = None) -> Iterator[HTML]: ...
 
 
 class _Clock:
@@ -351,8 +350,7 @@ class CCNewsSource:
 
                 if publisher.url_filter is not None and publisher.url_filter(target_url):
                     logger.debug(
-                        f"Skipped WARC record with target URI {target_url!r} because of "
-                        f"publisher specific URL filter"
+                        f"Skipped WARC record with target URI {target_url!r} because of publisher specific URL filter"
                     )
                     continue
 

--- a/src/fundus/scraping/session.py
+++ b/src/fundus/scraping/session.py
@@ -206,8 +206,8 @@ class SessionHandler:
 
         else:
             raise AssertionError(
-                f"Tried to open a session context within another thread. "
-                f"Exit the existing context before opening a new one."
+                "Tried to open a session context within another thread. "
+                "Exit the existing context before opening a new one."
             )
 
 

--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -85,7 +85,7 @@ class _ArchiveDecompressor:
 
     def _decompress_octet_stream(self, compressed_content: bytes) -> bytes:
         if (compression_format := CompressionFormats.identify(compressed_content)) is None:
-            logger.debug(f"Could not identify compression format")
+            logger.debug("Could not identify compression format")
             raise NotImplementedError
 
         return compression_format(compressed_content)
@@ -121,7 +121,7 @@ class URLSource(Iterable[str], ABC):
 
     @abstractmethod
     def __iter__(self) -> Iterator[str]:
-        raise NotImplemented
+        raise NotImplementedError
 
     def get_urls(self, max_urls: Optional[int] = None) -> Iterator[str]:
         """Returns a generator yielding up to <max_urls> URLs from <self>.

--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -368,12 +368,10 @@ class EventDict:
             self._alias(alias, key)
 
     @overload
-    def get_alias(self, ident: int) -> str:
-        ...
+    def get_alias(self, ident: int) -> str: ...
 
     @overload
-    def get_alias(self, ident: int, default: _T) -> Union[str, _T]:
-        ...
+    def get_alias(self, ident: int, default: _T) -> Union[str, _T]: ...
 
     def get_alias(self, ident: int, default=_sentinel):
         """Return the alias associated with a thread identifier.

--- a/src/fundus/utils/regex.py
+++ b/src/fundus/utils/regex.py
@@ -5,25 +5,21 @@ _T = TypeVar("_T")
 
 
 @overload
-def _get_match_dict(pattern: Pattern[str], string: str, conversion: Callable[[str], _T]) -> Dict[str, _T]:
-    ...
+def _get_match_dict(pattern: Pattern[str], string: str, conversion: Callable[[str], _T]) -> Dict[str, _T]: ...
 
 
 @overload
 def _get_match_dict(
     pattern: Pattern[str], string: str, conversion: Callable[[str], _T], keep_none: Literal[True]
-) -> Dict[str, Optional[_T]]:
-    ...
+) -> Dict[str, Optional[_T]]: ...
 
 
 @overload
-def _get_match_dict(pattern: Pattern[str], string: str) -> Dict[str, str]:
-    ...
+def _get_match_dict(pattern: Pattern[str], string: str) -> Dict[str, str]: ...
 
 
 @overload
-def _get_match_dict(pattern: Pattern[str], string: str, keep_none: Literal[True]) -> Dict[str, Optional[str]]:
-    ...
+def _get_match_dict(pattern: Pattern[str], string: str, keep_none: Literal[True]) -> Dict[str, Optional[str]]: ...
 
 
 def _get_match_dict(  # type: ignore[misc]

--- a/tests/resources/parser/attribute_annotations.py
+++ b/tests/resources/parser/attribute_annotations.py
@@ -12,10 +12,10 @@ def _parse_attribute_annotations() -> Dict[str, object]:
     # We import the attribute annotations types locally to make them accessible in the local namespace,
     # such that eval() can evaluate the type annotations.
     # Therefore, these imports are not unused and manageable more easily than defining them in the global namespace.
-    from datetime import datetime
-    from typing import Optional
+    from datetime import datetime  # noqa: F401
+    from typing import Optional  # noqa: F401
 
-    from fundus.parser import ArticleBody, Image
+    from fundus.parser import ArticleBody, Image  # noqa: F401
 
     attribute_guidelines_path = root_path / "docs" / "attribute_guidelines.md"
 

--- a/tests/resources/test_events.py
+++ b/tests/resources/test_events.py
@@ -22,7 +22,7 @@ class TestEvents:
 
         events.clear_event("success")
 
-        assert events.is_event_set("success") == False
+        assert not events.is_event_set("success")
 
     def test_set_clear_all(self):
         events = EventDict()
@@ -32,24 +32,24 @@ class TestEvents:
 
         events.set_for_all("success")
 
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == True
+        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) is True
 
         events.clear_for_all("success")
 
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == False
+        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) is False
 
         events.register_event("failure", 1)
         events.register_event("failure", 2)
 
         events.set_for_all()
 
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == True
-        assert events.is_event_set("failure", 1) == events.is_event_set("failure", 2) == True
+        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) is True
+        assert events.is_event_set("failure", 1) == events.is_event_set("failure", 2) is True
 
         events.clear_for_all()
 
-        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) == False
-        assert events.is_event_set("failure", 1) == events.is_event_set("failure", 2) == False
+        assert events.is_event_set("success", 1) == events.is_event_set("success", 2) is False
+        assert events.is_event_set("failure", 1) == events.is_event_set("failure", 2) is False
 
     def test_new_event_after_set_for_all(self):
         events = EventDict()
@@ -60,8 +60,8 @@ class TestEvents:
 
         events.register_event("success", 2)
 
-        assert events.is_event_set("success", 1) == True
-        assert events.is_event_set("success", 2) == False
+        assert events.is_event_set("success", 1)
+        assert not events.is_event_set("success", 2)
 
     def test_set_for_all_future_true(self):
         events = EventDict()
@@ -72,8 +72,8 @@ class TestEvents:
 
         events.register_event("success", 2)
 
-        assert events.is_event_set("success", 1) == True
-        assert events.is_event_set("success", 2) == True
+        assert events.is_event_set("success", 1)
+        assert events.is_event_set("success", 2)
 
     def test_clear_for_all_resets_futures(self):
         events = EventDict()
@@ -83,7 +83,7 @@ class TestEvents:
 
         events.register_event("success", 1)
 
-        assert events.is_event_set("success", 1) == False
+        assert not events.is_event_set("success", 1)
 
     def test_alias(self):
         events = EventDict(default_events=["success"])
@@ -92,7 +92,7 @@ class TestEvents:
 
         events.set_event("success", "main-thread")
 
-        assert events.is_event_set("success", "main-thread") == True
+        assert events.is_event_set("success", "main-thread")
 
     def test_set_all_with_alias(self):
         events = EventDict(default_events=["success"])
@@ -101,11 +101,11 @@ class TestEvents:
 
         events.set_for_all("success")
 
-        assert events.is_event_set("success", "main-thread") == True
+        assert events.is_event_set("success", "main-thread")
 
         events.clear_for_all("success")
 
-        assert events.is_event_set("success", "main-thread") == False
+        assert not events.is_event_set("success", "main-thread")
 
     def test_duplicate(self):
         events = EventDict()

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -15,15 +15,15 @@ class TestArticle:
         extraction = {"authors": ["Author"], "title": "title"}
 
         with pytest.raises(TypeError):
-            article = Article(extraction, html=html)  # type: ignore[arg-type, misc]
+            Article(extraction, html=html)  # type: ignore[arg-type, misc]
 
         with pytest.raises(TypeError):
-            article = Article(**extraction)  # type: ignore[arg-type]
+            Article(**extraction)  # type: ignore[arg-type]
 
-        article = Article(**{}, html=html)
-        article = Article(**extraction, html=html, exception=None)
-        article = Article(html=html, **extraction, exception=None)
-        article = Article(**extraction, html=html, exception=TypeError())
+        Article(**{}, html=html)
+        Article(**extraction, html=html, exception=None)
+        Article(html=html, **extraction, exception=None)
+        Article(**extraction, html=html, exception=TypeError())
 
     def test_default_values(self):
         extraction: Dict[str, Any] = {}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,7 +34,7 @@ class TestEvents:
         assert events.is_event_set("success", "thread-1") == events.is_event_set("success", "thread-2") is True
 
         events.clear_for_all("success")
-        assert events.is_event_set("success", "thread-1") == events.is_event_set("success", "thread-2") == False
+        assert events.is_event_set("success", "thread-1") == events.is_event_set("success", "thread-2") is False
 
         events.register_event("failure", "thread-1")
         events.register_event("failure", "thread-2")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -159,7 +159,7 @@ class TestParserProxy:
 
     def test_call(self, proxy_with_two_versions_and_different_attrs):
         parser_proxy = proxy_with_two_versions_and_different_attrs()
-        assert type(parser_proxy()) == parser_proxy.latest_version
+        assert type(parser_proxy()) is parser_proxy.latest_version
 
         for versioned_parser in parser_proxy:
             from_proxy = parser_proxy(versioned_parser.VALID_UNTIL)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -229,14 +229,14 @@ class TestParser:
         for versioned_parser in publisher.parser:
             # validate json
             version_name = versioned_parser.__name__
-            assert (
-                version_data := comparative_data.get(version_name)
-            ), f"Missing test data for parser version {version_name!r}"
+            assert (version_data := comparative_data.get(version_name)), (
+                f"Missing test data for parser version {version_name!r}"
+            )
 
             # validate test HTML
-            assert (
-                html := html_mapping.get(versioned_parser)
-            ), f"Missing test HTML for parser version {version_name} of publisher {publisher.name}"
+            assert (html := html_mapping.get(versioned_parser)), (
+                f"Missing test HTML for parser version {version_name} of publisher {publisher.name}"
+            )
 
             # re-instantiate parser to address deprecated attributes
             timestamp_instantiated_parser = publisher.parser(html.crawl_date)
@@ -251,13 +251,13 @@ class TestParser:
             # test coverage
             supported_attrs = set(timestamp_instantiated_parser.registered_attributes.names)
             missing_attrs = attributes_required_to_cover & supported_attrs - set(version_data.keys())
-            assert (
-                not missing_attrs
-            ), f"Test JSON for {version_name} of publisher {publisher.name} does not cover the following attribute(s): {missing_attrs}"
+            assert not missing_attrs, (
+                f"Test JSON for {version_name} of publisher {publisher.name} does not cover the following attribute(s): {missing_attrs}"
+            )
 
-            assert list(version_data.keys()) == sorted(
-                attributes_required_to_cover & supported_attrs
-            ), f"Test JSON for {version_name} is not in alphabetical order"
+            assert list(version_data.keys()) == sorted(attributes_required_to_cover & supported_attrs), (
+                f"Test JSON for {version_name} is not in alphabetical order"
+            )
 
             # compare data
             extraction = timestamp_instantiated_parser.parse(html.content, "raise")
@@ -317,5 +317,5 @@ class TestMetaInfo:
             meta_info = meta_file.load()
             assert meta_info, f"Meta info file {meta_file.path} is missing"
             assert sorted(meta_info.keys()) == list(meta_info.keys()), (
-                f"Meta info file {meta_file.path} " f"isn't ordered properly."
+                f"Meta info file {meta_file.path} isn't ordered properly."
             )

--- a/tests/test_publisher_collection.py
+++ b/tests/test_publisher_collection.py
@@ -32,9 +32,9 @@ class TestPublisherCollection:
 
         default_language = getattr(region, "default_language")
 
-        assert (
-            default_language in language_codes
-        ), f"Default language {default_language!r} isn't a ISO 639 language code"
+        assert default_language in language_codes, (
+            f"Default language {default_language!r} isn't a ISO 639 language code"
+        )
 
     @pytest.mark.parametrize(
         "publisher", [pytest.param(publisher, id=publisher.__name__) for publisher in PublisherCollection]

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -307,16 +307,14 @@ def load_test_case_data(publisher: Publisher) -> Dict[str, Dict[str, Any]]:
         return test_data
     else:
         raise ValueError(
-            f"Received invalid JSON format for publisher {publisher.name!r}. "
-            f"Expected a JSON with a dictionary as root."
+            f"Received invalid JSON format for publisher {publisher.name!r}. Expected a JSON with a dictionary as root."
         )
 
 
 def load_supported_publishers_markdown() -> bytes:
     if not supported_publishers_markdown_path.exists():
         raise FileNotFoundError(
-            f"The {supported_publishers_markdown_path.name!r} is missing. "
-            f"Run 'python -m fundus.utils.generate_tables'"
+            f"The {supported_publishers_markdown_path.name!r} is missing. Run 'python -m fundus.utils.generate_tables'"
         )
 
     with open(supported_publishers_markdown_path, "rb") as file:


### PR DESCRIPTION
Replaces `black` and `isort` with `ruff` for formatting and linting. Fixes all resulting lint errors across the codebase and updates CI accordingly.
