### PR TITLE
fix(publisher): update EveningStandard selectors for improved parsing

### DIFF
--- a/src/fundus/publishers/uk/evening_standard.py
+++ b/src/fundus/publishers/uk/evening_standard.py
@@ -17,8 +17,8 @@ from fundus.parser.utility import (
 class EveningStandardParser(ParserProxy):
     class V1(BaseParser):
         VALID_UNTIL = datetime.date(2024, 6, 30)
-        _paragraph_selector = CSSSelector("div.sc-bkSUFG.bdkDcZ")
-        _summary_selector = CSSSelector("div.sc-wkolL.dWZJhQ")
+        _paragraph_selector: XPath = CSSSelector("div.sc-bkSUFG.bdkDcZ")
+        _summary_selector: XPath = CSSSelector("div.sc-wkolL.dWZJhQ")
 
         @attribute
         def body(self) -> Optional[ArticleBody]:
@@ -63,9 +63,11 @@ class EveningStandardParser(ParserProxy):
             )
 
     class V1_1(V1):
-        _summary_selector = CSSSelector("div.sc-jgyXzG")
-        _subheadline_selector = CSSSelector("div#main div.sc-dFfFtc > h3")
-        _paragraph_selector = CSSSelector("div#main > div.sc-gEvEer p")
+        _summary_selector = XPath("//article//div[h1]/div[text()]")
+        _subheadline_selector = XPath(
+            "//article//div[@class]/div[@class]/div/*[(self::h2 or self::h3) and not(@class)]"
+        )
+        _paragraph_selector = XPath("//article//div[@class]/div[@class]/div[not(@class)]/div/p")
 
         @attribute
         def body(self) -> Optional[ArticleBody]:

--- a/tests/resources/parser/test_data/uk/EveningStandard.json
+++ b/tests/resources/parser/test_data/uk/EveningStandard.json
@@ -135,7 +135,9 @@
       "Dylan Jones"
     ],
     "body": {
-      "summary": [],
+      "summary": [
+        "Sir Tony Blair discusses peace-making, Brexit and Keir Starmer’s premiership in wide-ranging London Standard interview"
+      ],
       "sections": [
         {
           "headline": [],


### PR DESCRIPTION
Align parsing logic with website changes.

- Update paragraph, summary, and subheadline selectors in V1_1
- Adjust data structure in test resources for summaries

Note: breaking with convention, this PR updates the selectors of the current version without creating a new version. The reason for this decision is that the previous selectors were based on something like hashes for class names, which are apparently not consistent across system restarts. So the layout itself did not actually change, but rather the host machine got restarted (probably). This is underlined by the fact, that I accidentally fixed a bug in the current selector where the summary of the test case was not selected with the current setup.