### PR TITLE
Replace `requests` with `curl-cffi` and add browser impersonation support

### DIFF
--- a/docs/5_advanced_topics.md
+++ b/docs/5_advanced_topics.md
@@ -5,6 +5,7 @@
     * [Using `search()`](#using-search)
   * [Working with deprecated publishers](#working-with-deprecated-publishers)
   * [Filtering publishers for AI training](#filtering-publishers-for-ai-training)
+  * [Browser impersonation](#browser-impersonation)
 
 # Advanced Topics
 
@@ -40,5 +41,22 @@ Some publishers explicitly disallow the use of their content for AI training pur
 We _try_ to respect these wishes by introducing the `skip_publishers_disallowing_training` parameter in the `crawl()` function.
 Users intending to use Fundus to gather training data for AI models should set this parameter to `True` to avoid collecting articles from publishers that wish for their content to not be used in this way.
 Yet, as publishers are not required to mention this in their robots.txt file, users should additionally check the terms of use of the publishers they want to crawl and set the `disallows_training` attribute of the `Publisher` class accordingly.
+
+## Browser impersonation
+
+A small number of publishers gate their content behind anti-bot checks that inspect the TLS handshake and HTTP/2 fingerprint of the client.
+Fundus can use [`curl_cffi`](https://github.com/lexiforest/curl_cffi) to mimic a real browser's fingerprint for these publishers, but because doing so is intended to bypass an explicit anti-bot signal we consider it an ethical gray area and leave it **off by default**.
+
+To enable it, pass `impersonate=True` to the `Crawler`:
+
+````python
+from fundus import Crawler, PublisherCollection
+
+crawler = Crawler(PublisherCollection, impersonate=True)
+````
+
+When `impersonate=False` (the default), Fundus issues requests with its regular user-agent and TLS fingerprint regardless of what a publisher declares.
+Publishers that require impersonation will likely respond with 4xx/5xx in that case and simply produce no articles — Fundus does not skip them or warn about this.
+When `impersonate=True`, each publisher's declared profile (e.g. `"chrome"`) is used; publishers without a declared profile are unaffected.
 
 In the [next section](6_logging.md) we introduce you to Fundus logging mechanics.

--- a/docs/how_to_add_a_publisher.md
+++ b/docs/how_to_add_a_publisher.md
@@ -261,6 +261,8 @@ will exclude all sitemap URLs not containing the substring `sitemap-content-`.
    The default is: `{"user-agent": "Fundus/2.0 (contact: github.com/flairnlp/fundus)"}`.
 2. If you want to block URLs for the entire publisher use the `url_filter` parameter of `Publisher`.
 3. In some cases it can be necessary to append query parameters to the end of the URL, e.g. to load the article as one page. This can be achieved by adding the `query_parameter` attribute of `PublisherSpec` and assigning it a dictionary object containing the key - value pairs: e.g. `{"page": "all"}`. These key  - value pairs will be appended to all crawled URLs.
+4. If the publisher is only reachable through a browser-like TLS/HTTP fingerprint (i.e. plain `requests`/`curl` get blocked by an anti-bot layer such as Cloudflare or Akamai), you can declare a browser profile via the `impersonate` parameter, e.g. `impersonate="chrome"`. See [curl_cffi's supported targets](https://curl-cffi.readthedocs.io/en/latest/impersonate/targets.html) for the full list.
+   Because browser impersonation is an opt-in feature on the user side (see [Browser impersonation](5_advanced_topics.md#browser-impersonation)), the profile only takes effect when the user constructs the `Crawler` with `impersonate=True`; with the default `impersonate=False` your publisher will be requested without impersonation and will likely fail. Only set this when the publisher genuinely cannot be crawled without it.
 
 Now, let's put it all together to specify The Intercept as a new publisher in Fundus:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "colorama>=0.4, <1",
     "typing-extensions>=4.6, <5",
     "langdetect>=1.0, <2",
-    "requests>=2.28, <3",
     "tqdm>=4.66, <5",
     "fastwarc>=0.14, <1",
     "chardet>=5.2, <6",
@@ -40,7 +39,8 @@ dependencies = [
     "xmltodict>=0.13.0, <1",
     "bidict>=0.23, <1",
     "dateparser>=1.2.2, <2",
-    "robotspy>=0.13.0, <1"
+    "robotspy>=0.13.0, <1",
+    "curl-cffi>=0.7,<1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "colorama>=0.4, <1",
     "typing-extensions>=4.6, <5",
     "langdetect>=1.0, <2",
+    "requests>=2.28, <3",
     "tqdm>=4.66, <5",
     "fastwarc>=0.14, <1",
     "chardet>=5.2, <6",

--- a/scripts/publisher_coverage.py
+++ b/scripts/publisher_coverage.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, List, Optional, Union
 from fundus import Crawler, PublisherCollection
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.scraping.article import Article
-from fundus.scraping.session import socket_timeout
+from fundus.scraping.session import session_handler
 
 
 def main() -> None:
@@ -34,8 +34,7 @@ def main() -> None:
         PublisherCollection.get_subgroup_mapping().values(), key=lambda region: region.__name__
     )
 
-    # interrupts running network connections after <timeout_in_seconds>
-    with socket_timeout(timeout_in_seconds):
+    with session_handler.context(timeout=timeout_in_seconds):
         for publisher_region in publisher_regions:
             print(f"{publisher_region.__name__:-^50}")
 

--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -4,7 +4,9 @@ from typing import Dict, Iterable, Iterator, List, Optional, Set, Type, Union
 from warnings import warn
 
 import more_itertools
-from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
+from curl_cffi.requests import BrowserType, BrowserTypeLiteral
+from curl_cffi.requests.exceptions import ConnectionError, HTTPError, ReadTimeout
+from curl_cffi.requests.impersonate import normalize_browser_type
 from robots import RobotFileParser
 from typing_extensions import TypeAlias
 
@@ -42,10 +44,13 @@ class CustomRobotFileParser(RobotFileParser):
         "llms",
     }
 
-    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None):
+    def __init__(
+        self, url: str, headers: Optional[Dict[str, str]] = None, impersonate: Optional[BrowserTypeLiteral] = None
+    ):
         self.headers = headers
         self.disallows_training: bool = False
         self.url = url
+        self.impersonate = impersonate
         super().__init__(url)
 
     # noinspection PyAttributeOutsideInit
@@ -53,7 +58,7 @@ class CustomRobotFileParser(RobotFileParser):
         """Reads the robots.txt URL and feeds it to the parser."""
         try:
             # noinspection PyUnresolvedReferences
-            session = session_handler.get_session()
+            session = session_handler.get_session(self.impersonate)
             response = session.get_with_interrupt(self.url, headers=self.headers)
         except HTTPError as err:
             if err.response.status_code in (401, 403):
@@ -76,9 +81,11 @@ class CustomRobotFileParser(RobotFileParser):
 
 
 class Robots:
-    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None):
+    def __init__(
+        self, url: str, headers: Optional[Dict[str, str]] = None, impersonate: Optional[BrowserTypeLiteral] = None
+    ):
         self.url = url
-        self.robots_file_parser = CustomRobotFileParser(url, headers=headers)
+        self.robots_file_parser = CustomRobotFileParser(url, headers=headers, impersonate=impersonate)
         self.ready: bool = False
 
     def _read(self) -> None:
@@ -134,6 +141,7 @@ class Publisher:
         deprecated: bool = False,
         disallows_training: bool = False,
         suppress_robots: bool = False,
+        impersonate: Optional[BrowserTypeLiteral] = None,
     ):
         """Initialization of a new Publisher object
 
@@ -147,23 +155,40 @@ class Publisher:
             url_filter (Optional[URLFilter]): Regex filter to apply determining URLs to be skipped
             request_header (Optional[Dict[str, str]]): Request header to be used for the GET-request
             deprecated (bool): If True, the publisher is deprecated and skipped by default
-            disallows_training (bool): If True, the publisher disallows training on its articles in it's robots.txt file.
-                Note that this is only an indicator and users should verify the terms of use of the publisher before
-                using the articles for training purposes.
+            disallows_training (bool): If True, the publisher disallows training on its articles in
+                its robots.txt file. Note that this is only an indicator and users should verify the
+                terms of use of the publisher before using the articles for training purposes.
+            suppress_robots (bool): If True, robots.txt restrictions are ignored for this publisher
+            impersonate (Optional[str]): Browser profile to impersonate via CurlCffiAdapter, e.g.
+                "chrome" or "safari". If set, requests to this publisher use curl_cffi instead of
+                the standard urllib3 stack, which can bypass TLS fingerprint-based bot detection.
+                Check https://curl-cffi.readthedocs.io/en/latest/impersonate/targets.html for browser targets.
 
         """
         if not (name and domain and parser and sources):
             raise ValueError("Failed to create Publisher. Name, Domain, Parser and Sources are mandatory")
+
+        if (
+            impersonate is not None
+            and (impersonate := normalize_browser_type(impersonate)) not in BrowserType._value2member_map_
+        ):
+            raise ValueError(
+                f"Browser type <{impersonate}> not supported. Supported types are: "
+                f"{', '.join(BrowserType._value2member_map_.keys())}"
+            )
+
         self.name = name
         self.parser = parser()
         self.domain = domain
         self.query_parameter = query_parameter
         self.url_filter = url_filter
         self.request_header = request_header
+        self.impersonate = impersonate
         self.deprecated = deprecated
         self.robots = Robots(
             url=self.domain + "robots.txt" if self.domain.endswith("/") else self.domain + "/robots.txt",
             headers=self.request_header,
+            impersonate=impersonate,
         )
         self._disallows_training = disallows_training
 

--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -514,6 +514,7 @@ class DE(metaclass=PublisherGroup):
             NewsMap("https://newsfeed.kicker.de/googlesitemapnews.xml"),
         ],
         url_filter=regex_filter("/slideshow|/video|heute-live|live-konferenz|/bilder|/ticker"),
+        impersonate="chrome",
     )
 
     Krautreporter = Publisher(
@@ -594,7 +595,6 @@ class DE(metaclass=PublisherGroup):
             RSSFeed("https://www.freiepresse.de/rss/rss_regional.php"),
             Sitemap("https://www.freiepresse.de/sitemaps/articles_last2years.xml", reverse=True),
         ],
-        impersonate="chrome",
     )
 
     RuhrNachrichten = Publisher(

--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -594,7 +594,7 @@ class DE(metaclass=PublisherGroup):
             RSSFeed("https://www.freiepresse.de/rss/rss_regional.php"),
             Sitemap("https://www.freiepresse.de/sitemaps/articles_last2years.xml", reverse=True),
         ],
-        deprecated=True,
+        impersonate="chrome",
     )
 
     RuhrNachrichten = Publisher(

--- a/src/fundus/publishers/fr/__init__.py
+++ b/src/fundus/publishers/fr/__init__.py
@@ -51,5 +51,4 @@ class FR(metaclass=PublisherGroup):
             NewsMap("https://www.lesechos.fr/sitemap_news.xml"),
         ],
         impersonate="chrome",
