### PR TITLE
Set upper bound for `fastwarc` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "langdetect>=1.0, <2",
     "requests>=2.28, <3",
     "tqdm>=4.66, <5",
-    "fastwarc>=0.14, <1",
+    "fastwarc>=0.14, <0.16", # starting from version 0.16, FastWarc requires python >= 3.10
     "chardet>=5.2, <6",
     "dill>=0.3, <1",
     "dict2xml>=1.7.6, <2",


### PR DESCRIPTION
As with `fastwarc` version `0.16` the minimum required python version was raised to `>=3.10`, any `fastwarc` version `>=0.16` is no longer compatible with `fundus`