### PR TITLE
Remove `request_header` parameter for `WebSource`

### DIFF
--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -130,7 +130,7 @@ class Publisher:
         sources: List[URLSource],
         query_parameter: Optional[Dict[str, str]] = None,
         url_filter: Optional[URLFilter] = None,
-        request_header: Optional[Dict[str, str]] = _default_header,
+        request_header: Dict[str, str] = _default_header,
         deprecated: bool = False,
         disallows_training: bool = False,
         suppress_robots: bool = False,

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -145,7 +145,6 @@ class WebSource:
         url_source: Iterable[str],
         publisher: Publisher,
         url_filter: Optional[URLFilter] = None,
-        request_header: Optional[Dict[str, str]] = None,
         query_parameters: Optional[Dict[str, str]] = None,
         delay: Optional[Delay] = None,
         ignore_robots: bool = False,
@@ -154,10 +153,9 @@ class WebSource:
         self.url_source = url_source
         self.publisher = publisher
         self.url_filter = url_filter
-        self.request_header = request_header or _default_header
         self.query_parameters = query_parameters or {}
         if isinstance(url_source, URLSource):
-            url_source.set_header(self.request_header)
+            url_source.set_header(self.publisher.request_header)
 
         # parse robots:
         self.robots: Optional[Robots] = None
@@ -165,7 +163,7 @@ class WebSource:
             self.robots = self.publisher.robots
 
             if not ignore_crawl_delay:
-                if robots_delay := self.robots.crawl_delay(self.request_header.get("user-agent") or "*"):
+                if robots_delay := self.robots.crawl_delay(self.publisher.request_header.get("user-agent", "*")):
                     logger.debug(
                         f"Found crawl-delay of {robots_delay} seconds in robots.txt for {self.publisher.name}. "
                         f"Overwriting existing delay."
@@ -196,7 +194,9 @@ class WebSource:
             return None
 
         # check robots
-        if not (self.robots is None or self.robots.can_fetch(self.request_header.get("user-agent") or "*", url)):
+        if not (
+            self.robots is None or self.robots.can_fetch(self.publisher.request_header.get("user-agent", "*"), url)
+        ):
             logger.debug(f"Skipped requested URL {url!r} because of robots.txt")
             return None
 
@@ -214,7 +214,7 @@ class WebSource:
 
         # fetch html
         try:
-            response = session.get_with_interrupt(url, headers=self.request_header)
+            response = session.get_with_interrupt(url, headers=self.publisher.request_header)
 
         except (HTTPError, ConnectionError, ReadTimeout) as error:
             logger.warning(f"Skipped requested URL {url!r} because of {error!r}")

--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -94,7 +94,6 @@ class WebScraper(BaseScraper):
             WebSource(
                 url_source=url_source,
                 publisher=publisher,
-                request_header=publisher.request_header,
                 delay=delay,
                 url_filter=publisher.url_filter,
                 query_parameters=publisher.query_parameter,


### PR DESCRIPTION
This PR removes the now somewhat forgotten and unnecessary `request_header` parameter from the `WebSource` constructor and uses the `Publisher.request_header` field instead. Additionally, based on these changes, some minor refactoring is applied.