### PR TITLE
feat(publishers): mark Stern publisher as deprecated

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -1346,7 +1346,9 @@
         <code>Stern</code>
       </td>
       <td>
-        <div>Stern</div>
+        <div>
+          <strike>Stern</strike>
+        </div>
       </td>
       <td>
         <a href="https://www.stern.de/">

--- a/src/fundus/publishers/de/__init__.py
+++ b/src/fundus/publishers/de/__init__.py
@@ -298,6 +298,7 @@ class DE(metaclass=PublisherGroup):
         domain="https://www.stern.de/",
         parser=SternParser,
         sources=[RSSFeed("https://www.stern.de/feed/standard/alle-nachrichten/")],
+        deprecated=True,
     )
 
     NTV = Publisher(


### PR DESCRIPTION
`Stern` only returns javascript, making it impossible for us to parse until #644 is solved.