### PR TITLE
fix(deps): restrict curl-cffi version to <0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "bidict>=0.23, <1",
     "dateparser>=1.2.2, <2",
     "robotspy>=0.13.0, <1",
-    "curl-cffi>=0.7,<1",
+    "curl-cffi>=0.7,<0.16.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
closes #963 