-        request_header={"User-agent": "Fundus"},
     )

--- a/src/fundus/publishers/fr/__init__.py
+++ b/src/fundus/publishers/fr/__init__.py
@@ -50,5 +50,6 @@ class FR(metaclass=PublisherGroup):
             Sitemap("https://sitemap.lesechos.fr/sitemap_index.xml", reverse=True),
             NewsMap("https://www.lesechos.fr/sitemap_news.xml"),
         ],
-        deprecated=True,
+        impersonate="chrome",
+        request_header={"User-agent": "Fundus"},
     )

--- a/src/fundus/publishers/isl/__init__.py
+++ b/src/fundus/publishers/isl/__init__.py
@@ -21,5 +21,5 @@ class ISL(metaclass=PublisherGroup):
             RSSFeed("https://www.mbl.is/feeds/english/"),
             RSSFeed("https://www.mbl.is/feeds/helst/"),
         ],
-        deprecated=True,
+        impersonate="chrome",
     )

--- a/src/fundus/publishers/jp/__init__.py
+++ b/src/fundus/publishers/jp/__init__.py
@@ -85,6 +85,7 @@ class JP(metaclass=PublisherGroup):
                 sitemap_filter=inverse(regex_filter(r"[a-z]*\.sitemap\.xml$")),
             )
         ],
+        deprecated=True,
         impersonate="chrome",
     )
 
@@ -109,5 +110,4 @@ class JP(metaclass=PublisherGroup):
                 sitemap_filter=inverse(regex_filter(r"type=articles")),
             )
         ],
-        impersonate="chrome",
     )

--- a/src/fundus/publishers/jp/__init__.py
+++ b/src/fundus/publishers/jp/__init__.py
@@ -85,7 +85,7 @@ class JP(metaclass=PublisherGroup):
                 sitemap_filter=inverse(regex_filter(r"[a-z]*\.sitemap\.xml$")),
             )
         ],
-        deprecated=True,
+        impersonate="chrome",
     )
 
     SankeiShimbun = Publisher(
@@ -102,12 +102,12 @@ class JP(metaclass=PublisherGroup):
         name="Nikkan Geadai",
         domain="https://www.nikkan-gendai.com/",
         parser=NikkanGeadaiParser,
-        deprecated=True,
         sources=[
             Sitemap(
                 "https://www.nikkan-gendai.com/sitemap.xml",
                 reverse=True,
-                sitemap_filter=inverse(regex_filter(r"type=news")),
+                sitemap_filter=inverse(regex_filter(r"type=articles")),
             )
         ],
+        impersonate="chrome",
     )

--- a/src/fundus/publishers/na/__init__.py
+++ b/src/fundus/publishers/na/__init__.py
@@ -21,5 +21,5 @@ class NA(metaclass=PublisherGroup):
                 languages={"en", "kj"},
             ),
         ],
-        deprecated=True,
+        impersonate="chrome",
     )

--- a/src/fundus/publishers/na/__init__.py
+++ b/src/fundus/publishers/na/__init__.py
@@ -21,5 +21,4 @@ class NA(metaclass=PublisherGroup):
                 languages={"en", "kj"},
             ),
         ],
-        impersonate="chrome",
     )

--- a/src/fundus/publishers/uk/__init__.py
+++ b/src/fundus/publishers/uk/__init__.py
@@ -63,7 +63,7 @@ class UK(metaclass=PublisherGroup):
             Sitemap("https://www.telegraph.co.uk/sitemap.xml"),
             NewsMap("https://www.telegraph.co.uk/custom/daily-news/sitemap.xml"),
         ],
-        deprecated=True,
+        impersonate="chrome",
     )
 
     iNews = Publisher(

--- a/src/fundus/publishers/uk/__init__.py
+++ b/src/fundus/publishers/uk/__init__.py
@@ -53,6 +53,7 @@ class UK(metaclass=PublisherGroup):
             Sitemap("https://www.mirror.co.uk/sitemaps/sitemap_index.xml", reverse=True),
             NewsMap("https://www.mirror.co.uk/map_news.xml"),
         ],
+        impersonate="chrome",
     )
 
     TheTelegraph = Publisher(
@@ -63,7 +64,7 @@ class UK(metaclass=PublisherGroup):
             Sitemap("https://www.telegraph.co.uk/sitemap.xml"),
             NewsMap("https://www.telegraph.co.uk/custom/daily-news/sitemap.xml"),
         ],
-        impersonate="chrome",
+        impersonate="chrome99_android",
     )
 
     iNews = Publisher(
@@ -121,6 +122,7 @@ class UK(metaclass=PublisherGroup):
             Sitemap(f"https://www.dailymail.co.uk/sitemap-articles-year~{year.year}.xml")
             for year in rrule(YEARLY, dtstart=datetime(2021, 1, 1), until=datetime.today())
         ],
+        impersonate="chrome",
     )
 
     EveningStandard = Publisher(

--- a/src/fundus/publishers/us/__init__.py
+++ b/src/fundus/publishers/us/__init__.py
@@ -167,7 +167,7 @@ class US(metaclass=PublisherGroup):
             Sitemap("https://www.washingtontimes.com/sitemap-stories.xml"),
             Sitemap("https://www.washingtontimes.com/sitemap-entries.xml"),
         ],
-        deprecated=True,
+        impersonate="chrome",
     )
 
     WashingtonPost = Publisher(
@@ -182,7 +182,7 @@ class US(metaclass=PublisherGroup):
         ],
         # Adds a URL-filter to ignore incomplete URLs
         url_filter=regex_filter(r"washingtonpost.com(\/)?$"),
-        deprecated=True,
+        impersonate="chrome",
     )
 
     TheNewYorker = Publisher(

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -600,9 +600,7 @@ class Crawler(CrawlerBase):
             queue_wrapper(result_queue, article_task, silenced_exceptions=(CrashThread,))
         )
 
-        with session_handler.context(POOL_CONNECTIONS=len(publishers)), _manage_pool(
-            processes=len(publishers) or None
-        ) as pool:
+        with _manage_pool(processes=len(publishers) or None) as pool:
             yield from pool_queue_iter(pool.map_async(wrapped_article_task, publishers), result_queue)
 
     def _build_article_iterator(
@@ -826,7 +824,7 @@ class CCNewsCrawler(CrawlerBase):
             def run_disallow_training(publisher: Publisher) -> bool:
                 return publisher.disallows_training
 
-            with ThreadPoolExecutor(max_workers=max_workers) as executor, session_handler.context(TIMEOUT=10):
+            with ThreadPoolExecutor(max_workers=max_workers) as executor, session_handler.context(timeout=10):
                 future_to_publisher = {
                     executor.submit(run_disallow_training, publisher=publisher): publisher for publisher in publishers
                 }

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -454,7 +454,7 @@ class CrawlerBase(ABC):
                     if sum(article_count.values()) == max_articles:
                         break
         finally:
-            session_handler.close_current_session()
+            session_handler.close_sessions()
             if save_to_file is not None:
                 if isinstance(save_to_file, str):
                     save_to_file = Path(save_to_file)

--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -476,6 +476,7 @@ class Crawler(CrawlerBase):
         threading: bool = True,
         ignore_robots: bool = False,
         ignore_crawl_delay: bool = False,
+        impersonate: bool = False,
     ):
         """Fundus base class for crawling articles from the web.
 
@@ -506,6 +507,10 @@ class Crawler(CrawlerBase):
             ignore_crawl_delay (bool): Determines whether to ignore a crawl delay given by a publisher.
                 If set to False, this will overwrite <delay>. If ignore_robots is set to True, the crawl delay
                 will also be ignored.
+            impersonate (bool): If True, publishers that declare an `impersonate` browser profile will use
+                curl_cffi's TLS/HTTP fingerprint impersonation. If False (default), the profile is ignored
+                and requests go out with Fundus' regular fingerprint — publishers gated by anti-bot checks
+                will likely return 4xx/5xx. Defaults to False.
         """
 
         def filter_publishers(publisher: Publisher) -> bool:
@@ -528,6 +533,7 @@ class Crawler(CrawlerBase):
         self.threading = threading
         self.ignore_robots = ignore_robots
         self.ignore_crawl_delay = ignore_crawl_delay
