### PR TITLE
Add anonymous per thread entry for un aliased threads

### DIFF
--- a/src/fundus/utils/events.py
+++ b/src/fundus/utils/events.py
@@ -130,6 +130,11 @@ class EventDict:
     def _resolve(self, key: Optional[str]) -> str:
         """Resolve ``None`` to the calling thread's alias, or return ``key`` unchanged.
 
+        When the calling thread has no registered alias, an anonymous per-thread
+        entry is created automatically so that operations like :meth:`is_event_set`
+        and :meth:`get` work safely outside of any :meth:`context` block
+        (events default to unset).
+
         Should only be called while holding the internal lock.
 
         Args:
@@ -137,16 +142,15 @@ class EventDict:
 
         Returns:
             The alias string used as the key in ``_events``.
-
-        Raises:
-            RuntimeError: If ``key`` is ``None`` and the current thread has no
-                active context.
         """
         if key is None:
             ident = self._get_identifier()
             if ident in self._aliases.inv:
                 return self._aliases.inv[ident]
-            raise RuntimeError("Current thread has no active context. Pass an explicit alias key.")
+            anon_key = f"__thread_{ident}__"
+            if anon_key not in self._events:
+                self._events[anon_key] = ThreadEventDict(self.default_events, self._event_factory)
+            return anon_key
         return key
 
     def _pretty_resolve(self, key: Optional[str]) -> str:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -134,12 +134,11 @@ class TestEvents:
         # context has exited – alias is no longer active, but events must persist
         assert events.is_event_set("stop", "Sportschau") is True
 
-    def test_no_context_raises_runtime_error(self):
-        """Calling with key=None from a thread with no active context must raise RuntimeError."""
+    def test_no_context_creates_anonymous_entry(self):
+        """Calling with key=None from a thread with no active context creates an anonymous entry with unset events."""
         events = EventDict(default_events=["stop"])
 
-        with pytest.raises(RuntimeError):
-            events.is_event_set("stop")
+        assert not events.is_event_set("stop")
 
     def test_unknown_alias_raises_key_error(self):
         """Accessing a never-registered alias must still raise KeyError."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -140,6 +140,14 @@ class TestEvents:
 
         assert not events.is_event_set("stop")
 
+    def test_no_context_set_and_get(self):
+        """Setting and reading an event without a context works via the anonymous per-thread entry."""
+        events = EventDict(default_events=["stop"])
+
+        assert not events.is_event_set("stop")
+        events.set_event("stop")
+        assert events.is_event_set("stop")
+
     def test_unknown_alias_raises_key_error(self):
         """Accessing a never-registered alias must still raise KeyError."""
         events = EventDict(default_events=["stop"])


### PR DESCRIPTION
The previous changes made it impossible to use any object that queries/sets events (like `WebSource` etc.) outside of an alias context. This made testing and especially development very tedious in certain parts/scenarios. This PR adds an auto generated anonymous alias to threads that query/set events.