### PR TITLE
feat(publisher): deprecate LeMonde and implement V2 parser draft

### DIFF
--- a/docs/supported_publishers.md
+++ b/docs/supported_publishers.md
@@ -1825,7 +1825,9 @@
         <code>LeMonde</code>
       </td>
       <td>
-        <div>Le Monde</div>
+        <div>
+          <strike>Le Monde</strike>
+        </div>
       </td>
       <td>
         <a href="https://www.lemonde.fr/">

--- a/src/fundus/publishers/fr/__init__.py
+++ b/src/fundus/publishers/fr/__init__.py
@@ -18,6 +18,7 @@ class FR(metaclass=PublisherGroup):
             Sitemap("https://www.lemonde.fr/sitemap_index.xml"),
             NewsMap("https://www.lemonde.fr/sitemap_news.xml"),
         ],
+        deprecated=True
     )
 
     EuronewsFR = Publisher(

--- a/src/fundus/publishers/fr/__init__.py
+++ b/src/fundus/publishers/fr/__init__.py
@@ -18,7 +18,7 @@ class FR(metaclass=PublisherGroup):
             Sitemap("https://www.lemonde.fr/sitemap_index.xml"),
             NewsMap("https://www.lemonde.fr/sitemap_news.xml"),
         ],
-        deprecated=True
+        deprecated=True,
     )
 
     EuronewsFR = Publisher(

--- a/src/fundus/publishers/fr/le_monde.py
+++ b/src/fundus/publishers/fr/le_monde.py
@@ -15,6 +15,8 @@ from fundus.parser.utility import (
 
 class LeMondeParser(ParserProxy):
     class V1(BaseParser):
+        VALID_UNTIL = datetime.date(2025, 7, 1)  # This choice is arbitrary, this publisher has
+        # been failing the coverage for too long to determine the actual date
         _paragraph_selector = XPath("//p[contains(@class, 'article__paragraph')]")
         _summary_selector = XPath("//p[contains(@class, 'article__desc') or @id='js-summary-live']")
         _subheadline_selector = XPath("//h2[@class = 'article__sub-title']")
@@ -53,6 +55,49 @@ class LeMondeParser(ParserProxy):
                 paragraph_selector=self._paragraph_selector,
                 upper_boundary_selector=CSSSelector("article"),
                 image_selector=XPath("//figure/descendant::img[1]"),
+                caption_selector=XPath("./ancestor::figure//figcaption/text()"),
+                author_selector=XPath("./ancestor::figure//figcaption/span"),
+            )
+
+    class V2(BaseParser):
+        # This is a draft that could not be verified due to javascript execution issues
+
+        _summary_selector = XPath("//div[@class='ds-description']/span")
+        _paragraph_selector = XPath("//article/p")
+        _subheadline_selector = XPath("//article/h2")
+
+        @attribute
+        def body(self) -> Optional[ArticleBody]:
+            return extract_article_body_with_selector(
+                self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                summary_selector=self._summary_selector,
+                subheadline_selector=self._subheadline_selector,
+            )
+
+        @attribute
+        def title(self) -> Optional[str]:
+            return self.precomputed.meta.get("og:title")
+
+        @attribute
+        def topics(self) -> List[str]:
+            return self.precomputed.ld.bf_search("keywords")
+
+        @attribute
+        def publishing_date(self) -> Optional[datetime.datetime]:
+            return generic_date_parsing(self.precomputed.meta.get("og:article:published_time"))
+
+        @attribute
+        def authors(self) -> List[str]:
+            return generic_author_parsing(self.precomputed.meta.get("og:article:author"))
+
+        @attribute
+        def images(self) -> List[Image]:
+            return image_extraction(
+                doc=self.precomputed.doc,
+                paragraph_selector=self._paragraph_selector,
+                upper_boundary_selector=CSSSelector("article"),
+                image_selector=XPath("//figure[@class='article__media']//img"),
                 caption_selector=XPath("./ancestor::figure//figcaption/text()"),
                 author_selector=XPath("./ancestor::figure//figcaption/span"),
             )

--- a/src/fundus/publishers/fr/le_monde.py
+++ b/src/fundus/publishers/fr/le_monde.py
@@ -15,8 +15,6 @@ from fundus.parser.utility import (
 
 class LeMondeParser(ParserProxy):
     class V1(BaseParser):
-        VALID_UNTIL = datetime.date(2025, 7, 1)  # This choice is arbitrary, this publisher has
-        # been failing the coverage for too long to determine the actual date
         _paragraph_selector = XPath("//p[contains(@class, 'article__paragraph')]")
         _summary_selector = XPath("//p[contains(@class, 'article__desc') or @id='js-summary-live']")
         _subheadline_selector = XPath("//h2[@class = 'article__sub-title']")
@@ -59,45 +57,45 @@ class LeMondeParser(ParserProxy):
                 author_selector=XPath("./ancestor::figure//figcaption/span"),
             )
 
-    class V2(BaseParser):
-        # This is a draft that could not be verified due to javascript execution issues
+    # class V2(BaseParser):
+    # This is a draft that could not be verified due to javascript execution issues
 
-        _summary_selector = XPath("//div[@class='ds-description']/span")
-        _paragraph_selector = XPath("//article/p")
-        _subheadline_selector = XPath("//article/h2")
+    # _summary_selector = XPath("//div[@class='ds-description']/span")
+    # _paragraph_selector = XPath("//article/p")
+    # _subheadline_selector = XPath("//article/h2")
 
-        @attribute
-        def body(self) -> Optional[ArticleBody]:
-            return extract_article_body_with_selector(
-                self.precomputed.doc,
-                paragraph_selector=self._paragraph_selector,
-                summary_selector=self._summary_selector,
-                subheadline_selector=self._subheadline_selector,
-            )
+    # @attribute
+    # def body(self) -> Optional[ArticleBody]:
+    #    return extract_article_body_with_selector(
+    #        self.precomputed.doc,
+    #        paragraph_selector=self._paragraph_selector,
+    #        summary_selector=self._summary_selector,
+    #        subheadline_selector=self._subheadline_selector,
+    #    )
 
-        @attribute
-        def title(self) -> Optional[str]:
-            return self.precomputed.meta.get("og:title")
+    # @attribute
+    # def title(self) -> Optional[str]:
+    #    return self.precomputed.meta.get("og:title")
 
-        @attribute
-        def topics(self) -> List[str]:
-            return self.precomputed.ld.bf_search("keywords")
+    # @attribute
+    # def topics(self) -> List[str]:
+    #    return self.precomputed.ld.bf_search("keywords")
 
-        @attribute
-        def publishing_date(self) -> Optional[datetime.datetime]:
-            return generic_date_parsing(self.precomputed.meta.get("og:article:published_time"))
+    # @attribute
+    # def publishing_date(self) -> Optional[datetime.datetime]:
+    #    return generic_date_parsing(self.precomputed.meta.get("og:article:published_time"))
 
-        @attribute
-        def authors(self) -> List[str]:
-            return generic_author_parsing(self.precomputed.meta.get("og:article:author"))
+    # @attribute
+    # def authors(self) -> List[str]:
+    #    return generic_author_parsing(self.precomputed.meta.get("og:article:author"))
 
-        @attribute
-        def images(self) -> List[Image]:
-            return image_extraction(
-                doc=self.precomputed.doc,
-                paragraph_selector=self._paragraph_selector,
-                upper_boundary_selector=CSSSelector("article"),
-                image_selector=XPath("//figure[@class='article__media']//img"),
-                caption_selector=XPath("./ancestor::figure//figcaption/text()"),
-                author_selector=XPath("./ancestor::figure//figcaption/span"),
-            )
+    # @attribute
+    # def images(self) -> List[Image]:
+    #    return image_extraction(
+    #        doc=self.precomputed.doc,
+    #        paragraph_selector=self._paragraph_selector,
+    #        upper_boundary_selector=CSSSelector("article"),
+    #        image_selector=XPath("//figure[@class='article__media']//img"),
+    #        caption_selector=XPath("./ancestor::figure//figcaption/text()"),
+    #        author_selector=XPath("./ancestor::figure//figcaption/span"),
+    #    )


### PR DESCRIPTION
Mark LeMonde publisher as deprecated and introduce a draft for V2 parser.

Deprecated due to #644 