### PR TITLE
fix(publisher): update upper boundary selector for WDR parser

### DIFF
--- a/src/fundus/publishers/de/wdr.py
+++ b/src/fundus/publishers/de/wdr.py
@@ -55,7 +55,7 @@ class WDRParser(ParserProxy):
                 image_selector=XPath(
                     "//article//picture[not(@data-resp-img-id='LinklistenteaserImageSectionZModA')]//img[@class='img']"
                 ),
-                upper_boundary_selector=XPath("//div[@class='segment']"),
+                upper_boundary_selector=XPath("//div[@class='segment' or @class='section sectionArticle']"),
                 lower_boundary_selector=XPath("//div[@class='shareCon']"),
                 alt_selector=XPath("./@title"),
                 author_selector=re.compile(r"(?i)\|\s*bildquelle:(?P<credits>.+)"),


### PR DESCRIPTION
Adjust XPath to include additional class for enhanced parsing accuracy.

- Extend `upper_boundary_selector` to handle 'sectionArticle' class
- Maintain compatibility with existing `segment` class selection