### PR TITLE
fix(crawler): publisher skipping bug fix

### DIFF
--- a/src/fundus/scraping/crawler.py
+++ b/src/fundus/scraping/crawler.py
@@ -547,7 +547,7 @@ class Crawler(CrawlerBase):
         if skip_publishers_disallowing_training and publisher.disallows_training:
             logger.info(f"Skipping publisher {publisher.name} because it disallows training.")
             return
-        elif publisher.robots.disallow_all():
+        elif publisher.robots.disallow_all() and not self.ignore_robots:
             logger.info(f"Skipping publisher {publisher.name} because it disallows all URLs.")
             return
 


### PR DESCRIPTION
This PR fixes a bug where a publisher is skipped if access to the robots.txt is not granted, even though `ignore_robots` is set to `True`