### PR TITLE
feat(publisher): improve parsing for Netzpolitik articles

### DIFF
--- a/src/fundus/publishers/de/netzpolitik_org.py
+++ b/src/fundus/publishers/de/netzpolitik_org.py
@@ -7,11 +7,12 @@ from lxml.etree import XPath
 from fundus.parser import ArticleBody, BaseParser, Image, ParserProxy, attribute
 from fundus.parser.utility import (
     extract_article_body_with_selector,
+    generic_author_parsing,
     generic_date_parsing,
+    generic_nodes_to_text,
     generic_topic_parsing,
     image_extraction,
     parse_title_from_root,
-    strip_nodes_to_text,
 )
 
 
@@ -20,8 +21,10 @@ class NetzpolitikOrgParser(ParserProxy):
         _paragraph_selector = CSSSelector("div.entry-content p")
         _summary_selector = CSSSelector("div.entry-excerpt > p")
         _subheadline_selector = CSSSelector("div.entry-content > h3")
-        _author_selector = CSSSelector("span > a[rel='author']")
-        _topic_selector = CSSSelector("div.entry-footer__tags li")
+        _author_selector = CSSSelector("span > a[rel='author'], .np-intro-author-name-list a")
+        _topic_selector = CSSSelector("div.entry-footer__tags li, .wp-block-post-terms a")
+
+        _bloat_topics = {"Netzpolitischer Wochenrückblick"}
 
         @attribute
         def title(self) -> Optional[str]:
@@ -38,10 +41,10 @@ class NetzpolitikOrgParser(ParserProxy):
 
         @attribute
         def topics(self) -> List[str]:
-            topic_string = strip_nodes_to_text(self._topic_selector(self.precomputed.doc), join_on=",")
-            if topic_string is not None:
-                return generic_topic_parsing(topic_string, delimiter=",")
-            return []
+            return generic_topic_parsing(
+                generic_nodes_to_text(self._topic_selector(self.precomputed.doc), normalize=True),
+                result_filter=self._bloat_topics,
+            )
 
         @attribute
         def publishing_date(self) -> Optional[datetime.datetime]:
@@ -49,12 +52,13 @@ class NetzpolitikOrgParser(ParserProxy):
 
         @attribute
         def authors(self) -> List[str]:
-            return [node.text_content() for node in (self._author_selector(self.precomputed.doc) or [])]
+            return generic_author_parsing(generic_nodes_to_text(self._author_selector(self.precomputed.doc)))
 
         @attribute
         def images(self) -> List[Image]:
             return image_extraction(
                 doc=self.precomputed.doc,
+                image_selector=XPath("//figure//img[not(contains(@class, 'author-avatars'))]"),
                 paragraph_selector=self._paragraph_selector,
                 caption_selector=XPath("./ancestor::figure//figcaption/text()"),
                 author_selector=XPath("./ancestor::figure//figcaption/span"),


### PR DESCRIPTION
Enhance the Netzpolitik parser for more accurate data extraction.

- Expand author and topic selectors to cover additional cases
- Add `_bloat_topics` to filter irrelevant topics
- Replace `strip_nodes_to_text` with `generic_nodes_to_text` for topic parsing
- Implement `generic_author_parsing` for consistent author extraction
- Update image selector to exclude avatar images and refine caption parsing