### PR TITLE
Catch base curl_cffi Timeout instead of unused ReadTimeout subclass

### DIFF
--- a/src/fundus/publishers/base_objects.py
+++ b/src/fundus/publishers/base_objects.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 import more_itertools
 from curl_cffi.requests import BrowserType, BrowserTypeLiteral
-from curl_cffi.requests.exceptions import ConnectionError, HTTPError, ReadTimeout
+from curl_cffi.requests.exceptions import ConnectionError, HTTPError, Timeout
 from curl_cffi.requests.impersonate import normalize_browser_type
 from robots import RobotFileParser
 from typing_extensions import TypeAlias
@@ -91,7 +91,7 @@ class Robots:
     def _read(self) -> None:
         try:
             self.robots_file_parser.read()
-        except (ConnectionError, ReadTimeout):
+        except (ConnectionError, Timeout):
             logger.warning(f"Could not load robots {self.url!r}. Ignoring robots and continuing.")
             self.robots_file_parser.allow_all = True
         self.ready = True

--- a/src/fundus/scraping/html.py
+++ b/src/fundus/scraping/html.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 import chardet
 import requests
-from curl_cffi.requests.exceptions import ConnectionError, HTTPError, ReadTimeout
+from curl_cffi.requests.exceptions import ConnectionError, HTTPError, Timeout
 from fastwarc import ArchiveIterator, WarcRecord, WarcRecordType
 
 from fundus.logging import create_logger
@@ -183,7 +183,7 @@ class WebSource:
         try:
             response = session.get_with_interrupt(url, headers=self.publisher.request_header)
 
-        except (HTTPError, ConnectionError, ReadTimeout) as error:
+        except (HTTPError, ConnectionError, Timeout) as error:
             logger.warning(f"Skipped requested URL {url!r} because of {error!r}")
             if isinstance(error, HTTPError) and error.response.status_code >= 500:
                 logger.warning(f"Skipped {self.publisher.name!r} due to server errors: {error!r}")

--- a/src/fundus/scraping/url.py
+++ b/src/fundus/scraping/url.py
@@ -20,7 +20,7 @@ from urllib.parse import unquote, urlparse
 
 import feedparser
 import lxml.html
-from curl_cffi.requests.exceptions import ConnectionError, HTTPError, ReadTimeout
+from curl_cffi.requests.exceptions import ConnectionError, HTTPError, Timeout
 from lxml.etree import XMLParser, XPath
 
 from fundus.logging import create_logger
@@ -158,7 +158,7 @@ class RSSFeed(URLSource):
         try:
             response = session.get_with_interrupt(self.url, headers=headers)
 
-        except (HTTPError, ConnectionError, ReadTimeout) as err:
+        except (HTTPError, ConnectionError, Timeout) as err:
             logger.warning(f"Warning! Couldn't parse rss feed {self.url!r} because of {err}")
             return
         except Exception as error:
@@ -195,7 +195,7 @@ class Sitemap(URLSource):
             try:
                 response = session.get_with_interrupt(url=sitemap_url, headers=headers)
 
-            except (HTTPError, ConnectionError, ReadTimeout) as error:
+            except (HTTPError, ConnectionError, Timeout) as error:
                 logger.warning(f"Warning! Couldn't reach sitemap {sitemap_url!r} because of {error!r}")
                 return
             except Exception as error:


### PR DESCRIPTION
curl_cffi maps every libcurl timeout (`CURLE_OPERATION_TIMEDOUT`) to the base `Timeout` and never raises the vendored `ReadTimeout`/`ConnectTimeout` shims (both tagged `# not used`). The `except (..., ReadTimeout)` clauses carried over from the `requests` port therefore caught nothing, so a publisher timeout escaped the scraping task, was wrapped into a `RemoteException`, and crashed `publisher_coverage.py` despite `error_handling=suppress`.

Swaps `ReadTimeout` for the base `Timeout` in `html.py`, `url.py`, and `base_objects.py`. Since `ReadTimeout`/`ConnectTimeout` both subclass `Timeout`, this is strictly broader and future-proof.