+        self.impersonate = impersonate
 
     def _fetch_articles(
         self,
@@ -563,6 +569,7 @@ class Crawler(CrawlerBase):
             build_delay(),
             ignore_robots=self.ignore_robots,
             ignore_crawl_delay=self.ignore_crawl_delay,
+            impersonate=self.impersonate,
         )
         if not scraper.sources and self.restrict_sources_to:
             logger.warning(

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -32,35 +32,6 @@ __all__ = [
 
 logger = create_logger(__name__)
 
-# unfortunately lxml does not support case-insensitive CSSSelectors
-_content_type_selector = CSSSelector("meta[http-equiv='Content-Type'], meta[http-equiv='content-type']")
-_charset_selector = XPath("//meta[@charset]/@charset | //meta[@charSet]/@charSet")
-
-
-def _detect_charset_from_response(response: requests.Response) -> Optional[str]:
-    """Detects HTML encoding based on meta tag <http-equiv='Content-Type'>
-
-    Args:
-        response: Response to detect encoding for
-
-    Returns:
-        str: detected encoding or response.apparent_encoding or None
-    """
-    # see https://github.com/flairNLP/fundus/issues/446
-    # use response fallback to decode HTML in a first guess
-    if not (guessed_text := response.content.decode(response.encoding or "utf-8", errors="replace")):
-        return None
-    document = lxml.html.document_fromstring(guessed_text)
-    if (content_type_nodes := _content_type_selector(document)) and len(content_type_nodes) == 1:
-        content_type_node = content_type_nodes.pop()
-        for field in content_type_node.attrib.get("content", "").split(";"):
-            if "charset" in field:
-                charset = field.replace("charset=", "").strip()
-                return charset
-    elif charset := _charset_selector(document):
-        return str(charset.pop())
-    return response.apparent_encoding
-
 
 @dataclass(frozen=True)
 class HTML:
@@ -226,15 +197,6 @@ class WebSource:
             logger.debug(f"Skipped responded URL {str(response.url)!r} because of URL filter")
             return None
 
-        # decode response
-        if "charset" not in response.headers["content-type"]:
-            # That's actually the only place requests checks to detect encoding, so if charset
-            # is not set, requests falls back to default encodings (latin-1/utf-8)
-            logger.debug(f"Detect encoding from response for URL {str(response.url)!r}")
-            if not (encoding := _detect_charset_from_response(response)):
-                logger.warning(f"Could not detect encoding from response for URL {str(response.url)!r}")
-                return None
-            response.encoding = encoding
         html = response.text
 
         # check for redirects

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -1,16 +1,13 @@
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable, Dict, Iterable, Iterator, List, Optional, Protocol
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Protocol, Union
 from urllib.parse import urlparse
 
 import chardet
-import lxml.html
 import requests
+from curl_cffi.requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 from fastwarc import ArchiveIterator, WarcRecord, WarcRecordType
-from lxml.cssselect import CSSSelector
-from lxml.etree import XPath
-from requests import ConnectionError, HTTPError, ReadTimeout
 
 from fundus.logging import create_logger
 from fundus.publishers.base_objects import Publisher, Robots
@@ -112,7 +109,7 @@ class _Clock:
 class WebSource:
     def __init__(
         self,
-        url_source: Iterable[str],
+        url_source: Union[URLSource, Iterable[str]],
         publisher: Publisher,
         url_filter: Optional[URLFilter] = None,
         query_parameters: Optional[Dict[str, str]] = None,
@@ -124,8 +121,6 @@ class WebSource:
         self.publisher = publisher
         self.url_filter = url_filter
         self.query_parameters = query_parameters or {}
-        if isinstance(url_source, URLSource):
-            url_source.set_header(self.publisher.request_header)
 
         # parse robots:
         self.robots: Optional[Robots] = None
@@ -170,7 +165,7 @@ class WebSource:
             logger.debug(f"Skipped requested URL {url!r} because of robots.txt")
             return None
 
-        session = session_handler.get_session()
+        session = session_handler.get_session(self.publisher.impersonate)
 
         # prepare query parameters
         for key, value in self.query_parameters.items():
@@ -230,7 +225,13 @@ class WebSource:
         return combined_url_filter
 
     def fetch(self, url_filter: Optional[URLFilter] = None) -> Iterator[HTML]:
-        url_iterator = iter(self.url_source)
+        if isinstance(self.url_source, URLSource):
+            url_iterator = self.url_source.fetch(
+                session_handler.get_session(self.publisher.impersonate),
+                self.publisher.request_header,
+            )
+        else:
+            url_iterator = iter(self.url_source)
 
         while not self._is_stopped:
             try:

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -116,11 +116,13 @@ class WebSource:
         delay: Optional[Delay] = None,
         ignore_robots: bool = False,
         ignore_crawl_delay: bool = False,
+        impersonate: bool = False,
     ):
         self.url_source = url_source
         self.publisher = publisher
         self.url_filter = url_filter
         self.query_parameters = query_parameters or {}
+        self._impersonate_profile = publisher.impersonate if impersonate else None
 
         # parse robots:
         self.robots: Optional[Robots] = None
@@ -165,7 +167,7 @@ class WebSource:
             logger.debug(f"Skipped requested URL {url!r} because of robots.txt")
             return None
 
-        session = session_handler.get_session(self.publisher.impersonate)
+        session = session_handler.get_session(self._impersonate_profile)
 
         # prepare query parameters
         for key, value in self.query_parameters.items():
@@ -227,7 +229,7 @@ class WebSource:
     def fetch(self, url_filter: Optional[URLFilter] = None) -> Iterator[HTML]:
         if isinstance(self.url_source, URLSource):
             url_iterator = self.url_source.fetch(
-                session_handler.get_session(self.publisher.impersonate),
+                session_handler.get_session(self._impersonate_profile),
                 self.publisher.request_header,
             )
         else:

--- a/src/fundus/scraping/scraper.py
+++ b/src/fundus/scraping/scraper.py
@@ -78,6 +78,7 @@ class WebScraper(BaseScraper):
         delay: Optional[Delay] = None,
         ignore_robots: bool = False,
         ignore_crawl_delay: bool = False,
+        impersonate: bool = False,
     ):
         if restrict_sources_to:
             url_sources = tuple(
@@ -99,6 +100,7 @@ class WebScraper(BaseScraper):
                 query_parameters=publisher.query_parameter,
                 ignore_robots=ignore_robots,
                 ignore_crawl_delay=ignore_crawl_delay,
+                impersonate=impersonate,
             )
             for url_source in url_sources
         ]

--- a/src/fundus/scraping/session.py
+++ b/src/fundus/scraping/session.py
@@ -58,7 +58,7 @@ def _detect_encoding_from_bytes(response: bytes) -> str:
     elif encoding := chardet.detect(response)["encoding"]:
         logger.debug(f"Detected encoding from chardet: {encoding!r}")
     else:
-        logger.debug("Unable to detect encoding from response")
+        logger.debug("Unable to detect encoding from response. Defaulting to <utf-8>")
     # see https://github.com/flairNLP/fundus/issues/446
     return encoding or "utf-8"
 

