### PR TITLE
fix(publisher): update Daily News TZ sitemap URL and domain

### DIFF
--- a/src/fundus/publishers/tz/__init__.py
+++ b/src/fundus/publishers/tz/__init__.py
@@ -10,12 +10,13 @@ class TZ(metaclass=PublisherGroup):
 
     DailyNewsTZ = Publisher(
         name="Daily News (Tanzania)",
-        domain="https://www.dailynews.co.tz/",
+        domain="https://dailynews.co.tz/",
         parser=DailyNewsTZParser,
         sources=[
             Sitemap(
-                "https://dailynews.co.tz/wp-sitemap.xml",
+                "https://dailynews.co.tz/sitemap_index.xml",
                 sitemap_filter=inverse(regex_filter("post-sitemap")),
+                reverse=True,
                 languages={"en"},
             ),
         ],


### PR DESCRIPTION
Correct domain and sitemap URL for Daily News (Tanzania).

- Update domain to `https://dailynews.co.tz/`
- Replace sitemap URL with `https://dailynews.co.tz/sitemap_index.xml`
- Add reverse filtering for sitemap processing