### PR TITLE
Close pwn-request vulnerability in documentation workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,7 +17,7 @@ env:
   PYTHONPATH: .
 
 jobs:
-  update:
+  supported_publishers:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -39,7 +39,7 @@ jobs:
         run: python scripts/generate_tables.py
 
       - name: Commit changes
-        # [skip ci] prevents this commit from re-triggering the workflow.
+        # [skip ci] prevents this commit from triggering workflows.
         # https://github.com/stefanzweifel/git-auto-commit-action
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -11,53 +11,13 @@ on:
       - src/fundus/publishers/**
       - scripts/generate_tables.py
 
-  pull_request:
-    paths:
-      - src/fundus/publishers/**
-      - scripts/generate_tables.py
-
   workflow_dispatch:
 
 env:
   PYTHONPATH: .
 
-# The workflow is split into two jobs to separate privileged and unprivileged work:
-#
-#   validate — runs on pull requests (no write access)
-#     Regenerates the docs and fails if the output differs from what is committed.
-#     Contributors are expected to run scripts/generate_tables.py locally before opening a PR.
-#
-#   update — runs after merge to master or on manual dispatch (write access)
-#     Regenerates the docs and auto-commits any changes. This is the only place
-#     where contents: write is granted, and it only ever runs on trusted, already-merged code.
-#     workflow_dispatch allows force-regenerating the docs from the Actions UI without
-#     a code change — useful if the docs ever get out of sync.
-
 jobs:
-  validate:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up Git repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install Fundus
-        run: pip install -e .[dev]
-
-      - name: Generate 'supported_publishers.md'
-        run: python scripts/generate_tables.py
-
-      - name: Fail if generated docs are stale
-        run: git diff --exit-code docs/
-
   update:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -11,8 +11,7 @@ on:
       - src/fundus/publishers/**
       - scripts/generate_tables.py
 
-  # https://github.com/stefanzweifel/git-auto-commit-action/issues/211#issuecomment-1100105924
-  pull_request_target:
+  pull_request:
     paths:
       - src/fundus/publishers/**
       - scripts/generate_tables.py
@@ -21,34 +20,52 @@ on:
 
 env:
   PYTHONPATH: .
-  CI_COMMIT_MESSAGE: >-
-    ${{ 
-      github.event_name == 'pull_request' 
-      && format('Update documentation from @ {0} (#{1})', github.event.pull_request.head.sha, github.event.number) 
-      || format('Update documentation from @ {0}', github.sha)
-    }}
+
+# The workflow is split into two jobs to separate privileged and unprivileged work:
+#
+#   validate — runs on pull requests (no write access)
+#     Regenerates the docs and fails if the output differs from what is committed.
+#     Contributors are expected to run scripts/generate_tables.py locally before opening a PR.
+#
+#   update — runs after merge to master or on manual dispatch (write access)
+#     Regenerates the docs and auto-commits any changes. This is the only place
+#     where contents: write is granted, and it only ever runs on trusted, already-merged code.
+#     workflow_dispatch allows force-regenerating the docs from the Actions UI without
+#     a code change — useful if the docs ever get out of sync.
 
 jobs:
-  supported_publishers:
+  validate:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    
+
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install Fundus
+        run: pip install -e .[dev]
+
+      - name: Generate 'supported_publishers.md'
+        run: python scripts/generate_tables.py
+
+      - name: Fail if generated docs are stale
+        run: git diff --exit-code docs/
+
+  update:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
     permissions:
       contents: write
 
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v4
-    # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#use-in-forks-from-public-repositories
-        with:
-          # Checkout the fork/head-repository and push changes to the fork.
-          # If you skip this, the base repository will be checked out and changes
-          # will be committed to the base repository!
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-          # Checkout the branch made in the fork. Will automatically push changes
-          # back to this branch.
-          ref: ${{ github.head_ref }}
-
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
@@ -62,7 +79,9 @@ jobs:
         run: python scripts/generate_tables.py
 
       - name: Commit changes
+        # [skip ci] prevents this commit from re-triggering the workflow.
+        # https://github.com/stefanzweifel/git-auto-commit-action
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: ${{ env.CI_COMMIT_MESSAGE }}
+          commit_message: "docs: regenerate supported_publishers.md [skip ci]"
           file_pattern: docs


### PR DESCRIPTION
The previous workflow used `pull_request_target` to trigger doc generation. This trigger runs with base-repo write permissions even for PRs from forks and unlike `pull_request`, it fires immediately without requiring maintainer approval. Because it also checked out and executed code from the fork (`scripts/generate_tables.py`), any contributor could run arbitrary code with a `contents: write` token against the main repository without any human gating the execution.

**Fix:** replace `pull_request_target` with `pull_request` and split the workflow into two jobs:

- `validate` — runs on PRs, no write access; regenerates the docs and fails if the output differs from what is committed, requiring contributors to run the script locally
- `update` — runs on merge to master and manual dispatch only; holds `contents: write` and auto-commits the regenerated docs

Write access is now only ever granted to already-merged, trusted code.
