### PR TITLE
Fix DailyNewsTZ

### DIFF
--- a/src/fundus/publishers/tz/daily_news_tz.py
+++ b/src/fundus/publishers/tz/daily_news_tz.py
@@ -34,7 +34,7 @@ class DailyNewsTZParser(ParserProxy):
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.xpath_search("//Article//headline", scalar=True) or re.sub(
+            return self.precomputed.ld.xpath_search("(//Article//headline)[1]", scalar=True) or re.sub(
                 r"(?i)\s*-\s*(daily\s*news|habari\s*leo)\s*", "", self.precomputed.meta.get("og:title") or ""
             )
 

--- a/src/fundus/publishers/tz/daily_news_tz.py
+++ b/src/fundus/publishers/tz/daily_news_tz.py
@@ -34,9 +34,7 @@ class DailyNewsTZParser(ParserProxy):
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.xpath_search(
-                "(//Article//headline)[1]", scalar=True
-            ) or re.sub(
+            return self.precomputed.ld.xpath_search("(//Article//headline)[1]", scalar=True) or re.sub(
                 r"(?i)\s*-\s*(daily\s*news|habari\s*leo)\s*",
                 "",
                 self.precomputed.meta.get("og:title") or "",
@@ -55,15 +53,12 @@ class DailyNewsTZParser(ParserProxy):
         @attribute
         def authors(self) -> List[str]:
             return utility.generic_author_parsing(
-                self.precomputed.meta.get("twitter:data1")
-                or self.precomputed.ld.xpath_search("//Article//author")
+                self.precomputed.meta.get("twitter:data1") or self.precomputed.ld.xpath_search("//Article//author")
             )
 
         @attribute
         def publishing_date(self) -> Optional[datetime]:
-            return utility.generic_date_parsing(
-                self.precomputed.ld.bf_search("datePublished")
-            )
+            return utility.generic_date_parsing(self.precomputed.ld.bf_search("datePublished"))
 
         @attribute
         def images(self) -> List[Image]:

--- a/src/fundus/publishers/tz/daily_news_tz.py
+++ b/src/fundus/publishers/tz/daily_news_tz.py
@@ -34,8 +34,12 @@ class DailyNewsTZParser(ParserProxy):
 
         @attribute
         def title(self) -> Optional[str]:
-            return self.precomputed.ld.xpath_search("(//Article//headline)[1]", scalar=True) or re.sub(
-                r"(?i)\s*-\s*(daily\s*news|habari\s*leo)\s*", "", self.precomputed.meta.get("og:title") or ""
+            return self.precomputed.ld.xpath_search(
+                "(//Article//headline)[1]", scalar=True
+            ) or re.sub(
+                r"(?i)\s*-\s*(daily\s*news|habari\s*leo)\s*",
+                "",
+                self.precomputed.meta.get("og:title") or "",
             )
 
         @attribute
@@ -51,12 +55,15 @@ class DailyNewsTZParser(ParserProxy):
         @attribute
         def authors(self) -> List[str]:
             return utility.generic_author_parsing(
-                self.precomputed.meta.get("twitter:data1") or self.precomputed.ld.xpath_search("//Article//author")
+                self.precomputed.meta.get("twitter:data1")
+                or self.precomputed.ld.xpath_search("//Article//author")
             )
 
         @attribute
         def publishing_date(self) -> Optional[datetime]:
-            return utility.generic_date_parsing(self.precomputed.ld.bf_search("datePublished"))
+            return utility.generic_date_parsing(
+                self.precomputed.ld.bf_search("datePublished")
+            )
 
         @attribute
         def images(self) -> List[Image]:


### PR DESCRIPTION
DailyNewsTZ now das two ld json objects containing identical titles, causing an issue as `scalar=True` expects a single entry. This PR just modifies the XPath to choose the first.