--- a/src/fundus/scraping/session.py
+++ b/src/fundus/scraping/session.py
@@ -96,21 +96,16 @@ class InterruptableSession(curl_cffi.requests.Session[curl_cffi.requests.Respons
         logger.debug(f"{chain} ({response.elapsed}s)")
 
     def _follow_redirects(self, url: str, **kwargs: Any) -> curl_cffi.requests.Response:
-        """Follow redirects manually, building a response history.
-
-        When impersonating a browser, kwargs are dropped so curl_cffi can apply
-        the full browser fingerprint unmodified.
-        """
+        """Follow redirects manually, building a response history."""
         history: List[curl_cffi.requests.Response] = []
         current = url
-        request_kwargs = {} if self.impersonate else kwargs
 
         for _ in range(self.max_redirects):
-            response = self.get(current, **request_kwargs, allow_redirects=False)
+            response: curl_cffi.requests.Response = self.get(current, **kwargs, allow_redirects=False)
 
             if not (300 <= response.status_code <= 399):
                 object.__setattr__(response, "_history", history)
-                return response  # type: ignore[no-any-return]
+                return response
 
             location = response.headers.get("location")
             if not location:
@@ -135,12 +130,15 @@ class InterruptableSession(curl_cffi.requests.Session[curl_cffi.requests.Respons
         """Interruptable GET request.
 
         Submits the request to the persistent daemon thread and polls every second
-        for a stop event. Raises CrashThread if interrupted.
+        for a stop event. Raises CrashThread if interrupted. When impersonating a
+        browser, kwargs are dropped so curl_cffi can apply the full browser
+        fingerprint unmodified.
         """
         if self._closed:
             raise RuntimeError("Session is closed")
+        request_kwargs: Dict[str, Any] = {} if self.impersonate else kwargs
         response_queue: Queue[Union[curl_cffi.requests.Response, Exception]] = Queue()
-        self._task_queue.put(_RequestTask(url, kwargs, response_queue))
+        self._task_queue.put(_RequestTask(url, request_kwargs, response_queue))
 
         while True:
             try:
@@ -239,10 +237,10 @@ class SessionHandler:
         try:
             yield self
         finally:
-            self._context_lock.release()
             self.close_sessions()
             self._session_kwargs = prev_kwargs
             self._sessions = prev_sessions
+            self._context_lock.release()
 
 
 session_handler = SessionHandler()

--- a/src/fundus/scraping/session.py
+++ b/src/fundus/scraping/session.py
@@ -1,11 +1,16 @@
-import socket
+from __future__ import annotations
+
+import re
 import threading
 from contextlib import contextmanager
-from dataclasses import dataclass
 from queue import Empty, Queue
-from typing import Iterator, Optional, Union
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Union
+from urllib.parse import urljoin
 
-import requests.adapters
+import chardet
+import curl_cffi.requests
+from curl_cffi.requests import BrowserTypeLiteral
+from curl_cffi.requests.exceptions import HTTPError, TooManyRedirects
 from typing_extensions import Self
 
 from fundus.logging import create_logger
@@ -14,6 +19,7 @@ from fundus.utils.events import __EVENTS__
 logger = create_logger(__name__)
 
 _default_header = {"user-agent": "Fundus/2.0 (contact: github.com/flairnlp/fundus)"}
+_charset_re = re.compile(rb"charset\s*=\s*[\"']?\s*([^\"'\s;>]+)", re.IGNORECASE)
 
 
 class CrashThread(BaseException):
@@ -22,43 +28,125 @@ class CrashThread(BaseException):
     pass
 
 
-class InterruptableSession(requests.Session):
-    def __init__(self, timeout: Optional[int] = None):
+class _RequestTask(NamedTuple):
+    url: str
+    kwargs: Any
+    result_queue: Queue[Union[curl_cffi.requests.Response, Exception]]
+
+
+def _detect_encoding_from_html(response: bytes) -> Optional[str]:
+    """Extract the charset declared in an HTML meta tag, scanning only the first 2048 bytes."""
+    if match := _charset_re.search(response[:2048]):
+        return match.group(1).decode("ascii", errors="replace")
+    return None
+
+
+def _detect_encoding_from_bytes(response: bytes) -> str:
+    """Detect the character encoding of an HTML response.
+
+    Checks the HTML meta charset tag first, then falls back to chardet,
+    then to UTF-8 if neither yields a result.
+
+    Args:
+        response: Raw response bytes to detect encoding for.
+
+    Returns:
+        Detected encoding string, guaranteed non-empty.
+    """
+    if encoding := _detect_encoding_from_html(response):
+        logger.debug(f"Detected encoding from HTML: {encoding!r}")
+    elif encoding := chardet.detect(response)["encoding"]:
+        logger.debug(f"Detected encoding from chardet: {encoding!r}")
+    else:
+        logger.debug("Unable to detect encoding from response")
+    # see https://github.com/flairNLP/fundus/issues/446
+    return encoding or "utf-8"
+
+
+class _LocalState(threading.local):
+    def __init__(self) -> None:
         super().__init__()
-        self.timeout = timeout
+        self.session: Optional[InterruptableSession] = None
 
-    def get_with_interrupt(self, *args, **kwargs) -> requests.Response:
-        """Interruptable request.
 
-        This function hands over the request to another thread and checks every second
-        for an interrupt event. If there was an interrupt event, this function raises
-        a CrashThread exception.
+class InterruptableSession(curl_cffi.requests.Session[curl_cffi.requests.Response]):
+    """Extends curl_cffi Session with interruptable requests via a persistent daemon thread.
 
-        Args:
-            *args: requests.Session.get(*) arguments.
-            **kwargs: requests.Session.get(**) keyword arguments.
+    The daemon thread owns the curl handle for the lifetime of the session, enabling
+    connection reuse across requests. get_with_interrupt() submits work to the daemon
+    thread and polls for a stop event every second, raising CrashThread if interrupted.
+    """
 
-        Returns:
-            The response.
+    def __init__(self, **kwargs: Any) -> None:
+        # use_thread_local_curl=True gives the worker thread its own curl handle, separate
+        # from the caller thread's handle closed in close(). Prevents close() from touching
+        # a handle that may still be in use by the worker.
+        kwargs.pop("use_thread_local_curl", None)
+        super().__init__(use_thread_local_curl=True, **kwargs)
+        self._closed = False
+        self._task_queue: Queue[Optional[_RequestTask]] = Queue()
+        self._worker_thread = threading.Thread(target=self._worker_loop, name=f"session-worker-{id(self)}", daemon=True)
+        self._worker_thread.start()
 
-        Raises:
-            CrashThread: If the request is interrupted by a stop event.
-        """
-
-        def _req():
-            try:
-                response_queue.put(self.get(*args, **kwargs, timeout=self.timeout))
-            except Exception as error:
-                response_queue.put(error)
-
-        if args:
-            url = args[0]
+    @staticmethod
+    def _log_response(response: curl_cffi.requests.Response) -> None:
+        history: List[curl_cffi.requests.Response] = object.__getattribute__(response, "_history")
+        method = getattr(getattr(response, "request", None), "method", "GET")
+        if history:
+            hops = f"{history[0].url} → " + " → ".join(
+                f"{r.status_code} {next_r.url}" for r, next_r in zip(history, history[1:] + [response])
+            )
+            chain = f"{method} {hops} → {response.status_code}"
         else:
-            url = kwargs.get("url")
+            chain = f"{method} {response.url} -> {response.status_code}"
+        logger.debug(f"{chain} ({response.elapsed}s)")
 
-        response_queue: Queue[Union[requests.Response, Exception]] = Queue()
-        thread = threading.Thread(target=_req, daemon=True)
-        thread.start()
+    def _follow_redirects(self, url: str, **kwargs: Any) -> curl_cffi.requests.Response:
+        """Follow redirects manually, building a response history.
+
+        When impersonating a browser, kwargs are dropped so curl_cffi can apply
+        the full browser fingerprint unmodified.
+        """
+        history: List[curl_cffi.requests.Response] = []
+        current = url
+        request_kwargs = {} if self.impersonate else kwargs
+
+        for _ in range(self.max_redirects):
+            response = self.get(current, **request_kwargs, allow_redirects=False)
+
+            if not (300 <= response.status_code <= 399):
+                object.__setattr__(response, "_history", history)
+                return response  # type: ignore[no-any-return]
+
+            location = response.headers.get("location")
+            if not location:
+                raise HTTPError(f"Redirect {response.status_code} from {current!r} missing Location header")
+
+            history.append(response)
+            current = urljoin(str(response.url), location)
+
+        raise TooManyRedirects(f"Exceeded {self.max_redirects} maximum redirects following {url!r}")
+
+    def _worker_loop(self) -> None:
+        while True:
+            task = self._task_queue.get()
+            if task is None:
+                return
+            try:
+                task.result_queue.put(self._follow_redirects(task.url, **task.kwargs))
+            except Exception as error:
+                task.result_queue.put(error)
+
+    def get_with_interrupt(self, url: str, **kwargs: Any) -> curl_cffi.requests.Response:
+        """Interruptable GET request.
+
+        Submits the request to the persistent daemon thread and polls every second
+        for a stop event. Raises CrashThread if interrupted.
+        """
+        if self._closed:
+            raise RuntimeError("Session is closed")
+        response_queue: Queue[Union[curl_cffi.requests.Response, Exception]] = Queue()
+        self._task_queue.put(_RequestTask(url, kwargs, response_queue))
 
         while True:
             try:
@@ -70,156 +158,94 @@ class InterruptableSession(requests.Session):
             else:
                 if isinstance(response, Exception):
                     raise response
+                self._log_response(response)
+                response.raise_for_status()
                 return response
 
+    def close(self) -> None:
+        """Signal the worker thread to exit and close this thread's curl handle.
 
-@dataclass
-class CONFIG:
-    POOL_CONNECTIONS: int = 50
-    POOL_MAXSIZE: int = 1
-    TIMEOUT: Optional[int] = 30
+        Sending the sentinel is non-blocking — the daemon thread exits asynchronously
+        after finishing any in-flight request. Safe to call while a request is in flight.
+        """
+        self._closed = True
+        self._task_queue.put(None)
+        super().close()
 
 
 class SessionHandler:
-    """Object for handling project global request.Session
+    """Manages one thread-local InterruptableSession per thread.
 
-    The session life cycle consists of three steps which can be repeated indefinitely:
-    Build, Supply, Teardown.
-    Initially there is no session build within the session handler. When a session is requested
-    with get_session() either a new one is created with _session_factory() or the session handler's
-    existing one returned. Every subsequent call to get_session() will return the same
-    response.Session object. If close_current_session() is called, the current session will be
-    tear-downed and the next call to get_session() will build a new session.
+    Each thread gets its own session instance backed by a persistent daemon thread,
+    enabling connection reuse within a thread. Sessions are created lazily on first use.
+    If get_session() is called with a different impersonate profile than the existing
+    session, the old session is closed and replaced.
     """
 
-    def __init__(self):
-        self.CONFIG = CONFIG()
-        self._session: Optional[InterruptableSession] = None
-        self._session_lock = threading.Lock()
+    DEFAULT_SESSION_KWARGS: Dict[str, Any] = {"timeout": 30}
+
+    def __init__(self) -> None:
+        self._session_kwargs: Dict[str, Any] = dict(self.DEFAULT_SESSION_KWARGS)
         self._context_lock = threading.RLock()
+        self._thread_local = _LocalState()
 
-    def _session_factory(self) -> InterruptableSession:
-        """Builds a new Session
+    def get_session(self, impersonate: Optional[BrowserTypeLiteral] = None) -> InterruptableSession:
+        """Return the thread-local session, creating it lazily if needed.
 
-        This returns a new client session build from pre-defined configurations:
-        - pool_connections: <self.pool_connections>
-        - pool_maxsize: <self.pool_maxsize>
-        - hooks: (1) Hook to raise an `HTTPError` if one occurred. (2) Hook to log the request responses.
-
-        Returns:
-            A new requests.Session
+        If the existing session was created with a different impersonate profile,
+        it is closed and replaced with a fresh one matching the requested profile.
         """
-
-        logger.debug("Creating new session")
-        session = InterruptableSession(timeout=self.CONFIG.TIMEOUT)
-
-        def _response_log(response: requests.Response, *args, **kwargs) -> None:
-            history = response.history
-            previous_status_codes = [f"({response.status_code})" for response in history] if history else []
-            status_code_chain = " -> ".join(previous_status_codes + [f"({response.status_code})"])
-            logger.debug(
-                f"{status_code_chain} <{response.request.method} {response.url!r}> "
-                f"took {response.elapsed.total_seconds()} second(s)"
+        session = self._thread_local.session
+        if session is not None and session.impersonate != impersonate:
+            logger.debug(f"Replacing session (impersonate={session.impersonate!r} → {impersonate!r})")
+            session.close()
+            self._thread_local.session = None
+        if self._thread_local.session is None:
+            self._thread_local.session = InterruptableSession(
+                impersonate=impersonate,
+                default_encoding=_detect_encoding_from_bytes,
+                **self._session_kwargs,
             )
-
-        # hooks
-        response_hooks = [lambda response, *args, **kwargs: response.raise_for_status(), _response_log]
-        session.hooks["response"].extend(response_hooks)
-
-        # adapters
-        session.mount(
-            "http://",
-            requests.adapters.HTTPAdapter(
-                pool_connections=self.CONFIG.POOL_CONNECTIONS, pool_maxsize=self.CONFIG.POOL_MAXSIZE
-            ),
-        )
-        session.mount(
-            "https://",
-            requests.adapters.HTTPAdapter(
-                pool_connections=self.CONFIG.POOL_CONNECTIONS, pool_maxsize=self.CONFIG.POOL_MAXSIZE
-            ),
-        )
-
-        return session
-
-    def get_session(self) -> InterruptableSession:
-        """Requests the current build session
-
-        If called for the first time or after close_current_session was called,
-        this function will build a new session. Every subsequent call will return
-        the same session object until the session is closed with close_current_session().
-
-        Returns:
-            requests.Session: The current build session
-        """
-
-        with self._session_lock:
-            if not self._session:
-                self._session = self._session_factory()
-            return self._session
+        return self._thread_local.session
 
     def close_current_session(self) -> None:
-        """Tears down the current build session
-
-        Returns:
-            None
-        """
-        if self._session is not None:
-            session = self.get_session()
-            logger.debug(f"Close session {session}")
-            session.close()
-            self._session = None
+        """Tears down the session for the current thread."""
+        if self._thread_local.session is not None:
+            logger.debug(f"Close session (impersonate={self._thread_local.session.impersonate!r})")
+            self._thread_local.session.close()
+            self._thread_local.session = None
 
     @contextmanager
-    def context(self, **kwargs) -> Iterator[Self]:
-        """Thread-safe context manager for temporarily overriding session configuration.
+    def context(self, **kwargs: Any) -> Iterator[Self]:
+        """Context manager for temporarily overriding session kwargs.
 
-        This context manager temporarily replaces the current `CONFIG` instance with a new one
-        constructed from the provided keyword arguments and clears the current session.
-        Subsequent calls to `get_session()` will use the new configuration, while existing
-        sessions remain unchanged. Internally we use a reentrant lock (RLock) to allow nested
-        contexts within the same thread.
-
-        To prevent deadlocks, attempting to open a new context in another thread while already in
-        a context raises an `AssertionError`.`
+        Merges kwargs with the defaults for the duration of the block, then
+        restores the previous state on exit. Only one context may be active at a time.
 
         Args:
-            **kwargs: Keyword arguments corresponding to `CONFIG` parameters.
-
-        Returns:
-            SessionHandler: The current session handler instance with the temporary configuration.
+            **kwargs: Any curl_cffi Session kwargs to override (e.g. timeout=10, verify=False).
 
         Raises:
-            AssertionError: If a context is already active in another thread.
+            AssertionError: If a context is already active.
         """
-
-        if self._context_lock.acquire(blocking=False):
-            prev = self.CONFIG, self._session
-            self.CONFIG = CONFIG(**kwargs)
-            self._session = None
-
-            try:
-                yield self
-            finally:
-                self._context_lock.release()
-                self.CONFIG, self._session = prev
-
-        else:
+        if not self._context_lock.acquire(blocking=False):
             raise AssertionError(
-                "Tried to open a session context within another thread. "
+                "Tried to open a session context while another is already active. "
                 "Exit the existing context before opening a new one."
             )
 
+        prev_kwargs = self._session_kwargs
+        prev_thread_local = self._thread_local
+        self._session_kwargs = {**self.DEFAULT_SESSION_KWARGS, **kwargs}
+        self._thread_local = _LocalState()
 
-@contextmanager
-def socket_timeout(timeout: Optional[int] = None):
-    """Temporarily sets the socket timeout within this context."""
-    old_timeout = socket.getdefaulttimeout()
-    socket.setdefaulttimeout(timeout)
-    try:
-        yield
-    finally:
-        socket.setdefaulttimeout(old_timeout)
+        try:
+            yield self
+        finally:
+            self._context_lock.release()
+            self.close_current_session()
+            self._session_kwargs = prev_kwargs
+            self._thread_local = prev_thread_local
 
 
 session_handler = SessionHandler()

--- a/src/fundus/scraping/session.py
+++ b/src/fundus/scraping/session.py
@@ -63,12 +63,6 @@ def _detect_encoding_from_bytes(response: bytes) -> str:
     return encoding or "utf-8"
 
 
-class _LocalState(threading.local):
-    def __init__(self) -> None:
-        super().__init__()
-        self.session: Optional[InterruptableSession] = None
-
-
 class InterruptableSession(curl_cffi.requests.Session[curl_cffi.requests.Response]):
     """Extends curl_cffi Session with interruptable requests via a persistent daemon thread.
 
@@ -174,7 +168,7 @@ class InterruptableSession(curl_cffi.requests.Session[curl_cffi.requests.Respons
 
 
 class SessionHandler:
-    """Manages one thread-local InterruptableSession per thread.
+    """Manages one InterruptableSession per thread via a thread-id registry.
 
     Each thread gets its own session instance backed by a persistent daemon thread,
     enabling connection reuse within a thread. Sessions are created lazily on first use.
@@ -187,33 +181,36 @@ class SessionHandler:
     def __init__(self) -> None:
         self._session_kwargs: Dict[str, Any] = dict(self.DEFAULT_SESSION_KWARGS)
         self._context_lock = threading.RLock()
-        self._thread_local = _LocalState()
+        self._sessions: Dict[int, InterruptableSession] = {}
 
     def get_session(self, impersonate: Optional[BrowserTypeLiteral] = None) -> InterruptableSession:
-        """Return the thread-local session, creating it lazily if needed.
+        """Return the session for the current thread, creating it lazily if needed.
 
         If the existing session was created with a different impersonate profile,
         it is closed and replaced with a fresh one matching the requested profile.
         """
-        session = self._thread_local.session
+        tid = threading.get_ident()
+        session = self._sessions.get(tid)
+
         if session is not None and session.impersonate != impersonate:
-            logger.debug(f"Replacing session (impersonate={session.impersonate!r} → {impersonate!r})")
+            logger.debug(f"Replacing session in thread-{tid} (impersonate={session.impersonate!r} → {impersonate!r})")
             session.close()
-            self._thread_local.session = None
-        if self._thread_local.session is None:
-            self._thread_local.session = InterruptableSession(
+            session = None
+        if session is None:
+            session = InterruptableSession(
                 impersonate=impersonate,
                 default_encoding=_detect_encoding_from_bytes,
                 **self._session_kwargs,
             )
-        return self._thread_local.session
+            self._sessions[tid] = session
+        return session
 
-    def close_current_session(self) -> None:
-        """Tears down the session for the current thread."""
-        if self._thread_local.session is not None:
-            logger.debug(f"Close session (impersonate={self._thread_local.session.impersonate!r})")
-            self._thread_local.session.close()
-            self._thread_local.session = None
+    def close_sessions(self) -> None:
+        """Closes and removes all open sessions."""
+        sessions, self._sessions = self._sessions, {}
+        for tid, session in sessions.items():
+            logger.debug(f"Close session in thread-{tid} (impersonate={session.impersonate!r})")
+            session.close()
 
     @contextmanager
     def context(self, **kwargs: Any) -> Iterator[Self]:
@@ -235,17 +232,17 @@ class SessionHandler:
             )
 
         prev_kwargs = self._session_kwargs
-        prev_thread_local = self._thread_local
+        prev_sessions = self._sessions
         self._session_kwargs = {**self.DEFAULT_SESSION_KWARGS, **kwargs}
-        self._thread_local = _LocalState()
+        self._sessions = {}
 
         try:
             yield self
         finally:
             self._context_lock.release()
-            self.close_current_session()
+            self.close_sessions()
             self._session_kwargs = prev_kwargs
-            self._thread_local = prev_thread_local
+            self._sessions = prev_sessions
 
 
 session_handler = SessionHandler()

--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -20,12 +20,12 @@ from urllib.parse import unquote, urlparse
 
 import feedparser
 import lxml.html
+from curl_cffi.requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 from lxml.etree import XMLParser, XPath
-from requests import ConnectionError, HTTPError, ReadTimeout
 
 from fundus.logging import create_logger
 from fundus.scraping.filter import URLFilter, inverse
-from fundus.scraping.session import _default_header, session_handler
+from fundus.scraping.session import InterruptableSession, _default_header, session_handler
 
 logger = create_logger(__name__)
 
@@ -112,20 +112,29 @@ class URLSource(Iterable[str], ABC):
     url: str
     languages: Set[str] = field(default_factory=set)
 
-    _request_header: Dict[str, str] = field(default_factory=dict)
-
     def __post_init__(self):
-        if not self._request_header:
-            self._request_header = _default_header
         if not is_valid_url(self.url):
             logger.error(f"{type(self).__name__} initialized with invalid URL {self.url}")
 
-    def set_header(self, request_header: Dict[str, str]) -> None:
-        self._request_header = request_header
-
     @abstractmethod
-    def __iter__(self) -> Iterator[str]:
+    def fetch(self, session: InterruptableSession, headers: Dict[str, str]) -> Iterator[str]:
+        """Fetch URLs using the provided session and headers.
+
+        Args:
+            session: The HTTP session to use for requests.
+            headers: Request headers to include. Note that when the session was created
+                with an impersonate profile, headers may be dropped in favour of the
+                browser fingerprint (see InterruptableSession.get_with_interrupt).
+        """
         raise NotImplementedError
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate URLs using a default session and headers.
+
+        Intended for standalone/testing use. Production scraping goes through
+        WebSource, which calls fetch() with publisher-specific session and headers.
+        """
+        return self.fetch(session_handler.get_session(), _default_header)
 
     def get_urls(self, max_urls: Optional[int] = None) -> Iterator[str]:
         """Returns a generator yielding up to <max_urls> URLs from <self>.
@@ -145,10 +154,9 @@ class URLSource(Iterable[str], ABC):
 
 @dataclass
 class RSSFeed(URLSource):
-    def __iter__(self) -> Iterator[str]:
-        session = session_handler.get_session()
+    def fetch(self, session: InterruptableSession, headers: Dict[str, str]) -> Iterator[str]:
         try:
-            response = session.get_with_interrupt(self.url, headers=self._request_header)
+            response = session.get_with_interrupt(self.url, headers=headers)
 
         except (HTTPError, ConnectionError, ReadTimeout) as err:
             logger.warning(f"Warning! Couldn't parse rss feed {self.url!r} because of {err}")
@@ -180,13 +188,12 @@ class Sitemap(URLSource):
     _url_selector: ClassVar[XPath] = XPath("//*[local-name()='url']/*[local-name()='loc']")
     _parser = XMLParser(strip_cdata=False, recover=True)
 
-    def __iter__(self) -> Iterator[str]:
+    def fetch(self, session: InterruptableSession, headers: Dict[str, str]) -> Iterator[str]:
         def yield_recursive(sitemap_url: str) -> Iterator[str]:
-            session = session_handler.get_session()
             if not is_valid_url(sitemap_url):
                 logger.info(f"Skipped sitemap {sitemap_url!r} because the URL is malformed")
             try:
-                response = session.get_with_interrupt(url=sitemap_url, headers=self._request_header)
+                response = session.get_with_interrupt(url=sitemap_url, headers=headers)
 
             except (HTTPError, ConnectionError, ReadTimeout) as error:
                 logger.warning(f"Warning! Couldn't reach sitemap {sitemap_url!r} because of {error!r}")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,6 +1,8 @@
 import pytest
 
 from fundus import Crawler, NewsMap, RSSFeed
+from fundus.publishers.base_objects import Publisher
+from fundus.scraping.html import WebSource
 
 
 class TestPipeline:
@@ -47,3 +49,43 @@ class TestPipeline:
         crawler = Crawler(group_with_valid_publisher_subgroup)
         next(crawler.crawl(max_articles=0), None)
         next(crawler.crawl(max_articles=0), None)
+
+
+class TestImpersonate:
+    def test_crawler_default_impersonate_false(self, group_with_valid_publisher_subgroup):
+        crawler = Crawler(group_with_valid_publisher_subgroup)
+        assert crawler.impersonate is False
+
+    def test_crawler_stores_impersonate_flag(self, group_with_valid_publisher_subgroup):
+        crawler = Crawler(group_with_valid_publisher_subgroup, impersonate=True)
+        assert crawler.impersonate is True
+
+    def test_websource_disabled_drops_publisher_profile(self, parser_proxy_with_version):
+        publisher = Publisher(
+            name="impersonating",
+            domain="https://test.com/",
+            sources=[RSSFeed("https://test.com/feed")],
+            parser=parser_proxy_with_version,
+            impersonate="chrome",
+        )
+        source = WebSource(
+            url_source=publisher.source_mapping[RSSFeed][0],
+            publisher=publisher,
+            impersonate=False,
+        )
+        assert source._impersonate_profile is None
+
+    def test_websource_enabled_uses_publisher_profile(self, parser_proxy_with_version):
+        publisher = Publisher(
+            name="impersonating",
+            domain="https://test.com/",
+            sources=[RSSFeed("https://test.com/feed")],
+            parser=parser_proxy_with_version,
+            impersonate="chrome",
+        )
+        source = WebSource(
+            url_source=publisher.source_mapping[RSSFeed][0],
+            publisher=publisher,
+            impersonate=True,
+        )
+        assert source._impersonate_profile == publisher.impersonate

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -114,17 +114,17 @@ class TestContext:
             nonlocal pre_context_session, inside_context_session
             pre_context_session = session_handler.get_session()
             ready.set()
-            entered.wait()
+            assert entered.wait(5)
             inside_context_session = session_handler.get_session()
             sampled.set()
 
         t = Thread(target=worker)
         t.start()
-        ready.wait()
+        assert ready.wait(5)
 
         with session_handler.context(timeout=9999):
             entered.set()
-            sampled.wait()
+            assert sampled.wait(5)
 
         t.join()
 
@@ -144,12 +144,12 @@ class TestContext:
             nonlocal pre_context_session, post_context_session
             pre_context_session = session_handler.get_session()
             entered.set()
-            exited.wait()
+            assert exited.wait(5)
             post_context_session = session_handler.get_session()
 
         t = Thread(target=worker)
         t.start()
-        entered.wait()
+        assert entered.wait(5)
 
         with session_handler.context(timeout=9999):
             pass
@@ -181,20 +181,22 @@ class TestInterruptableSession:
         """close() returns immediately even when a request is in flight."""
         session = InterruptableSession()
         inside_request = threading.Event()
+        allow_return = threading.Event()
 
         def slow_follow_redirects(url, **kwargs):
             inside_request.set()
-            time.sleep(30)
+            allow_return.wait(timeout=5)
 
         with patch.object(session, "_follow_redirects", side_effect=slow_follow_redirects):
             result_queue: Queue[Union[curl_cffi.requests.Response, Exception]] = Queue()
             session._task_queue.put(_RequestTask("http://example.com", {}, result_queue))
-            inside_request.wait()
+            assert inside_request.wait(5)
 
             start = time.monotonic()
             session.close()
             assert time.monotonic() - start < 1.0
 
+        allow_return.set()
         session._worker_thread.join(timeout=2)
 
     def test_request_runs_on_worker_thread(self):
@@ -257,13 +259,14 @@ class TestInterruptableSession:
         """CrashThread is raised in the caller when the stop event fires while polling."""
         session = InterruptableSession()
         inside_request = threading.Event()
+        allow_return = threading.Event()
 
         def slow_follow_redirects(url, **kwargs):
             inside_request.set()
-            time.sleep(30)
+            allow_return.wait(timeout=5)
 
         def set_stop():
-            inside_request.wait()
+            assert inside_request.wait(5)
             __EVENTS__.set_event("stop", "test-stop-event")
 
         stopper = Thread(target=set_stop, daemon=True)
@@ -275,6 +278,7 @@ class TestInterruptableSession:
                     session.get_with_interrupt("http://example.com")
 
         stopper.join(timeout=2)
+        allow_return.set()
         session.close()
 
     def test_use_thread_local_curl_always_true(self):
@@ -287,6 +291,37 @@ class TestInterruptableSession:
         session = InterruptableSession(timeout=42, verify=False)
         assert session.timeout == 42
         assert session.verify is False
+        session.close()
+
+    def test_impersonate_drops_kwargs_before_dispatch(self):
+        """When impersonating, get_with_interrupt strips caller kwargs so curl_cffi's fingerprint is unmodified."""
+        session = InterruptableSession(impersonate="chrome")
+        final = _mock_response()
+        captured_kwargs = []
+
+        def capturing_follow(url, **kwargs):
+            captured_kwargs.append(kwargs)
+            return final
+
+        with patch.object(session, "_follow_redirects", side_effect=capturing_follow):
+            session.get_with_interrupt("http://example.com", headers={"x-custom": "value"})
+
+        assert captured_kwargs[0] == {}
+        session.close()
+
+    def test_no_impersonate_forwards_kwargs(self):
+        session = InterruptableSession()
+        final = _mock_response()
+        captured_kwargs = []
+
+        def capturing_follow(url, **kwargs):
+            captured_kwargs.append(kwargs)
+            return final
+
+        with patch.object(session, "_follow_redirects", side_effect=capturing_follow):
+            session.get_with_interrupt("http://example.com", headers={"x-custom": "value"})
+
+        assert captured_kwargs[0] == {"headers": {"x-custom": "value"}}
         session.close()
 
     def test_raise_for_status_propagates(self):
@@ -375,22 +410,7 @@ class TestFollowRedirects:
 
         session.close()
 
-    def test_impersonate_drops_kwargs(self):
-        session = InterruptableSession(impersonate="chrome")
-        final = _mock_response()
-        captured_kwargs = []
-
-        def capturing_get(url, **kwargs):
-            captured_kwargs.append(kwargs)
-            return final
-
-        with patch.object(session, "get", side_effect=capturing_get):
-            session._follow_redirects("http://example.com", headers={"x-custom": "value"})
-
-        assert captured_kwargs[0] == {"allow_redirects": False}
-        session.close()
-
-    def test_no_impersonate_keeps_kwargs(self):
+    def test_kwargs_passed_through(self):
         session = InterruptableSession()
         final = _mock_response()
         captured_kwargs = []

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -416,16 +416,32 @@ class TestSessionHandlerExtra:
         session = session_handler.get_session(impersonate="chrome")
         assert session.impersonate == "chrome"
 
-    def test_close_current_session_is_noop_when_no_session(self):
+    def test_close_sessions_is_noop_when_no_sessions(self):
         session_handler = SessionHandler()
-        session_handler.close_current_session()  # must not raise
+        session_handler.close_sessions()  # must not raise
 
-    def test_close_current_session_calls_close(self):
+    def test_close_sessions_closes_all_sessions(self):
         session_handler = SessionHandler()
-        session = session_handler.get_session()
-        with patch.object(session, "close") as mock_close:
-            session_handler.close_current_session()
-        mock_close.assert_called_once()
+        results = {}
+        barrier = threading.Barrier(2)
+
+        def worker(name):
+            s = session_handler.get_session()
+            results[name] = s
+            barrier.wait()
+
+        t = threading.Thread(target=worker, args=("other",))
+        t.start()
+        worker("main")
+        t.join()
+
+        mocks = {name: patch.object(s, "close") for name, s in results.items()}
+        with mocks["main"] as m_main, mocks["other"] as m_other:
+            session_handler.close_sessions()
+
+        m_main.assert_called_once()
+        m_other.assert_called_once()
+        assert session_handler._sessions == {}
 
     def test_get_session_replaces_session_on_impersonate_mismatch(self):
         session_handler = SessionHandler()

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -1,21 +1,46 @@
+import threading
+import time
+from queue import Queue
 from threading import Thread
+from typing import Union
+from unittest.mock import MagicMock, patch
 
+import curl_cffi
 import pytest
+from curl_cffi.requests.exceptions import HTTPError, TooManyRedirects
 
-from fundus.scraping.session import CONFIG, SessionHandler
+from fundus.scraping.session import (
+    CrashThread,
+    InterruptableSession,
+    SessionHandler,
+    _RequestTask,
+)
+from fundus.utils.events import __EVENTS__
 from tests.exceptions import Success
+
+
+def _mock_response(status_code: int = 200) -> MagicMock:
+    """Build a mock curl_cffi response that satisfies InterruptableSession._log_response."""
+    response = MagicMock()
+    response._history = []  # object.__getattribute__ reads directly from __dict__
+    response.status_code = status_code
+    response.url = "https://example.com"
+    response.elapsed = 0.01
+    response.request = None
+    response.raise_for_status = MagicMock()
+    return response
 
 
 class TestContext:
     def test_config_override(self):
         session_handler = SessionHandler()
-        prev = session_handler.CONFIG
+        prev = session_handler._session_kwargs
 
-        with session_handler.context(TIMEOUT=-9999):
-            assert session_handler.CONFIG != prev
-            assert session_handler.CONFIG.TIMEOUT == -9999
+        with session_handler.context(timeout=-9999):
+            assert session_handler._session_kwargs != prev
+            assert session_handler._session_kwargs["timeout"] == -9999
 
-        assert session_handler.CONFIG == prev
+        assert session_handler._session_kwargs == prev
 
     def test_new_session(self):
         session_handler = SessionHandler()
@@ -30,20 +55,20 @@ class TestContext:
     def test_nested_context(self):
         session_handler = SessionHandler()
 
-        with session_handler.context(TIMEOUT=1):
-            with session_handler.context(TIMEOUT=2):
+        with session_handler.context(timeout=1):
+            with session_handler.context(timeout=2):
                 assert session_handler.get_session().timeout == 2
 
             assert session_handler.get_session().timeout == 1
 
-        assert session_handler.get_session().timeout == CONFIG.TIMEOUT
+        assert session_handler.get_session().timeout == SessionHandler.DEFAULT_SESSION_KWARGS["timeout"]
 
     def test_thread_safety(self):
         session_handler = SessionHandler()
 
         def set_context(timeout: int = 100):
             with pytest.raises(Success):
-                with session_handler.context(TIMEOUT=timeout):
+                with session_handler.context(timeout=timeout):
                     assert session_handler.get_session().timeout == timeout
                     raise Success
 
@@ -62,7 +87,7 @@ class TestContext:
         assert session_handler.get_session() == prev
 
         # 3. open new context
-        with session_handler.context(TIMEOUT=12):
+        with session_handler.context(timeout=12):
             # 4. the thread should raise an AssertionError
             thread = Thread(target=set_context_fail)
             thread.start()
@@ -75,3 +100,400 @@ class TestContext:
         thread = Thread(target=set_context, args=(13,))
         thread.start()
         thread.join()
+
+    def test_context_resets_other_threads_sessions(self):
+        """Other threads get a fresh session inside a context, not their pre-context session."""
+        session_handler = SessionHandler()
+        pre_context_session = None
+        inside_context_session = None
+        ready = threading.Event()
+        entered = threading.Event()
+        sampled = threading.Event()
+
+        def worker():
+            nonlocal pre_context_session, inside_context_session
+            pre_context_session = session_handler.get_session()
+            ready.set()
+            entered.wait()
+            inside_context_session = session_handler.get_session()
+            sampled.set()
+
+        t = Thread(target=worker)
+        t.start()
+        ready.wait()
+
+        with session_handler.context(timeout=9999):
+            entered.set()
+            sampled.wait()
+
+        t.join()
+
+        assert inside_context_session is not None
+        assert inside_context_session is not pre_context_session
+        assert inside_context_session.timeout == 9999
+
+    def test_context_restores_other_threads_sessions(self):
+        """After the context exits, other threads get back their original session."""
+        session_handler = SessionHandler()
+        pre_context_session = None
+        post_context_session = None
+        entered = threading.Event()
+        exited = threading.Event()
+
+        def worker():
+            nonlocal pre_context_session, post_context_session
+            pre_context_session = session_handler.get_session()
+            entered.set()
+            exited.wait()
+            post_context_session = session_handler.get_session()
+
+        t = Thread(target=worker)
+        t.start()
+        entered.wait()
+
+        with session_handler.context(timeout=9999):
+            pass
+
+        exited.set()
+        t.join()
+
+        assert post_context_session is pre_context_session
+
+
+class TestInterruptableSession:
+    def test_worker_thread_starts_on_init(self):
+        session = InterruptableSession()
+        assert session._worker_thread.is_alive()
+        session.close()
+
+    def test_worker_thread_is_daemon(self):
+        session = InterruptableSession()
+        assert session._worker_thread.daemon
+        session.close()
+
+    def test_worker_thread_exits_after_close(self):
+        session = InterruptableSession()
+        session.close()
+        session._worker_thread.join(timeout=2)
+        assert not session._worker_thread.is_alive()
+
+    def test_close_is_nonblocking(self):
+        """close() returns immediately even when a request is in flight."""
+        session = InterruptableSession()
+        inside_request = threading.Event()
+
+        def slow_follow_redirects(url, **kwargs):
+            inside_request.set()
+            time.sleep(30)
+
+        with patch.object(session, "_follow_redirects", side_effect=slow_follow_redirects):
+            result_queue: Queue[Union[curl_cffi.requests.Response, Exception]] = Queue()
+            session._task_queue.put(_RequestTask("http://example.com", {}, result_queue))
+            inside_request.wait()
+
+            start = time.monotonic()
+            session.close()
+            assert time.monotonic() - start < 1.0
+
+        session._worker_thread.join(timeout=2)
+
+    def test_request_runs_on_worker_thread(self):
+        """_follow_redirects executes on the worker thread, not the caller thread."""
+        session = InterruptableSession()
+        caller_thread_id = threading.current_thread().ident
+        captured_thread_id = None
+
+        def capture_thread(url, **kwargs):
+            nonlocal captured_thread_id
+            captured_thread_id = threading.current_thread().ident
+            return _mock_response()
+
+        with patch.object(session, "_follow_redirects", side_effect=capture_thread):
+            session.get_with_interrupt("http://example.com")
+
+        assert captured_thread_id is not None
+        assert captured_thread_id != caller_thread_id
+        assert captured_thread_id == session._worker_thread.ident
+        session.close()
+
+    def test_same_worker_thread_handles_all_requests(self):
+        """All requests go through the same persistent worker thread, enabling connection reuse."""
+        session = InterruptableSession()
+        captured_thread_ids = []
+
+        def capture_thread(url, **kwargs):
+            captured_thread_ids.append(threading.current_thread().ident)
+            return _mock_response()
+
+        with patch.object(session, "_follow_redirects", side_effect=capture_thread):
+            for _ in range(3):
+                session.get_with_interrupt("http://example.com")
+
+        assert len(set(captured_thread_ids)) == 1
+        assert captured_thread_ids[0] == session._worker_thread.ident
+        session.close()
+
+    def test_response_returned_to_caller(self):
+        session = InterruptableSession()
+        mock = _mock_response(status_code=200)
+
+        with patch.object(session, "_follow_redirects", return_value=mock):
+            response = session.get_with_interrupt("http://example.com")
+
+        assert response is mock
+        session.close()
+
+    def test_exception_propagates_to_caller(self):
+        """Exceptions raised in the worker thread are re-raised in the caller thread."""
+        session = InterruptableSession()
+
+        with patch.object(session, "_follow_redirects", side_effect=ConnectionError("unreachable")):
+            with pytest.raises(ConnectionError, match="unreachable"):
+                session.get_with_interrupt("http://example.com")
+
+        session.close()
+
+    def test_crash_thread_on_stop_event(self):
+        """CrashThread is raised in the caller when the stop event fires while polling."""
+        session = InterruptableSession()
+        inside_request = threading.Event()
+
+        def slow_follow_redirects(url, **kwargs):
+            inside_request.set()
+            time.sleep(30)
+
+        def set_stop():
+            inside_request.wait()
+            __EVENTS__.set_event("stop", "test-stop-event")
+
+        stopper = Thread(target=set_stop, daemon=True)
+
+        with patch.object(session, "_follow_redirects", side_effect=slow_follow_redirects):
+            stopper.start()
+            with __EVENTS__.context("test-stop-event"):
+                with pytest.raises(CrashThread):
+                    session.get_with_interrupt("http://example.com")
+
+        stopper.join(timeout=2)
+        session.close()
+
+    def test_use_thread_local_curl_always_true(self):
+        """use_thread_local_curl=True is enforced regardless of what kwargs pass."""
+        session = InterruptableSession(use_thread_local_curl=False)
+        assert session._use_thread_local_curl is True
+        session.close()
+
+    def test_kwargs_forwarded_to_curl_session(self):
+        session = InterruptableSession(timeout=42, verify=False)
+        assert session.timeout == 42
+        assert session.verify is False
+        session.close()
+
+    def test_raise_for_status_propagates(self):
+        session = InterruptableSession()
+        mock = _mock_response(status_code=404)
+        mock.raise_for_status.side_effect = HTTPError("404")
+
+        with patch.object(session, "_follow_redirects", return_value=mock):
+            with pytest.raises(HTTPError):
+                session.get_with_interrupt("http://example.com")
+
+        session.close()
+
+
+def _redirect_response(status_code: int, location: str) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = MagicMock()
+    response.headers.get = MagicMock(return_value=location)
+    response.url = "http://example.com"
+    return response
+
+
+class TestFollowRedirects:
+    def test_no_redirect_returns_response_with_empty_history(self):
+        session = InterruptableSession()
+        final = _mock_response()
+
+        with patch.object(session, "get", return_value=final):
+            result = session._follow_redirects("http://example.com", headers={"x": "y"})
+
+        assert result is final
+        assert object.__getattribute__(result, "_history") == []
+        session.close()
+
+    def test_redirect_chain_builds_history(self):
+        session = InterruptableSession()
+        r1 = _redirect_response(301, "http://example.com/step2")
+        r2 = _redirect_response(302, "http://example.com/final")
+        final = _mock_response()
+
+        with patch.object(session, "get", side_effect=[r1, r2, final]):
+            result = session._follow_redirects("http://example.com")
+
+        assert result is final
+        assert object.__getattribute__(result, "_history") == [r1, r2]
+        session.close()
+
+    def test_redirect_chain_follows_location_urls(self):
+        session = InterruptableSession()
+        r1 = _redirect_response(301, "http://example.com/step2")
+        final = _mock_response()
+        captured_urls = []
+
+        def capturing_get(url, **kwargs):
+            captured_urls.append(url)
+            return r1 if url == "http://example.com" else final
+
+        with patch.object(session, "get", side_effect=capturing_get):
+            session._follow_redirects("http://example.com")
+
+        assert captured_urls == ["http://example.com", "http://example.com/step2"]
+        session.close()
+
+    def test_missing_location_header_raises_http_error(self):
+        session = InterruptableSession()
+        redirect = MagicMock()
+        redirect.status_code = 301
+        redirect.headers = MagicMock()
+        redirect.headers.get = MagicMock(return_value=None)
+        redirect.url = "http://example.com"
+
+        with patch.object(session, "get", return_value=redirect):
+            with pytest.raises(HTTPError):
+                session._follow_redirects("http://example.com")
+
+        session.close()
+
+    def test_too_many_redirects_raises(self):
+        session = InterruptableSession()
+        redirect = _redirect_response(301, "http://example.com/loop")
+
+        with patch.object(session, "get", return_value=redirect):
+            with pytest.raises(TooManyRedirects):
+                session._follow_redirects("http://example.com")
+
+        session.close()
+
+    def test_impersonate_drops_kwargs(self):
+        session = InterruptableSession(impersonate="chrome")
+        final = _mock_response()
+        captured_kwargs = []
+
+        def capturing_get(url, **kwargs):
+            captured_kwargs.append(kwargs)
+            return final
+
+        with patch.object(session, "get", side_effect=capturing_get):
+            session._follow_redirects("http://example.com", headers={"x-custom": "value"})
+
+        assert captured_kwargs[0] == {"allow_redirects": False}
+        session.close()
+
+    def test_no_impersonate_keeps_kwargs(self):
+        session = InterruptableSession()
+        final = _mock_response()
+        captured_kwargs = []
+
+        def capturing_get(url, **kwargs):
+            captured_kwargs.append(kwargs)
+            return final
+
+        with patch.object(session, "get", side_effect=capturing_get):
+            session._follow_redirects("http://example.com", headers={"x-custom": "value"})
+
+        assert captured_kwargs[0].get("headers") == {"x-custom": "value"}
+        session.close()
+
+
+class TestSessionHandlerExtra:
+    def test_get_session_returns_same_instance(self):
+        session_handler = SessionHandler()
+        assert session_handler.get_session() is session_handler.get_session()
+
+    def test_get_session_respects_impersonate(self):
+        session_handler = SessionHandler()
+        session = session_handler.get_session(impersonate="chrome")
+        assert session.impersonate == "chrome"
+
+    def test_close_current_session_is_noop_when_no_session(self):
+        session_handler = SessionHandler()
+        session_handler.close_current_session()  # must not raise
+
+    def test_close_current_session_calls_close(self):
+        session_handler = SessionHandler()
+        session = session_handler.get_session()
+        with patch.object(session, "close") as mock_close:
+            session_handler.close_current_session()
+        mock_close.assert_called_once()
+
+    def test_get_session_replaces_session_on_impersonate_mismatch(self):
+        session_handler = SessionHandler()
+        first = session_handler.get_session(impersonate=None)
+        second = session_handler.get_session(impersonate="chrome")
+        assert first is not second
+        assert second.impersonate == "chrome"
+
+    def test_context_restores_session_on_exception(self):
+        session_handler = SessionHandler()
+        prev = session_handler.get_session()
+
+        with pytest.raises(RuntimeError):
+            with session_handler.context(timeout=5):
+                raise RuntimeError("boom")
+
+        assert session_handler.get_session() is prev
+
+
+class TestGetWithInterruptClosed:
+    def test_raises_after_close(self):
+        session = InterruptableSession()
+        session.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            session.get_with_interrupt("http://example.com")
+
+    def test_does_not_raise_before_close(self):
+        session = InterruptableSession()
+        mock = _mock_response()
+        with patch.object(session, "_follow_redirects", return_value=mock):
+            session.get_with_interrupt("http://example.com")  # must not raise
+        session.close()
+
+
+class TestEncoding:
+    def test_charset_detected_from_meta_tag(self):
+        from fundus.scraping.session import _detect_encoding_from_html
+
+        html = b'<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">'
+        assert _detect_encoding_from_html(html) == "iso-8859-1"
+
+    def test_charset_detected_without_quotes(self):
+        from fundus.scraping.session import _detect_encoding_from_html
+
+        html = b"<meta charset=utf-8>"
+        assert _detect_encoding_from_html(html) == "utf-8"
+
+    def test_no_charset_returns_none(self):
+        from fundus.scraping.session import _detect_encoding_from_html
+
+        assert _detect_encoding_from_html(b"<html><body>no charset here</body></html>") is None
+
+    def test_charset_only_scanned_in_first_2048_bytes(self):
+        from fundus.scraping.session import _detect_encoding_from_html
+
+        prefix = b"x" * 2048
+        html = prefix + b'<meta charset="utf-8">'
+        assert _detect_encoding_from_html(html) is None
+
+    def test_detect_encoding_falls_back_to_utf8(self):
+        from fundus.scraping.session import _detect_encoding_from_bytes
+
+        # bytes that chardet cannot identify reliably → fallback
+        assert _detect_encoding_from_bytes(b"") == "utf-8"
+
+    def test_detect_encoding_prefers_html_meta_over_chardet(self):
+        from fundus.scraping.session import _detect_encoding_from_bytes
+
+        html = b'<meta charset="iso-8859-1">' + b"\xe9\xe0\xfc" * 100
+        result = _detect_encoding_from_bytes(html)
+        assert result == "iso-8859-1"


### PR DESCRIPTION
### Summary

- **Swap HTTP backend**: `requests` is replaced by `curl-cffi` across the entire scraping stack (`session.py`, `html.py`, `url.py`, `base_objects.py`). `curl-cffi` wraps libcurl with a TLS/JA3 fingerprint that matches real browsers, making it significantly harder for sites to detect and block Fundus.

- **Browser impersonation per publisher**: `Publisher` gains an optional `impersonate` parameter (e.g. `"chrome"`, `"safari"`). When set, every HTTP request (including robots.txt fetches, RSS/sitemap crawls, and article fetches) is made with the corresponding browser fingerprint. The value is validated against `curl-cffi`'s supported targets at construction time.

- **Reworked `SessionHandler`**: Replaced the old single shared session with a per-thread registry (`Dict[int, InterruptableSession]`). Each session is backed by a persistent worker thread, keeping the curl handle alive across requests for connection reuse. `context()` swaps the registry atomically, giving all threads a clean slate and restoring their original sessions on exit.

- **`URLSource.fetch()` API**: The abstract `__iter__` on `URLSource` is replaced by `fetch(session, headers)`, letting `WebSource` pass the publisher's session (with the right impersonate profile) down into RSS and sitemap sources. `__iter__` is kept as a convenience wrapper for standalone/testing use.

- **Encoding detection moved into the session layer**: The lxml-based charset detection in `html.py` is removed. `curl-cffi` receives a `default_encoding` callable (`_detect_encoding_from_bytes`) that checks the HTML `<meta charset>` tag first, then falls back to chardet, then to UTF-8, applied automatically before the response text is read.

- **Un-deprecate TLS-protected publishers**: Publishers that were previously deprecated due to TLS fingerprint blocking are re-enabled, now that impersonation makes them reachable again.

### Test plan

- [x] `pytest tests/test_session_handler.py` — 39 unit tests covering `InterruptableSession`, `SessionHandler`, redirect following, encoding detection, and context behaviour
- [x] Smoke-crawl a plain publisher (no impersonation) and verify articles are returned with correct encoding
- [x] Smoke-crawl an impersonation-enabled publisher (e.g. one of the re-enabled TLS-protected ones) and verify articles are returned
- [x] Verify `Publisher(impersonate="invalid")` raises `ValueError` at construction time