### PR TITLE
Replace `urllib` parser with `robotspy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "dict2xml>=1.7.6, <2",
     "xmltodict>=0.13.0, <1",
     "bidict>=0.23, <1",
-    "dateparser>=1.2.2, <2"
+    "dateparser>=1.2.2, <2",
+    "robotspy>=0.13.0, <1"
 ]
 
 [project.urls]

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 from textwrap import indent
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Type, Union
-from urllib.robotparser import RobotFileParser
 from warnings import warn
 
 import more_itertools
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
+from robots import RobotFileParser
 from typing_extensions import TypeAlias
 
 from fundus.logging import create_logger


### PR DESCRIPTION
While fixing the `TheSun` parser, I discovered that Python's `urllib.robotparser.RobotFileParser`
fails to reliably parse robots.txt rules in certain real-world formats.

Further investigation revealed a well-known issue [[1](https://github.com/python/cpython/issues/138907)] in the official CPython implementation,
where the parser does not handle modern robots.txt conventions correctly — most notably,
blank lines between stacked `User-agent` declarations and their associated rules cause the
entire rule block to be silently dropped.

This PR replaces the official `RobotFileParser` with a `robotspy` drop in replacement.