### PR TITLE
ci(docs): authenticate documentation workflow via GitHub App token

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -24,8 +24,20 @@ jobs:
       contents: write
 
     steps:
+      # Mints a short-lived token for the 'fundus-docs-bot' GitHub App, which is
+      # allowed to bypass branch protection on 'master'. The default GITHUB_TOKEN
+      # cannot push to the protected branch.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+
       - name: Set up Git repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v6


### PR DESCRIPTION
The `Documentation` workflow regenerates `docs/supported_publishers.md` and commits it back to `master`. Since `master` is protected, the default `GITHUB_TOKEN` cannot push and the run fails with `GH006`.

This adds an `actions/create-github-app-token@v1` step that mints a short-lived token for the `fundus-docs-bot` GitHub App and passes it to `actions/checkout`, so the auto-commit step pushes as the App. All other steps are unchanged.

**Required before merge**
- Repo secrets `DOCS_BOT_APP_ID` and `DOCS_BOT_PRIVATE_KEY`
- The App added to the `master` ruleset bypass list (App bypass requires a Ruleset, not classic branch protection)

The App is scoped to `Contents: write` on this repo only, and the token is minted fresh per run (~1h lifetime).

**Verified**

A `workflow_dispatch` run against this branch ([run 32954562637](https://github.com/flairNLP/fundus/actions/runs/32954562637)) completed successfully: the App token was minted, `actions/checkout` used it, and `git-auto-commit-action` pushed the regenerated docs back to the branch. The temporary publisher change used to produce a docs diff, and the resulting bot commit, have both been removed — the PR is now the workflow change only.

Not covered by that test: the run checked out this branch, so the protected-branch bypass on `master` is exercised for the first time only after merge.