### PR TITLE
Fix review cache reuse, enable impersonation, track skill drift

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -10,7 +10,7 @@ their own agent with the installer below.
 
 | Skill | What it does |
 |-------|--------------|
-| [`review-publisher`](review-publisher/SKILL.md) | Reviews a publisher PR (new publisher or parser-version change): crawls live articles to verify the extracted `ArticleBody` mirrors the real article, checks `VALID_UNTIL` / version bumps / `validate=False` / `free_access`, and drafts a single GitHub review. |
+| [`review-publisher`](review-publisher/SKILL.md) | Reviews a publisher PR (new publisher or parser-version change): crawls live articles to verify the extracted `ArticleBody` mirrors the real article, checks `VALID_UNTIL` / version bumps / `validate=False` / `free_access` / `impersonate`, and drafts a single GitHub review. |
 
 `install.py` (the installer launcher) and the `installer/` package behind it, plus this
 `README.md`, round out the folder.
@@ -46,9 +46,21 @@ python skills/install.py
 ```
 
 It shows a live list of *skills* for the selected agent. Each row is a skill; the **Installed** column
-shows whether it's installed (`✓`) or not (`·`). Move the cursor with `↑`/`↓`, then press `space` to act
-on the highlighted skill — installing it if it's absent, uninstalling it if it's present. The list updates
-in place, so you never have to re-run. `r` refreshes from disk and `q` quits.
+shows how the installed copy stands against the source in this repo:
+
+| | Meaning | What to do |
+|---|---|---|
+| `·` | not installed | `space` to install |
+| `✓` | installed, identical to `skills/` | nothing |
+| `↑` | the repo has moved on since you installed | re-install (toggle off, then on) |
+| `≠` | the **installed copy** was edited in place | port the edit back into `skills/` *first* — re-installing overwrites it |
+| `?` | no usable install manifest (pre-manifest, corrupt, or from an older fingerprint algorithm), and the two differ | compare by hand, then re-install |
+
+The **Version** column shows the source's `version:`, or `installed → source` when they differ.
+
+Move the cursor with `↑`/`↓`, then `space` to install (if absent) or uninstall (if present) — it keys
+off presence, not sync state, so on a `↑`/`≠` row it uninstalls and re-installing is the second press.
+The list updates in place. `r` refreshes from disk, `q` quits.
 
 Skills install to `./.claude/skills/`, scoped to this repo — where they're relevant (Fundus skills
 reference repo files and run against the repo) — and never pushed (`.claude/` is in the committed
@@ -65,6 +77,20 @@ pip install -e .[dev]
 Re-install (toggle off, then on) after editing a skill source to refresh the installed copy. Restart
 your agent so it picks up a newly installed skill.
 
+## Versioning and drift
+
+Installing writes an `.install-manifest.json` into the installed folder holding the skill's `version`
+and a **content fingerprint**. Each refresh re-fingerprints both sides against that record, which is
+what separates the repo moving on (`↑`) from the copy being edited in place (`≠`). The manifest also
+carries a `format`; changing how fingerprints are computed means bumping it, so old manifests read as
+`?` rather than accusing an untouched copy of local edits.
+
+The fingerprint does the work, not the version: nobody editing an installed copy bumps a label. `≠`
+is the state worth acting on — work under `.claude/` that exists nowhere else, which a re-install
+would throw away. `version:` is optional (unversioned shows `—`); bump it when users should notice,
+and a `↑` row then reads `1.0.0 → 1.1.0`. `__pycache__`/`.pyc` are excluded, since an installed
+skill accumulates them just by running.
+
 ## Supported agents
 
 | Agent | Status | Target |
@@ -80,7 +106,7 @@ required; the rest are optional:
 ```
 skills/
 └── my-skill/
-    ├── SKILL.md          # required: frontmatter (name/description) + instructions
+    ├── SKILL.md          # required: frontmatter (name/description/version) + instructions
     ├── PLAYBOOK.md       # the steps SKILL.md links to as a sibling
     ├── requirements.txt  # optional: extra pip deps, installed on install
     └── scripts/          # optional: helper scripts the playbook calls
@@ -88,13 +114,15 @@ skills/
 ```
 
 A minimal `SKILL.md` looks like this — the block fenced by `---` at the top is the **YAML frontmatter**
-(a small metadata header): the installer reads its one-line `description` for the dashboard, and your
-agent reads `name`/`description` to decide when to invoke the skill. Everything after the closing `---`
+(a small metadata header): the installer reads its one-line `description` for the dashboard and its
+optional `version` for the Version column, and your agent reads `name`/`description` to decide when to
+invoke the skill. Everything after the closing `---`
 is the instructions the agent follows.
 
 ```markdown
 ---
 name: my-skill
+version: 1.0.0
 description: One-line summary of what this skill does and, crucially, when the agent should use it.
 ---
 

--- a/skills/installer/core.py
+++ b/skills/installer/core.py
@@ -11,16 +11,34 @@ future plain CLI, or tests without dragging in the TUI stack. The two domain obj
 
 Installing copies the whole folder (``shutil.copytree``) into the agent's config dir (under
 the repo's gitignored ``.claude/``); re-installing refreshes the copy in place.
+
+Every install drops a :data:`MANIFEST_FILE` recording the declared ``version`` and a content
+**fingerprint**, which is how :meth:`Agent.status` tells the two kinds of drift apart: the repo
+moved on (reinstall), or the installed copy was edited in place (reinstalling discards it). A
+version alone can't catch the second — whoever edits a copy has no reason to bump it.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+# Records what was installed; excluded from fingerprints so it isn't part of the skill.
+MANIFEST_FILE = ".install-manifest.json"
+# Bump whenever `fingerprint` changes: a digest written by an older algorithm is not comparable,
+# and treating it as one would report an untouched copy as edited in place. A manifest at any
+# other format reads as untracked until the skill is re-installed.
+MANIFEST_FORMAT = 1
+# Build artefacts a copied folder accumulates on use; never part of what was installed.
+_IGNORED_NAMES = {"__pycache__", MANIFEST_FILE}
+_IGNORED_SUFFIXES = {".pyc", ".pyo"}
 
 INSTALLER_DIR = Path(__file__).resolve().parent  # skills/installer/
 SKILLS_DIR = INSTALLER_DIR.parent  # skills/
@@ -50,7 +68,17 @@ class Skill:
     @property
     def description(self) -> str:
         """The one-line ``description`` from this skill's SKILL.md frontmatter (``""`` if none)."""
-        return _frontmatter_description(self.skill_md)
+        return _frontmatter_field(self.skill_md, "description")
+
+    @property
+    def version(self) -> str:
+        """The ``version`` from frontmatter (``""`` if none) — a hand-bumped label only; drift
+        detection uses :func:`fingerprint`, so an unversioned skill is fine."""
+        return _frontmatter_field(self.skill_md, "version")
+
+    def fingerprint(self) -> str:
+        """Content hash of this skill's source folder."""
+        return fingerprint(self.source)
 
 
 def discover_skills() -> Dict[str, Skill]:
@@ -64,6 +92,58 @@ def discover_skills() -> Dict[str, Skill]:
         for path in sorted(SKILLS_DIR.iterdir())
         if path.is_dir() and (path / "SKILL.md").is_file()
     }
+
+
+def fingerprint(root: Path) -> str:
+    """Content hash of a skill folder: names and bytes, not folder state.
+
+    Paths go in POSIX-relative so a rename registers and the digest matches across platforms;
+    bytes are hashed raw, since normalising line endings would hide exactly the differences this
+    exists to surface. Mode bits and empty directories are *not* covered — a `chmod -x` on an
+    installed script still reads as in sync.
+    """
+    digest = hashlib.sha256()
+    for path in sorted(_skill_files(root), key=lambda p: p.relative_to(root).as_posix()):
+        data = path.read_bytes()
+        # Both parts length-prefixed, so no arrangement of names and contents hashes the same
+        # two ways (colons are legal in filenames, so prefixing only the content isn't enough).
+        name = path.relative_to(root).as_posix()
+        header = f"{len(name)}:{name}:{len(data)}:"
+        digest.update(header.encode("utf-8"))
+        digest.update(data)
+    return digest.hexdigest()
+
+
+def _skill_files(root: Path) -> List[Path]:
+    """Every file that counts as part of a skill — build artefacts and the manifest excluded."""
+    return [
+        path
+        for path in root.rglob("*")
+        if path.is_file()
+        and path.suffix not in _IGNORED_SUFFIXES
+        and not any(part in _IGNORED_NAMES for part in path.relative_to(root).parts)
+    ]
+
+
+@dataclass(frozen=True)
+class InstallStatus:
+    """How an installed skill relates to its source.
+
+    ``source_changed`` and ``local_changed`` are independent because the fixes differ (see the
+    module docstring). ``tracked`` is False for a pre-manifest install, where a difference can't
+    be attributed to either side — both flags then carry the same "they differ".
+    """
+
+    installed: bool
+    tracked: bool
+    source_changed: bool
+    local_changed: bool
+    installed_version: str
+    source_version: str
+
+    @property
+    def in_sync(self) -> bool:
+        return self.installed and not self.source_changed and not self.local_changed
 
 
 # --- agents (where skills get installed) ---
@@ -111,8 +191,37 @@ class Agent:
                 False,
                 [*req_log, f"  rolled back '{skill.name}' files — any packages pip already installed stay"],
             )
-        head = f"installed '{skill.name}' for {self.name} -> {dest / 'SKILL.md'}"
+        # Last, so a manifest only ever describes a fully landed install.
+        _write_manifest(dest, skill)
+        version = f" v{skill.version}" if skill.version else ""
+        head = f"installed '{skill.name}'{version} for {self.name} -> {dest / 'SKILL.md'}"
         return InstallResult(True, [head, *req_log])
+
+    def status(self, skill: Skill) -> InstallStatus:
+        """Where the installed copy stands relative to the source — see :class:`InstallStatus`."""
+        dest = self.destination(skill)
+        source_version = skill.version
+        if not dest.exists():
+            return InstallStatus(False, False, False, False, "", source_version)
+        manifest = _read_manifest(dest) or {}
+        source_now = skill.fingerprint()
+        installed_now = fingerprint(dest)
+        recorded = str(manifest.get("fingerprint") or "")
+        # An unusable manifest is one we cannot compare against: absent (pre-manifest install),
+        # truncated, or — the one that bites on upgrade — written by a different `fingerprint`
+        # algorithm, whose digest would differ for a copy nobody touched. Each would otherwise
+        # read as ≠ ("your local edits are about to be destroyed") for work that never happened.
+        if not recorded or manifest.get("format") != MANIFEST_FORMAT:
+            differs = installed_now != source_now
+            return InstallStatus(True, False, differs, differs, "", source_version)
+        return InstallStatus(
+            installed=True,
+            tracked=True,
+            source_changed=source_now != recorded,
+            local_changed=installed_now != recorded,
+            installed_version=str(manifest.get("version", "")),
+            source_version=source_version,
+        )
 
     def uninstall(self, skill: Skill) -> List[str]:
         dest = self.destination(skill)
@@ -137,6 +246,34 @@ def available_agents() -> Dict[str, Agent]:
 
 
 # --- helpers ---
+
+
+def _write_manifest(dest: Path, skill: Skill) -> None:
+    """Record what was just installed, so a later run can detect drift on either side."""
+    # `source` and `installed_at` have no reader — they are breadcrumbs for a human opening the
+    # file to ask where a copy came from. `version` and `fingerprint` are what `status` uses.
+    manifest = {
+        "format": MANIFEST_FORMAT,
+        "skill": skill.name,
+        "version": skill.version,
+        "fingerprint": fingerprint(dest),
+        "source": str(skill.source),
+        "installed_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    (dest / MANIFEST_FILE).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def _read_manifest(dest: Path) -> Optional[Dict[str, object]]:
+    """The manifest, or None if absent/unreadable — a corrupt one degrades to "untracked"
+    rather than crashing the dashboard."""
+    path = dest / MANIFEST_FILE
+    if not path.is_file():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
 
 
 def _install_requirements(skill: Skill) -> Tuple[bool, List[str]]:
@@ -188,12 +325,13 @@ def _pip_error_tail(stdout: str, stderr: str) -> List[str]:
     return chosen[-5:] if chosen else ["(pip produced no output)"]
 
 
-def _frontmatter_description(skill_md: Path) -> str:
-    """Pull the one-line ``description`` from a SKILL.md's YAML frontmatter.
+def _frontmatter_field(skill_md: Path, field: str) -> str:
+    """Pull one field from a SKILL.md's YAML frontmatter.
 
     Handles both inline (``description: foo``) and block-scalar (``description: >-``) forms;
-    returns ``""`` when the file is missing or has no frontmatter description.
+    returns ``""`` when the file is missing or has no such field.
     """
+    key = f"{field}:"
     try:
         text = skill_md.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -210,9 +348,9 @@ def _frontmatter_description(skill_md: Path) -> str:
     capturing = False
     for line in lines[1:end]:
         if not capturing:
-            if line.startswith("description:"):
+            if line.startswith(key):
                 capturing = True
-                rest = line[len("description:") :].strip()
+                rest = line[len(key) :].strip()
                 # Skip block-scalar indicators (``>-``, ``|``, …); keep inline text.
                 if rest and rest[0] not in "|>":
                     parts.append(rest)

--- a/skills/installer/tui.py
+++ b/skills/installer/tui.py
@@ -1,8 +1,8 @@
 """Textual dashboard for the skill installer.
 
-A live list of *skills* for the selected agent. Each row is a skill; the **Installed** column
-shows whether it's installed (``✓``) or not (``·``). Move the cursor to a skill and toggle it
-to install it (if absent) or uninstall it (if present) — the list updates in place, no
+A live list of *skills* for the selected agent. The **Installed** column shows both presence and
+drift: ``✓`` in sync, ``↑`` repo moved on, ``≠`` copy edited in place, ``·`` absent. Move the
+cursor to a skill and toggle it to install (if absent) or uninstall (if present) — in place, no
 re-running.
 
 This module owns everything textual/rich; all install logic lives in :mod:`installer.core`.
@@ -18,19 +18,40 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.widgets import DataTable, Footer, Header, RadioButton, RadioSet, RichLog, Static
 
-from .core import Agent, InstallResult, Skill, available_agents, discover_skills
+from .core import Agent, InstallResult, InstallStatus, Skill, available_agents, discover_skills
 
 _YES = Text("✓", style="bold green", justify="center")
 _NO = Text("·", style="dim", justify="center")
+# Kept apart because the fix differs: ↑ reinstall; ≠ the copy holds work a reinstall would lose.
+_OUTDATED = Text("↑", style="bold yellow", justify="center")
+_MODIFIED = Text("≠", style="bold magenta", justify="center")
+# Pre-manifest install whose folders differ: real drift, direction unknown.
+_UNKNOWN = Text("?", style="bold yellow", justify="center")
 # Install failed and was rolled back: a transient marker, replaced by · on the next refresh
 # (the rollback makes "not installed" the true steady state, so refresh doesn't lie).
 _FAILED = Text("!", style="bold red", justify="center")
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"  # braille "wheel": a busy cell cycles through these frames
 _INSTALLED_COL = "installed"
+_VERSION_COL = "version"
 
 
-def _status(installed: bool) -> Text:
-    return _YES if installed else _NO
+def _status(status: InstallStatus) -> Text:
+    """One glyph for the row. Local edits outrank a stale repo: reinstalling would lose them."""
+    if not status.installed:
+        return _NO
+    if status.in_sync:
+        return _YES
+    if not status.tracked:
+        return _UNKNOWN  # differs, but nothing says which side moved
+    return _MODIFIED if status.local_changed else _OUTDATED
+
+
+def _version_cell(status: InstallStatus) -> Text:
+    """The source version, prefixed with the installed one when they differ."""
+    source = status.source_version or "—"
+    if status.installed and status.installed_version and status.installed_version != status.source_version:
+        return Text(f"{status.installed_version} → {source}", style="yellow")
+    return Text(source, style="dim")
 
 
 def _spinner_cell(frame: int) -> Text:
@@ -93,12 +114,15 @@ class InstallerApp(App[None]):
             self.query_one("#agent", RadioSet).border_title = "Agent"
         else:
             self.sub_title = f"agent: {self._agent_names[0]}"
-        self.table.border_title = "Skills - ✓ = installed"
+        self.table.border_title = (
+            "Skills - ✓ in sync | ↑ repo newer | ≠ edited in place | ? unknown | ! failed | · absent"
+        )
         self.table.border_subtitle = "↑/↓ pick a skill · space to (un)install"
         self.detail.border_title = "Description"
         self.output.border_title = "Log"
         self.table.add_column("Skill", key="skill")
         self.table.add_column("Installed", key=_INSTALLED_COL, width=12)
+        self.table.add_column("Version", key=_VERSION_COL, width=16)
         self._rebuild()
         self.table.focus()
         self._show_description(self._highlighted_skill())
@@ -126,9 +150,11 @@ class InstallerApp(App[None]):
         self.table.clear()
         for name in sorted(self.skills):
             skill = self.skills[name]
+            status = agent.status(skill)
             self.table.add_row(
                 Text(name, style="bold"),
-                _status(agent.is_installed(skill)),
+                _status(status),
+                _version_cell(status),
                 key=name,
             )
 
@@ -144,8 +170,9 @@ class InstallerApp(App[None]):
 
     def _refresh_row(self, name: str) -> None:
         agent = self._agent()
-        skill = self.skills[name]
-        self.table.update_cell(name, _INSTALLED_COL, _status(agent.is_installed(skill)))
+        status = agent.status(self.skills[name])
+        self.table.update_cell(name, _INSTALLED_COL, _status(status))
+        self.table.update_cell(name, _VERSION_COL, _version_cell(status))
 
     def _write_log(self, lines: List[str], style: str = "") -> None:
         """Write core-produced log lines as literal Text — styled, and safe against any
@@ -168,6 +195,7 @@ class InstallerApp(App[None]):
         if self._busy:
             return  # an install is in flight — ignore toggles until it finishes
         agent = self._agent()
+        # Keyed on presence, not sync state: space on a ↑/≠ row uninstalls, same as on ✓.
         if agent.is_installed(skill):
             self._write_log(agent.uninstall(skill))
             self._refresh_row(skill.name)

--- a/skills/review-publisher/PLAYBOOK.md
+++ b/skills/review-publisher/PLAYBOOK.md
@@ -8,6 +8,12 @@
 All mechanics run through one driver (`<skill>` is the skill directory SKILL.md told you):
 
     python "<skill>/scripts/review.py" {crawl,sweep,show,adjudicate,status,payload} <cc>.<Class>
+    python "<skill>/scripts/review.py" done
+
+The cache is keyed on the **commit under review** (derived from git, nothing to pass), so no other
+review inherits these articles and adjudications and a mid-review push retires them rather than
+letting them be replayed against changed code. `done` removes it (§6). `--pr` on `crawl` is
+recorded, so `status` and `payload` can name the PR back to you.
 
 The driver owns the bookkeeping and prints its own next steps and warnings — trust that output, and
 **act on its `!` lines rather than just acknowledging them**. What it never does is judge; this
@@ -38,7 +44,8 @@ photo caption corrupts that mapping. Over-capture is a blocker, not a nit.
 
 - **The PR number**, and whether it's **your own** PR (changes the event — §4). If the user didn't
   name one: `gh pr view --json number,title,author` reads the current branch's PR — show and confirm
-  it; if the branch has none, ask. Never guess. (`author` also settles the own-PR question.)
+  it; if the branch has none, ask. Never guess — pass it to `crawl` as `--pr`. (`author` also
+  settles the own-PR question.)
 - The publisher(s) as `PublisherCollection.<cc>.<Class>` and the parser version(s) touched.
 
 ## 1. Static read
@@ -47,6 +54,9 @@ photo caption corrupts that mapping. Over-capture is a blocker, not a nit.
 gh pr checkout <PR_NUMBER>
 gh pr diff <PR_NUMBER>
 ```
+
+**Check out before you crawl** — the cache is keyed on `HEAD`, so crawling first draws against
+`master` and the checkout then strands that cache (`status` reports no state).
 
 - `@attribute` return types match [`attribute_guidelines.md`](/docs/attribute_guidelines.md).
 - **`validate=False` attributes are checked by nobody but you** — CI type-checks validated
@@ -60,13 +70,21 @@ gh pr diff <PR_NUMBER>
   leaving it unset is the intended `date.max`.)
 - **Version bump fits the change**: selector-only fix → minor (`V1_1(V1)`); new or substantially
   changed attributes → major (`V2`). Flag a mismatch in either direction.
+- **`impersonate`**: a browser profile (e.g. `"chrome"`) routing this publisher through curl_cffi,
+  for sites behind a TLS-fingerprint anti-bot layer. The value is validated in `Publisher.__init__`,
+  so a bad target fails at import; what's yours is whether it belongs there at all. **Present** — set
+  it *only* when the publisher genuinely can't be crawled without it
+  ([`how_to_add_a_publisher.md`](/docs/how_to_add_a_publisher.md)); ask the PR to say why, a nit
+  unless plainly cargo-culted. **Absent** — the tell is §2's crawl coming back empty. It's opt-in
+  user-side, so under the default `Crawler(impersonate=False)` a declared profile does nothing and
+  the publisher just yields nothing, silently; the review's crawl always passes `impersonate=True`.
 - **Changes to `parser/utility.py`** (`generic_topic_parsing`, `apply_result_filter`,
   `image_extraction`, …) affect every publisher — check the call sites.
 
 ## 2. Crawl live articles and verify the body
 
 ```bash
-python "<skill>/scripts/review.py" crawl <cc>.<Class>   # pool 100 -> read 10
+python "<skill>/scripts/review.py" crawl <cc>.<Class> --pr <PR>   # pool 100 -> read 10
 ```
 
 **The defaults are the budget.** Raising `--pool` or `--review` costs a second live crawl and
@@ -100,6 +118,21 @@ evidence about the articles nobody read. An interrupted crawl caches nothing; ju
   per-attribute failures. **0 articles after a fair attempt is itself a blocker-level finding** —
   report it, don't stall. Inspect via the cached html (`show` prints paths); many publishers block
   generic fetchers, so never fetch manually with `urllib`/`requests`.
+- **0 articles and no `impersonate` declared?** A fingerprint block looks exactly like broken
+  sources, but the fix is a one-line declaration. Rule it in or out before writing that finding:
+
+  ```python
+  # In a *fresh* process: a robots.txt already read as 403 stays disallowed, and re-reading it
+  # can't undo that, so reusing the crawl's interpreter would answer 0 for the wrong reason.
+  from fundus import Crawler, PublisherCollection
+  publisher = PublisherCollection.<cc>.<Class>
+  publisher.impersonate = "chrome"                             # in-process only, nothing on disk
+  publisher.robots.robots_file_parser.impersonate = "chrome"   # robots.txt is often blocked too
+  print(len(list(Crawler(publisher, impersonate=True).crawl(max_articles=1, only_complete=False))))
+  ```
+
+  An article back means the finding is the **missing `impersonate` profile**, `"chrome"` as the fix.
+  Nothing back and the empty-draw finding stands as written.
 
 ### Tier 1 — coherence read (every cached article, from the crawl output)
 
@@ -115,7 +148,7 @@ Tier 2 exists for exactly that.
 
 ```bash
 python "<skill>/scripts/review.py" sweep <cc>.<Class>                 # same cache, no network
-python "<skill>/scripts/review.py" sweep <cc>.<Class> --version V1_1  # pin a legacy version; re-runs free
+python "<skill>/scripts/review.py" sweep <cc>.<Class> --version V1_1  # pin a legacy version; free
 ```
 
 The sweep applies the version's real body selectors to each cached article and emits candidates with
@@ -134,7 +167,7 @@ ids. **A candidate is a question, not a verdict** — the answer depends on the 
 ```bash
 python "<skill>/scripts/review.py" show <cc>.<Class> <id>      # full text + cached html paths
 python "<skill>/scripts/review.py" adjudicate <cc>.<Class> <id> ok --note "site-wide cookie banner"
-python "<skill>/scripts/review.py" adjudicate <cc>.<Class> <id> blocker --note "<ul> of match results dropped; <url>"
+python "<skill>/scripts/review.py" adjudicate <cc>.<Class> <id> blocker --note "<ul> dropped; <url>"
 ```
 
 `ok` = benign; `blocker` = real finding, with the note as its evidence line. Adjudicate from the
@@ -250,8 +283,18 @@ gh api repos/flairNLP/fundus/pulls/<PR>/reviews -X POST --input "<cache>/review.
 The review posts under the `gh`-authenticated user; with `REQUEST_CHANGES` it blocks merge until
 resolved if the repo enforces review gating.
 
+## 6. Close the review out
+
+```bash
+python "<skill>/scripts/review.py" done
+```
+
+Removes this commit's cache — every publisher at once, which is why it takes no arguments. Run it
+*after* the POST: until then the cache is the evidence behind the review. Skip it only if the user
+wants the html kept — and say so. (`crawl` prunes abandoned caches, but only after a week.)
+
 ---
 
-*Cleanup: with scratch in the cache/temp dir there's nothing to clean in the repo. If anything of
+*Cleanup: `done` clears the temp cache; nothing of the review lands in the repo. If anything of
 yours did land in the working dir, remove only that; never touch pre-existing untracked files
 without asking.*

--- a/skills/review-publisher/SKILL.md
+++ b/skills/review-publisher/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: review-publisher
+version: 2.0.0
 description: >-
   Review a Fundus publisher PR — one that adds a new publisher or adds/changes a parser version.
   Crawls live articles to verify the extracted ArticleBody mirrors the real article (no missing or
-  leaked content), checks VALID_UNTIL / version bumps / validate=False attributes / free_access, and
-  drafts a single GitHub review. Use when asked to review a publisher or parser PR.
+  leaked content), checks VALID_UNTIL / version bumps / validate=False attributes / free_access /
+  impersonate, and drafts a single GitHub review. Use when asked to review a publisher or parser PR.
 ---
 
 # Review a Publisher PR
@@ -15,12 +16,15 @@ SKILL.md*, so note the literal path above now. The procedure lives in the siblin
 The bundled driver — the only tool you need — is:
 
     python "<skill>/scripts/review.py" {crawl,sweep,show,adjudicate,status,payload} <cc>.<Class>
+    python "<skill>/scripts/review.py" done
 
-Open the PLAYBOOK and work through §1–§5; it's the source of truth. These are the guardrails to
+Open the PLAYBOOK and work through §1–§6; it's the source of truth. These are the guardrails to
 hold onto even before you open it:
 
 - **No PR named? Resolve it first** — read the current branch's PR (`gh pr view`), confirm it, or ask.
-  Never guess or default to the latest.
+  Never guess or default to the latest. `gh pr checkout` it **before** the first crawl — the cache is
+  keyed on `HEAD`. Pass `--pr` to `crawl` so the driver can name it back to you; `done` clears the
+  cache once the review is posted (§6).
 - **Don't run `pytest` / `mypy` / `ruff`** — CI covers them; your value-add is live-article correctness.
 - **The body must mirror the article** — no dropped paragraphs, no leaked boilerplate. The driver's
   crawl-once-then-sweep flow (§2) is a hard gate on **every** publisher: every candidate it surfaces

--- a/skills/review-publisher/scripts/_store.py
+++ b/skills/review-publisher/scripts/_store.py
@@ -1,4 +1,4 @@
-"""Persistence for the publisher-review driver (`review.py`): one cache dir per review.
+"""Persistence for the publisher-review driver (`review.py`): one cache dir per publisher.
 
 The cache dir holds the raw crawled bytes (`NN.html`) plus a single `state.json` that is
 the source of truth for the whole review: crawl parameters, the per-article records, the
@@ -6,26 +6,44 @@ pool-wide scan, the sweep's candidates, and the agent's adjudications. Everythin
 knows it knows from here, which is what makes the workflow crash-safe (state is rewritten after
 every article) and gateable (`payload_gaps` can name exactly what is still missing).
 
-Layout of a cache dir (default: <tempdir>/fundus-review/<cc>.<Class>/):
+Caches are keyed on the **commit under review** — the HEAD of the repo the parser is imported from.
+Derived, not passed, so there is no flag to get wrong and every agent computes the same key. Two
+consequences fall out of that choice rather than needing code: a review of a *different* commit
+can never inherit these articles and adjudications, and when the PR author pushes a fix the old
+cache simply stops being addressed, so adjudications made against superseded parser code can't be
+replayed. `review.py done` removes the commit's caches; `crawl` prunes ones nobody cleaned up.
 
-    state.json   # crawl meta + article records + pool scan + sweep candidates + adjudications
-    01.html      # raw html.content bytes for article 1 (exact crawled bytes)
-    02.html      # ...
+Layout (<tempdir>/fundus-review/<short-sha>/<cc>.<Class>/):
+
+    d732ca85/
+      ca.NationalPost/
+        state.json      # crawl meta + article records + pool scan + candidates + adjudications
+        01.html         # article 1's html.content, re-encoded UTF-8 (see `save_article`)
+        findings.json   # `payload`: the adjudicated evidence
+        review.json     # `payload`: the review to post, as a skeleton
+      ca.TorontoStar/   # another publisher in the same review — its own crawl, sweep and gate
 """
 
+import functools
 import hashlib
 import json
+import re
 import shutil
+import subprocess
 import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import fundus
 from fundus import Article, PublisherCollection, Requires
 from fundus.publishers.base_objects import Publisher
 
 STATE_FILE = "state.json"
+# What `payload` writes: the adjudicated evidence, and the review built from it.
+FINDINGS_FILE = "findings.json"
+REVIEW_FILE = "review.json"
 
 # Adjudication verdicts: "ok" = benign (boilerplate outside the body for a drop candidate,
 # legitimately repeated content for a leak candidate); "blocker" = a real finding.
@@ -56,38 +74,137 @@ def resolve_publisher(spec: str) -> Publisher:
     return publisher
 
 
+def cache_root() -> Path:
+    return Path(tempfile.gettempdir()) / "fundus-review"
+
+
+@functools.lru_cache(maxsize=1)
+def commit_id() -> str:
+    """Short SHA of the repo the parser under review comes from, or "detached" if git can't say.
+
+    Cached: it is constant within a process, and two `git` calls in one command could otherwise
+    straddle a checkout and have the driver name a different commit than the one it acted on.
+
+    Anchored to `fundus.__file__` (<root>/src/fundus/__init__.py), not the working directory: the
+    cache is about the parser code being imported, and the driver runs from anywhere. Sanitised on
+    the way out, because it builds directories that later get deleted.
+    """
+    root = Path(fundus.__file__).resolve().parents[2]
+    try:
+        git = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "detached"
+    return (re.sub(r"[^A-Za-z0-9]", "", git.stdout.strip()) if git.returncode == 0 else "") or "detached"
+
+
+def commit_cache_dir() -> Path:
+    """Everything this commit's review wrote — the unit `done` tears down."""
+    return cache_root() / commit_id()
+
+
 def default_cache_dir(spec: str) -> Path:
-    """Predictable per-publisher temp location, so every subcommand agrees without a path."""
-    return Path(tempfile.gettempdir()) / "fundus-review" / spec
+    """Per-publisher location inside the commit's dir, so every subcommand agrees without a path."""
+    return commit_cache_dir() / spec
 
 
-def resolve_cache_dir(spec: str, provided: Optional[str]) -> Path:
-    return Path(provided) if provided else default_cache_dir(spec)
+def _assert_review_cache(cache_dir: Path, action: str) -> None:
+    """Refuse to touch a directory that isn't ours: a non-empty dir with no `state.json` is
+    somebody's files, not a review cache. An empty one is a crawl killed before its first write.
+
+    Mostly matters for `remove_commit_cache`, which walks whatever the commit dir happens to hold;
+    `prepare_cache_dir` only ever reaches a path this module built.
+    """
+    if any(cache_dir.iterdir()) and not (cache_dir / STATE_FILE).exists():
+        raise SystemExit(
+            f"refusing to {action} {cache_dir}: non-empty and no {STATE_FILE}, so it doesn't look "
+            f"like a review cache. Remove it by hand if that is really what you want."
+        )
 
 
 def prepare_cache_dir(cache_dir: Path) -> None:
-    """Wipe and recreate `cache_dir` for a fresh crawl — refusing anything that isn't a review cache.
-
-    The guard is what makes `--cache-dir` safe: a non-empty directory without a
-    `state.json` (someone's working tree, a typo'd path) is never deleted.
-    """
+    """Wipe and recreate `cache_dir` for a fresh crawl — refusing anything that isn't a review cache."""
     if cache_dir.exists():
-        if any(cache_dir.iterdir()) and not (cache_dir / STATE_FILE).exists():
-            raise SystemExit(
-                f"refusing to wipe {cache_dir}: non-empty and no {STATE_FILE}, so it doesn't look like "
-                f"a review cache. Use a valid or not-yet-existing --cache-dir."
-            )
+        _assert_review_cache(cache_dir, "wipe")
         shutil.rmtree(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
+
+
+def remove_commit_cache() -> List[str]:
+    """Delete this commit's caches, returning the specs removed.
+
+    Refuses if the dir holds anything that isn't a review cache, so a stray `done` can't take down
+    real work. An *empty* child is fine to remove — that is a crawl killed before its first write,
+    not somebody's files (same rule as `_assert_review_cache`).
+    """
+    commit_dir = commit_cache_dir()
+    if not commit_dir.exists():
+        return []
+    children = sorted(commit_dir.iterdir())
+    for child in children:
+        if child.is_dir():
+            _assert_review_cache(child, "remove")
+        else:
+            raise SystemExit(f"refusing to remove {commit_dir}: it holds the file {child.name!r}.")
+    # Every child, not just the ones with state: `rmtree` takes the lot, so reporting only the
+    # stateful ones would tell the reviewer "nothing to remove" right after removing something.
+    removed = [child.name for child in children]
+    try:
+        shutil.rmtree(commit_dir)
+    except OSError as error:  # a file still open (an editor, a pager) - fail like the rest of the module
+        raise SystemExit(f"could not remove {commit_dir}: {error}")
+    return removed
+
+
+def prune_stale_caches(max_age_days: int = 7) -> List[str]:
+    """Drop caches from reviews that ended without `done`, so abandoned ones can't pile up.
+
+    Only touches dirs that look like review caches throughout, and never this commit's own.
+    Best-effort: a dir that vanishes underneath us (or that we may not delete) is skipped.
+    """
+    root, mine = cache_root(), commit_cache_dir()
+    if not root.exists():
+        return []
+    cutoff = time.time() - max_age_days * 86400
+    pruned: List[str] = []
+    for cached in sorted(root.iterdir()):
+        # The whole body, not just the rmtree: another review pruning or crawling concurrently can
+        # delete `cached` between any two of these calls, and housekeeping must never be the reason
+        # a crawl dies before it crawls.
+        try:
+            if not cached.is_dir() or cached == mine or cached.stat().st_mtime > cutoff:
+                continue
+            children = list(cached.iterdir())
+            if any(not c.is_dir() or (any(c.iterdir()) and not (c / STATE_FILE).exists()) for c in children):
+                continue  # not ours throughout — leave it alone
+            shutil.rmtree(cached)
+        except OSError:
+            continue  # vanished underneath us, or not ours to delete
+        pruned.append(cached.name)
+    return pruned
 
 
 # --- state file ---
 
 
-def new_state(spec: str, pool: int) -> Dict[str, Any]:
+def new_state(spec: str, pr: Optional[str], pool: int, impersonate: Optional[str]) -> Dict[str, Any]:
     return {
         "publisher": spec,
-        "crawl": {"pool": pool, "started": time.time(), "finished": None, "completed": False},
+        # Metadata, not identity: the commit owns the path. Recorded so `status` says what this
+        # cache is about and `payload` can fill in the `gh` commands.
+        "pr": pr,
+        "crawl": {
+            "pool": pool,
+            "started": time.time(),
+            "finished": None,
+            "completed": False,
+            # The declared browser profile, or None: the fingerprint the draw came back through.
+            "impersonate": impersonate,
+        },
         "articles": [],
         "scan": None,
         "sweep": None,

--- a/skills/review-publisher/scripts/review.py
+++ b/skills/review-publisher/scripts/review.py
@@ -10,18 +10,24 @@ machine so the agent can't substitute "looks clean" for verification:
     status      where the review stands; exit 0 only when nothing is pending
     payload     refuse while anything is un-adjudicated, else emit findings.json plus a
                 review.json skeleton — the review to post, mechanical half prefilled (§5)
+    done        remove this commit's whole cache once the verdict is posted
 
 Both tiers and every re-run work the *same* crawled draw (PLAYBOOK.md §2): `crawl` is the
 only networked step, everything else replays the cache. Re-sweeping (e.g. `--version V1`)
 costs nothing and keeps existing adjudications — candidate ids are content-hashes.
 
+The cache is scoped to the commit under review (derived from git, nothing to pass), so no other
+review can inherit these articles and adjudications, and a push by the PR author retires them
+rather than letting them be replayed against changed code; `done` removes the lot.
+
 Usage (any working directory; <skill>/ is this skill's directory):
 
-    python <skill>/scripts/review.py crawl ca.NationalPost [--pool 100] [--review 10]
+    python <skill>/scripts/review.py crawl ca.NationalPost --pr 970 [--pool 100] [--review 10]
     python <skill>/scripts/review.py sweep ca.NationalPost [--version V1_1]
     python <skill>/scripts/review.py adjudicate ca.NationalPost D3f2a1c ok --note "cookie banner"
     python <skill>/scripts/review.py status ca.NationalPost
     python <skill>/scripts/review.py payload ca.NationalPost
+    python <skill>/scripts/review.py done
 """
 
 import argparse
@@ -32,16 +38,19 @@ import logging
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import lxml.etree
 import lxml.html
 from _store import (
+    FINDINGS_FILE,
+    REVIEW_FILE,
     VERDICTS,
     blocker_candidates,
     body_units,
     candidate_id,
     candidates,
+    commit_id,
     default_cache_dir,
     load_state,
     missing_attributes,
@@ -49,9 +58,10 @@ from _store import (
     payload_gaps,
     pending_candidates,
     prepare_cache_dir,
+    prune_stale_caches,
     read_html,
     record_crawl_date,
-    resolve_cache_dir,
+    remove_commit_cache,
     resolve_publisher,
     save_article,
     write_state,
@@ -81,10 +91,9 @@ REVIEW_ARTICLES = 10  # articles actually reviewed (the draw), independent of th
 # --- small helpers ---
 
 
-def _self_invocation(args: argparse.Namespace, command: str) -> str:
-    """A copy-pasteable follow-up command with the resolved script path and cache dir."""
-    cache_flag = f' --cache-dir "{args.cache_dir}"' if args.cache_dir else ""
-    return f'python "{SCRIPT}" {command} {args.publisher}{cache_flag}'
+def _self_invocation(spec: str, command: str) -> str:
+    """A copy-pasteable follow-up command with the resolved script path."""
+    return f'python "{SCRIPT}" {command} {spec}'
 
 
 def _require_state(cache_dir: Path, spec: str) -> Dict[str, Any]:
@@ -92,6 +101,19 @@ def _require_state(cache_dir: Path, spec: str) -> Dict[str, Any]:
     if state is None:
         raise SystemExit(f"no review state in {cache_dir} - run `crawl {spec}` first.")
     return state
+
+
+def _impersonation_line(declared: Optional[str]) -> str:
+    """The fingerprint the draw came back through — shared by `crawl` and `status`."""
+    if declared:
+        return f"impersonate: declares {declared!r}, used for this crawl - §1: is it justified?"
+    return "impersonate: none declared; regular fingerprint."
+
+
+def _open_review(args: argparse.Namespace) -> Tuple[Path, Dict[str, Any]]:
+    """The cache dir and its state — how every subcommand except `crawl` and `done` starts."""
+    cache_dir = default_cache_dir(args.publisher)
+    return cache_dir, _require_state(cache_dir, args.publisher)
 
 
 def _records_by_index(state: Dict[str, Any]) -> Dict[int, Dict[str, Any]]:
@@ -201,10 +223,12 @@ def cmd_crawl(args: argparse.Namespace) -> int:
         set_log_level(logging.INFO)
 
     publisher = resolve_publisher(args.publisher)
-    cache_dir = resolve_cache_dir(args.publisher, args.cache_dir)
+    if pruned := prune_stale_caches():
+        print(f"pruned {len(pruned)} stale review cache(s) that never ran `done`.")
+    cache_dir = default_cache_dir(args.publisher)
     prepare_cache_dir(cache_dir)
 
-    state = new_state(args.publisher, args.pool)
+    state = new_state(args.publisher, args.pr, args.pool, publisher.impersonate)
     write_state(cache_dir, state)
 
     pool: List[Article] = []
@@ -217,7 +241,9 @@ def cmd_crawl(args: argparse.Namespace) -> int:
         # this buffers in memory — an interrupted crawl caches nothing and is simply re-run.
         # `only_complete=False`: fundus' default draw drops articles missing title/body/publishing_date,
         # which is exactly the parser failure a review must see. They reach the scan like any other.
-        pool = list(Crawler(publisher).crawl(max_articles=args.pool, only_complete=False))
+        # `impersonate=True`: a declared profile only applies when the user opts in this way, and
+        # publishers declaring none are unaffected - without it, protected publishers draw 0.
+        pool = list(Crawler(publisher, impersonate=True).crawl(max_articles=args.pool, only_complete=False))
         risks = _scan_pool(publisher.parser, pool)
         selection = _select_for_review(pool, risks, args.review)
 
@@ -249,8 +275,11 @@ def cmd_crawl(args: argparse.Namespace) -> int:
         f"crawled and scanned {len(pool)} article(s): {len(flagged)} flagged; reviewing {reviewing} "
         f"({reviewed_flagged} flagged, {reviewing - reviewed_flagged} diverse) -> {cache_dir}"
     )
+    print(_impersonation_line(publisher.impersonate))
     if reviewing == 0:
         print("0 articles crawled - sources or parser likely broken; that is itself a blocker-level finding.")
+        if publisher.impersonate is None:
+            print("  no impersonate profile is declared - rule a TLS-fingerprint block in or out first (§2).")
         return 0
     if (state["scan"] or {}).get("medoid_flagged"):
         print("! the most typical article in the pool is flagged - a mainstream failure, not an edge case.")
@@ -270,7 +299,7 @@ def cmd_crawl(args: argparse.Namespace) -> int:
         for label, members in sorted(classes.items(), key=lambda item: -len(item[1])):
             print(f"    {len(members):>3}x  {label}  e.g. {pool[members[0].index].html.requested_url}")
         print("         (per-article rows, with flags and drop signatures, are in state.json under `scan`)")
-    print(f"next (Tier 2): {_self_invocation(args, 'sweep')}")
+    print(f"next (Tier 2): {_self_invocation(args.publisher, 'sweep')}")
     return 0
 
 
@@ -301,8 +330,7 @@ def _aggregate_drops(per_article: List[Tuple[int, SweepResult]], spec: str) -> L
 
 def cmd_sweep(args: argparse.Namespace) -> int:
     publisher = resolve_publisher(args.publisher)
-    cache_dir = resolve_cache_dir(args.publisher, args.cache_dir)
-    state = _require_state(cache_dir, args.publisher)
+    cache_dir, state = _open_review(args)
 
     parser_proxy = publisher.parser
     version_map = version_classes(parser_proxy)
@@ -383,8 +411,8 @@ def cmd_sweep(args: argparse.Namespace) -> int:
         print(line)
     if state["sweep"]["candidates"]:
         print("adjudicate each candidate (`show <id>` for detail, cached html included):")
-        print(f'  {_self_invocation(args, "adjudicate")} <id> ok|blocker --note "..."')
-    print(f"then: {_self_invocation(args, 'status')}")
+        print(f'  {_self_invocation(args.publisher, "adjudicate")} <id> ok|blocker --note "..."')
+    print(f"then: {_self_invocation(args.publisher, 'status')}")
     return 0
 
 
@@ -400,8 +428,7 @@ def _find_candidate(state: Dict[str, Any], candidate_ref: str) -> Dict[str, Any]
 
 
 def cmd_show(args: argparse.Namespace) -> int:
-    cache_dir = resolve_cache_dir(args.publisher, args.cache_dir)
-    state = _require_state(cache_dir, args.publisher)
+    cache_dir, state = _open_review(args)
     candidate = _find_candidate(state, args.id)
     records = _records_by_index(state)
 
@@ -423,8 +450,7 @@ def cmd_show(args: argparse.Namespace) -> int:
 
 
 def cmd_adjudicate(args: argparse.Namespace) -> int:
-    cache_dir = resolve_cache_dir(args.publisher, args.cache_dir)
-    state = _require_state(cache_dir, args.publisher)
+    cache_dir, state = _open_review(args)
     candidate = _find_candidate(state, args.id)
 
     state.setdefault("adjudications", {})[candidate["id"]] = {
@@ -446,19 +472,20 @@ def cmd_adjudicate(args: argparse.Namespace) -> int:
 
 
 def cmd_status(args: argparse.Namespace) -> int:
-    cache_dir = resolve_cache_dir(args.publisher, args.cache_dir)
-    state = _require_state(cache_dir, args.publisher)
+    cache_dir, state = _open_review(args)
     crawl, scan, sweep = state["crawl"], state.get("scan"), state.get("sweep")
     adjudications = state.get("adjudications") or {}
 
     print(f"publisher: {state['publisher']}")
+    print(f"PR:        {state.get('pr') or '<not recorded - pass --pr on crawl>'}")
     print(f"cache:     {cache_dir}")
     print(
         f"crawl:     {len(state['articles'])} reviewed (pool {crawl.get('pool', '?')}), "
         f"{'completed' if crawl.get('completed') else 'NOT completed (interrupted?)'}"
     )
+    print(_impersonation_line(crawl.get("impersonate")))
     if scan is None:
-        print("scan:      not run - this cache predates the pool scan; re-crawl to get it")
+        print("scan:      not run - the crawl was interrupted before the pool scan; re-crawl")
     else:
         print(
             f"scan:      {scan['pool']} scanned, {scan['flagged']} flagged, "
@@ -557,8 +584,7 @@ def _review_skeleton(parser_path: str, findings: Dict[str, Any], blockers: List[
 
 
 def cmd_payload(args: argparse.Namespace) -> int:
-    cache_dir = resolve_cache_dir(args.publisher, args.cache_dir)
-    state = _require_state(cache_dir, args.publisher)
+    cache_dir, state = _open_review(args)
 
     gaps = payload_gaps(state)
     if gaps:
@@ -594,12 +620,12 @@ def cmd_payload(args: argparse.Namespace) -> int:
         "ok_candidates": sum(1 for c in candidates(state) if adjudications.get(c["id"], {}).get("verdict") == "ok"),
     }
 
-    findings_file = cache_dir / "findings.json"
+    findings_file = cache_dir / FINDINGS_FILE
     findings_file.write_text(json.dumps(findings, ensure_ascii=False, indent=2), encoding="utf-8")
     print(json.dumps(findings, ensure_ascii=False, indent=2))
     print(RULE)
 
-    review_file = cache_dir / "review.json"
+    review_file = cache_dir / REVIEW_FILE
     if review_file.exists():
         print(f"{review_file} already exists - keeping your edits (delete it and re-run to regenerate).")
     else:
@@ -614,8 +640,24 @@ def cmd_payload(args: argparse.Namespace) -> int:
     print("    it; your own PR -> COMMENT regardless; never APPROVE")
     print("  - a multi-publisher PR gets ONE review: fold the other publishers into this body/comments")
     print("show the filled review.json to the user, and once they approve:")
-    print("  gh pr view <PR> --json headRefOid -q .headRefOid          # -> commit_id")
-    print(f'  gh api repos/flairNLP/fundus/pulls/<PR>/reviews -X POST --input "{review_file}"')
+    pr = state.get("pr") or "<PR>"
+    print(f"  gh pr view {pr} --json headRefOid -q .headRefOid          # -> commit_id")
+    print(f'  gh api repos/flairNLP/fundus/pulls/{pr}/reviews -X POST --input "{review_file}"')
+    print("then close it out - removes every publisher's cache for this commit:")
+    print(f'  python "{SCRIPT}" done')
+    return 0
+
+
+# --- done ---
+
+
+def cmd_done(args: argparse.Namespace) -> int:
+    """Tear down this commit's review cache once the verdict is posted."""
+    commit, removed = commit_id(), remove_commit_cache()
+    if not removed:
+        print(f"nothing to remove for commit {commit}.")
+        return 0
+    print(f"removed the review cache for commit {commit}: {', '.join(removed)}")
     return 0
 
 
@@ -631,12 +673,12 @@ def main() -> int:
     def add(name: str, help_text: str) -> argparse.ArgumentParser:
         sub = subparsers.add_parser(name, help=help_text)
         sub.add_argument("publisher", help="publisher spec, e.g. 'ca.NationalPost'")
-        sub.add_argument(
-            "--cache-dir", default=None, help=f"override the cache dir (default: {default_cache_dir('<spec>')})"
-        )
         return sub
 
     crawl = add("crawl", "crawl a candidate pool, scan all of it, then Tier-1 read + cache a subset")
+    # Metadata, not identity — the commit owns the cache path (`_store.commit_id`). Recorded here
+    # so `status` and `payload` can name the PR without being told again.
+    crawl.add_argument("--pr", default=None, help="the PR under review, e.g. 970 - recorded in the state")
     crawl.add_argument("--pool", type=int, default=100, help="candidate articles to crawl and scan")
     crawl.add_argument("--review", type=int, default=REVIEW_ARTICLES, help="articles to cache and read from that pool")
     crawl.add_argument(
@@ -663,6 +705,10 @@ def main() -> int:
 
     payload = add("payload", "emit findings.json - refuses while anything is pending")
     payload.set_defaults(func=cmd_payload)
+
+    # Commit-scoped, so it needs nothing: the key is derived, not passed.
+    done = subparsers.add_parser("done", help="remove this commit's review cache once the verdict is posted")
+    done.set_defaults(func=cmd_done)
 
     args = parser.parse_args()
     result: int = args.func(args)

--- a/tests/test_review_skill.py
+++ b/tests/test_review_skill.py
@@ -7,6 +7,7 @@ above all, ways it could report a silent false "clean".
 import json
 import os
 import shutil
+import subprocess
 import sys
 import time
 from datetime import datetime
@@ -355,7 +356,7 @@ class TestStore:
             lambda *a, **k: SimpleNamespace(returncode=0, stdout="  \n"),  # git answered nothing
         ):
             _store.commit_id.cache_clear()
-            monkeypatch.setattr(_store.subprocess, "run", run)
+            monkeypatch.setattr(subprocess, "run", run)
             assert _store.commit_id() == "detached"
         monkeypatch.undo()
         _store.commit_id.cache_clear()
@@ -420,7 +421,8 @@ class TestStore:
         assert "chrome131" in review._impersonation_line("chrome131")
         assert "none declared" in review._impersonation_line(None)
         # `status` reads it off a state dict, so a cache predating the field must not crash.
-        assert review._impersonation_line({}.get("impersonate"))
+        crawl: Dict[str, Any] = {}
+        assert review._impersonation_line(crawl.get("impersonate"))
 
     def test_missing_attributes_matches_the_default_draw(self):
         # `Requires` is fundus' own filter, so a summary-only body counts as missing here exactly

--- a/tests/test_review_skill.py
+++ b/tests/test_review_skill.py
@@ -5,8 +5,10 @@ above all, ways it could report a silent false "clean".
 """
 
 import json
+import os
 import shutil
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -337,6 +339,89 @@ class TestStore:
         _store.prepare_cache_dir(cache_root / "fresh")  # nonexistent is simply created
         assert (cache_root / "fresh").is_dir()
 
+    def test_commit_id_is_derived_from_the_imported_fundus_and_stays_inside_the_cache_root(self) -> None:
+        # Derived, not passed: every agent computes the same key with no flag and no env var.
+        # It must also never escape the cache root, whatever git hands back.
+        assert _store.commit_id() and _store.commit_id().isalnum()
+        assert _store.commit_cache_dir().parent == _store.cache_root()
+        assert _store.commit_cache_dir().name == _store.commit_id()
+
+    def test_commit_id_falls_back_when_git_cannot_answer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A tarball install, a missing git binary: still usable, still inside the cache root.
+        # `commit_id` is cached, so each case needs a cold cache - and the real value restored after.
+        for run in (
+            lambda *a, **k: (_ for _ in ()).throw(OSError()),
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout=""),
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="  \n"),  # git answered nothing
+        ):
+            _store.commit_id.cache_clear()
+            monkeypatch.setattr(_store.subprocess, "run", run)
+            assert _store.commit_id() == "detached"
+        monkeypatch.undo()
+        _store.commit_id.cache_clear()
+
+    def test_remove_commit_cache_takes_every_publisher_but_refuses_foreign_entries(
+        self, cache_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        commit = cache_root / "d732ca85"
+        for spec in ("ca.NationalPost", "ca.TorontoStar"):
+            (commit / spec).mkdir(parents=True)
+            (commit / spec / _store.STATE_FILE).write_text("{}", encoding="utf-8")
+        monkeypatch.setattr(_store, "commit_cache_dir", lambda: commit)
+
+        # A crawl killed before its first write leaves an empty dir. It must not wedge teardown,
+        # and since `rmtree` takes it too it belongs in what the caller is told was removed.
+        (commit / "ca.Empty").mkdir()
+        assert _store.remove_commit_cache() == ["ca.Empty", "ca.NationalPost", "ca.TorontoStar"]
+        assert not commit.exists()
+        assert _store.remove_commit_cache() == []  # already gone is a no-op, not an error
+
+        # Anything that is *not* a review cache stops the teardown entirely.
+        (commit / "notes").mkdir(parents=True)
+        (commit / "notes" / "important.md").write_text("hand-written", encoding="utf-8")
+        with pytest.raises(SystemExit):
+            _store.remove_commit_cache()
+        assert (commit / "notes" / "important.md").exists()
+
+    def test_prune_stale_caches_skips_fresh_and_foreign_dirs(
+        self, cache_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_store, "cache_root", lambda: cache_root)
+        monkeypatch.setattr(_store, "commit_cache_dir", lambda: cache_root / "mine")
+
+        def make(name: str, age_days: float) -> Path:
+            path = cache_root / name / "ca.X"
+            path.mkdir(parents=True)
+            (path / _store.STATE_FILE).write_text("{}", encoding="utf-8")
+            stale = time.time() - age_days * 86400
+            os.utime(cache_root / name, (stale, stale))
+            return cache_root / name
+
+        make("mine", 30)  # this commit's own cache is never pruned out from under it
+        make("old", 30)
+        make("recent", 1)
+        foreign = cache_root / "foreign" / "notes"
+        foreign.mkdir(parents=True)
+        (foreign / "keep.md").write_text("x", encoding="utf-8")
+        os.utime(cache_root / "foreign", (time.time() - 30 * 86400,) * 2)
+
+        assert _store.prune_stale_caches(max_age_days=7) == ["old"]
+        assert (cache_root / "mine").exists() and (cache_root / "recent").exists()
+        assert (foreign / "keep.md").exists()
+
+    def test_new_state_records_the_declared_impersonation_profile(self) -> None:
+        # The profile decides the TLS fingerprint the draw came back through, so the review's
+        # claims are claims about it - it has to survive into the state, not just the crawl.
+        declared = _store.new_state("mx.Test", "970", 100, "chrome")
+        assert declared["crawl"]["impersonate"] == "chrome"
+        assert _store.new_state("ca.Test", None, 100, None)["crawl"]["impersonate"] is None
+
+    def test_impersonation_line_names_the_profile_and_survives_an_old_cache(self) -> None:
+        assert "chrome131" in review._impersonation_line("chrome131")
+        assert "none declared" in review._impersonation_line(None)
+        # `status` reads it off a state dict, so a cache predating the field must not crash.
+        assert review._impersonation_line({}.get("impersonate"))
+
     def test_missing_attributes_matches_the_default_draw(self):
         # `Requires` is fundus' own filter, so a summary-only body counts as missing here exactly
         # as it does in the default crawl - the review must not invent its own truthiness.
@@ -381,6 +466,40 @@ class TestStore:
         assert any("did not complete" in gap for gap in _store.payload_gaps(state))
 
 
+class TestCommands:
+    """The two contracts a caller acts on: `status`' exit code, and what `done` says it removed."""
+
+    def test_status_exits_nonzero_until_the_gate_is_open(
+        self, cache_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SKILL.md and PLAYBOOK §2 both state "no verdict before status reports READY"; the exit
+        # code is the machine-checkable half of that, so it needs to actually track the gate.
+        cache = cache_root / "cache"
+        cache.mkdir()
+        monkeypatch.setattr(review, "default_cache_dir", lambda spec: cache)
+        args = SimpleNamespace(publisher="xx.Test")
+
+        ready = TestPayloadSkeleton._ready_state()
+        pending = dict(ready, adjudications={})
+        _store.write_state(cache, pending)
+        assert review.cmd_status(cast(Any, args)) == 1  # a candidate is un-adjudicated
+
+        _store.write_state(cache, ready)
+        assert review.cmd_status(cast(Any, args)) == 0
+
+    def test_done_reports_everything_it_removed(self, cache_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # `rmtree` takes the whole commit dir, so a publisher dir left empty by an interrupted
+        # crawl is removed too - saying "nothing to remove" there would be a lie about a delete.
+        commit = cache_root / "abc1234"
+        (commit / "ca.Interrupted").mkdir(parents=True)  # crawl killed before its first write
+        monkeypatch.setattr(_store, "commit_cache_dir", lambda: commit)
+        monkeypatch.setattr(review, "commit_id", lambda: "abc1234")
+
+        assert review.cmd_done(cast(Any, SimpleNamespace())) == 0
+        assert not commit.exists()
+        assert review.cmd_done(cast(Any, SimpleNamespace())) == 0  # gone already is still fine
+
+
 class TestPayloadSkeleton:
     """`payload` must emit review.json as a fillable skeleton — and never clobber a filled one."""
 
@@ -388,6 +507,7 @@ class TestPayloadSkeleton:
     def _ready_state() -> Dict[str, Any]:
         return {
             "publisher": "xx.Test",
+            "pr": "970",
             "crawl": {"pool": 50, "started": 1.0, "finished": 2.0, "completed": True},
             "articles": [{"index": 1, "url": "https://x.test/a", "html_file": "01.html"}],
             "scan": {"pool": 50, "flagged": 4, "reviewed": 1, "reviewed_flagged": 1, "medoid_flagged": False},
@@ -409,7 +529,8 @@ class TestPayloadSkeleton:
         _store.write_state(cache, self._ready_state())
         monkeypatch.setattr(review, "resolve_publisher", lambda spec: SimpleNamespace(parser=None))
         monkeypatch.setattr(review, "_parser_source_path", lambda proxy: "src/fundus/publishers/xx/test.py")
-        args = SimpleNamespace(publisher="xx.Test", cache_dir=str(cache))
+        monkeypatch.setattr(review, "default_cache_dir", lambda spec: cache)
+        args = SimpleNamespace(publisher="xx.Test", pr=None)
 
         assert review.cmd_payload(cast(Any, args)) == 0
         skeleton = json.loads((cache / "review.json").read_text(encoding="utf-8"))
@@ -419,6 +540,7 @@ class TestPayloadSkeleton:
         assert comment["path"] == "src/fundus/publishers/xx/test.py" and comment["side"] == "RIGHT"
         assert "match results list dropped" in comment["body"] and "https://x.test/a" in comment["body"]
         assert not isinstance(comment["line"], int)  # an unfilled stub must fail the POST, not post
+        assert (cache / "findings.json").is_file()
 
         # A second run must keep the agent's edits rather than regenerate over them.
         (cache / "review.json").write_text("edited by the agent", encoding="utf-8")

--- a/tests/test_skill_installer.py
+++ b/tests/test_skill_installer.py
@@ -1,0 +1,212 @@
+"""Tests for the skill installer's drift detection (skills/installer/core.py).
+
+`core` is stdlib-only by design, so these need no textual and no network. They build a synthetic
+skill (no `requirements.txt`, so `install` never shells out to pip) and drive the real install.
+
+What they pin is the distinction the manifest exists for: a version string cannot tell "the repo
+moved on" from "someone edited the installed copy", because whoever edits a copy in place does not
+bump a version. Those two have opposite fixes, so conflating them is the failure worth a test.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SKILLS = Path(__file__).resolve().parents[1] / "skills"
+sys.path.insert(0, str(_SKILLS))
+
+from installer.core import (  # noqa: E402
+    MANIFEST_FILE,
+    MANIFEST_FORMAT,
+    Agent,
+    InstallStatus,
+    Skill,
+    fingerprint,
+)
+from installer.tui import _status, _version_cell  # noqa: E402
+
+
+def _skill(root: Path, version: str = "1.0.0") -> Skill:
+    source = root / "src" / "my-skill"
+    (source / "scripts").mkdir(parents=True, exist_ok=True)
+    (source / "SKILL.md").write_text(
+        f"---\nname: my-skill\nversion: {version}\ndescription: A test skill.\n---\n\ndo the thing\n",
+        encoding="utf-8",
+    )
+    (source / "scripts" / "run.py").write_text("print('hi')\n", encoding="utf-8")
+    return Skill("my-skill", source)
+
+
+class TestFingerprint:
+    def test_reflects_content_and_names_but_ignores_build_artefacts(self, tmp_path: Path) -> None:
+        skill = _skill(tmp_path)
+        baseline = fingerprint(skill.source)
+
+        # __pycache__ and .pyc are what a *copied* skill accumulates simply by being run; counting
+        # them would report drift on every installed skill the moment the agent used it.
+        (skill.source / "scripts" / "__pycache__").mkdir()
+        (skill.source / "scripts" / "__pycache__" / "run.cpython-38.pyc").write_bytes(b"\x00\x01")
+        assert fingerprint(skill.source) == baseline
+
+        (skill.source / "scripts" / "run.py").write_text("print('bye')\n", encoding="utf-8")
+        assert fingerprint(skill.source) != baseline
+
+    @pytest.mark.skipif(os.name == "nt", reason="`:` is not a legal filename character on Windows")
+    def test_name_and_content_cannot_be_confused_for_one_another(self, tmp_path: Path) -> None:
+        # Why *both* halves carry a length prefix: `:` is the field separator and is a legal
+        # filename character on POSIX, so hashing "<name>:<len>:<bytes>" would let a colon in a
+        # name reproduce another folder's byte stream. Unconstructible on Windows, hence the skip.
+        def folder(case: str, name: str, content: str) -> str:
+            root = tmp_path / case
+            root.mkdir()
+            (root / name).write_text(content, encoding="utf-8")
+            return fingerprint(root)
+
+        # Without the name prefix both stream as "a:5:b:1:c" — verified; with it they diverge.
+        assert folder("one", "a", "b:1:c") != folder("two", "a:5:b", "c")
+
+    def test_renaming_a_file_changes_the_digest(self, tmp_path: Path) -> None:
+        skill = _skill(tmp_path)
+        baseline = fingerprint(skill.source)
+        (skill.source / "scripts" / "run.py").rename(skill.source / "scripts" / "main.py")
+        assert fingerprint(skill.source) != baseline
+
+
+class TestInstallStatus:
+    def test_tracks_a_fresh_install_then_both_directions_of_drift(self, tmp_path: Path) -> None:
+        skill = _skill(tmp_path)
+        agent = Agent("test", tmp_path / "agent" / "skills")
+
+        absent = agent.status(skill)
+        assert not absent.installed and absent.source_version == "1.0.0"
+
+        assert agent.install(skill).ok
+        dest = agent.destination(skill)
+        assert (dest / MANIFEST_FILE).is_file()
+        fresh = agent.status(skill)
+        assert fresh.in_sync and fresh.tracked
+        assert fresh.installed_version == "1.0.0" and fresh.source_version == "1.0.0"
+
+        # The agent ran the installed skill: cache files must not read as an edit.
+        (dest / "scripts" / "__pycache__").mkdir()
+        (dest / "scripts" / "__pycache__" / "run.cpython-38.pyc").write_bytes(b"\x00\x01")
+        assert agent.status(skill).in_sync
+
+        # Repo moves on -> reinstall to update. Not "edited locally".
+        (skill.source / "SKILL.md").write_text(
+            "---\nname: my-skill\nversion: 1.1.0\ndescription: A test skill.\n---\n\nnew steps\n",
+            encoding="utf-8",
+        )
+        outdated = agent.status(skill)
+        assert outdated.source_changed and not outdated.local_changed
+        assert outdated.installed_version == "1.0.0" and outdated.source_version == "1.1.0"
+
+        # Someone edits the installed copy too: now both sides moved, and the local edit is the
+        # one that matters — reinstalling would silently discard it.
+        (dest / "scripts" / "run.py").write_text("print('patched in place')\n", encoding="utf-8")
+        diverged = agent.status(skill)
+        assert diverged.source_changed and diverged.local_changed
+
+        # Reinstalling settles both and rewrites the manifest at the new version.
+        assert agent.install(skill).ok
+        assert agent.status(skill).in_sync
+        assert agent.status(skill).installed_version == "1.1.0"
+
+    def test_local_edit_alone_is_not_reported_as_the_repo_moving_on(self, tmp_path: Path) -> None:
+        skill = _skill(tmp_path)
+        agent = Agent("test", tmp_path / "agent" / "skills")
+        assert agent.install(skill).ok
+
+        (agent.destination(skill) / "scripts" / "run.py").write_text("print('local')\n", encoding="utf-8")
+        status = agent.status(skill)
+        assert status.local_changed and not status.source_changed
+
+    def test_a_copy_installed_before_manifests_reads_as_untracked(self, tmp_path: Path) -> None:
+        # The real case this shipped into: copies already under .claude/ have no manifest, so the
+        # difference is visible but cannot be attributed to either side. Say so, don't guess.
+        skill = _skill(tmp_path)
+        agent = Agent("test", tmp_path / "agent" / "skills")
+        assert agent.install(skill).ok
+        (agent.destination(skill) / MANIFEST_FILE).unlink()
+
+        assert agent.status(skill).tracked is False
+        assert agent.status(skill).in_sync  # identical folders still read as in sync
+
+        (agent.destination(skill) / "scripts" / "run.py").write_text("print('drifted')\n", encoding="utf-8")
+        untracked = agent.status(skill)
+        assert not untracked.tracked and not untracked.in_sync
+        assert untracked.source_changed and untracked.local_changed  # differs, direction unknown
+
+    def test_a_manifest_without_a_fingerprint_is_untracked_not_edited_in_place(self, tmp_path: Path) -> None:
+        # A truncated or foreign-schema manifest knows nothing; reporting it as a local edit would
+        # tell the user to rescue work that does not exist.
+        skill = _skill(tmp_path)
+        agent = Agent("test", tmp_path / "agent" / "skills")
+        assert agent.install(skill).ok
+        (agent.destination(skill) / MANIFEST_FILE).write_text('{"skill": "my-skill"}', encoding="utf-8")
+
+        status = agent.status(skill)
+        assert not status.tracked and status.in_sync  # folders still match, so: no drift claimed
+
+    def test_a_manifest_from_another_fingerprint_algorithm_is_untracked_not_edited_in_place(
+        self, tmp_path: Path
+    ) -> None:
+        # The upgrade case: `fingerprint` changes, so every existing manifest's digest no longer
+        # matches a copy nobody touched. Without the format check that reads as ≠ - "rescue your
+        # local edits" for edits that never happened. Caught for real on this repo's own install.
+        skill = _skill(tmp_path)
+        agent = Agent("test", tmp_path / "agent" / "skills")
+        assert agent.install(skill).ok
+        manifest_path = agent.destination(skill) / MANIFEST_FILE
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["format"] == MANIFEST_FORMAT  # a fresh install is always current
+
+        manifest["format"] = MANIFEST_FORMAT + 1
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        status = agent.status(skill)
+        assert not status.tracked and status.in_sync  # folders match, so claim no drift at all
+
+    def test_a_corrupt_manifest_degrades_to_untracked_rather_than_crashing(self, tmp_path: Path) -> None:
+        skill = _skill(tmp_path)
+        agent = Agent("test", tmp_path / "agent" / "skills")
+        assert agent.install(skill).ok
+        (agent.destination(skill) / MANIFEST_FILE).write_text("{not json", encoding="utf-8")
+
+        assert agent.status(skill).tracked is False
+
+    def test_uninstall_takes_the_manifest_with_it(self, tmp_path: Path) -> None:
+        skill = _skill(tmp_path)
+        agent = Agent("test", tmp_path / "agent" / "skills")
+        assert agent.install(skill).ok
+        agent.uninstall(skill)
+
+        assert not agent.destination(skill).exists()
+        assert not agent.status(skill).installed
+
+
+class TestGlyphs:
+    """`_status` is where "local edits outrank a stale repo" is decided — swapping those two
+    branches turns "your work is about to be destroyed" into "just reinstall"."""
+
+    @staticmethod
+    def _status_of(installed: bool, tracked: bool, source: bool, local: bool) -> str:
+        return str(_status(InstallStatus(installed, tracked, source, local, "1.0.0", "1.1.0")))
+
+    def test_every_state_maps_to_its_documented_glyph(self) -> None:
+        assert self._status_of(False, False, False, False) == "·"
+        assert self._status_of(True, True, False, False) == "✓"
+        assert self._status_of(True, True, True, False) == "↑"
+        assert self._status_of(True, True, False, True) == "≠"
+        assert self._status_of(True, True, True, True) == "≠"  # local edits outrank a stale repo
+        assert self._status_of(True, False, False, False) == "✓"
+        assert self._status_of(True, False, True, True) == "?"  # differs, direction unknown
+
+    def test_version_cell_shows_the_move_only_when_there_is_one(self) -> None:
+        same = InstallStatus(True, True, False, False, "1.0.0", "1.0.0")
+        moved = InstallStatus(True, True, True, False, "1.0.0", "1.1.0")
+        assert str(_version_cell(same)) == "1.0.0"
+        assert str(_version_cell(moved)) == "1.0.0 → 1.1.0"
+        assert str(_version_cell(InstallStatus(False, False, False, False, "", ""))) == "—"

--- a/tests/test_skill_installer.py
+++ b/tests/test_skill_installer.py
@@ -63,7 +63,9 @@ class TestFingerprint:
             root = tmp_path / case
             root.mkdir()
             (root / name).write_text(content, encoding="utf-8")
-            return fingerprint(root)
+            # `str(...)`: checking tests/ on its own resolves `fingerprint` through the sys.path
+            # insert above, so its return type is Any there and `warn_return_any` fires.
+            return str(fingerprint(root))
 
         # Without the name prefix both stream as "a:5:b:1:c" — verified; with it they diverge.
         assert folder("one", "a", "b:1:c") != folder("two", "a:5:b", "c")


### PR DESCRIPTION
## 1. Review caches are scoped to the commit under review

Caches were keyed on the publisher alone (`<tmp>/fundus-review/<cc>.<Class>`) and never deleted. Only `crawl` wipes, so a `sweep`/`status`/`payload` run before it replayed the *previous* review's articles and adjudications — silently, and `payload_gaps` couldn't see it. 47 such directories were on my machine, one a finished review from a month earlier that `payload` would still have emitted findings from.

They are now keyed on the commit:

```
<tmp>/fundus-review/<short-sha>/<cc>.<Class>/
```

The sha comes from `git rev-parse --short HEAD` against the repo `fundus` is imported from — derived, not passed, so no flag to get wrong and the same value under any agent. Two properties fall out for free: a different commit can't inherit these articles, and a mid-review push retires the cache rather than letting adjudications be replayed against superseded parser code.

- **`done`** (new) tears the commit's caches down; PLAYBOOK §6 runs it after the POST.
- **`crawl`** prunes caches older than 7 days.
- **`--cache-dir` is gone.** It bypassed the scoping on every path that mattered.
- **`--pr`** stays on `crawl` as metadata: recorded in `state.json` so `status` and `payload` can name the PR and fill the `gh` commands. Not part of any path.
- PLAYBOOK §1 now says to `gh pr checkout` **before** crawling. Wrong order used to silently review `master`; now the checkout moves `HEAD` and the driver forces a re-crawl.

## 2. The review crawl uses browser impersonation

`cmd_crawl` now passes `Crawler(publisher, impersonate=True)`.

A declared `impersonate="chrome"` only applies when the *caller* opts in this way (`scraping/html.py:125`); publishers declaring none are unaffected. Without it, every publisher behind a TLS-fingerprint anti-bot layer drew zero articles and the review reported "sources or parser likely broken" for a publisher that works. Verified against `mx.MexicoNewsDaily` (`chrome131`): articles with the flag, nothing without.

The profile is recorded in the state and printed by `crawl` and `status`, so a review's body claims are attributable to a specific fingerprint. §1 gains a bullet on both directions a declaration can be wrong — present but unjustified, absent but needed — and §2 a by-hand check for the empty draw, including the `robots.txt` latch (a 403 sticks, so it needs a fresh process).

## 3. Installed skills are tracked for drift

`skills/` is the source and `.claude/skills/` an installed copy, but nothing compared them — the installed `review-publisher` had a fix in `_sweep.py` that existed nowhere else and had drifted unnoticed for weeks.

Installs now write an `.install-manifest.json` with the skill's `version` and a content fingerprint. `Agent.status()` re-fingerprints both sides against it, separating the two kinds of drift — they have opposite fixes:

| | Meaning | What to do |
|---|---|---|
| `·` | not installed | install |
| `✓` | in sync | nothing |
| `↑` | the repo moved on | re-install |
| `≠` | the **installed copy** was edited in place | port it back to `skills/` first — a re-install destroys it |
| `?` | no usable manifest, and the two differ | compare by hand |

A version alone can't catch `≠` — nobody editing an installed copy bumps a label; the fingerprint does that work. `version:` stays optional: unversioned skills show `—` and still get full drift detection.

The manifest carries a `format`, so changing the fingerprint algorithm degrades old manifests to `?` rather than accusing an untouched copy of local edits. Not hypothetical — it fired on this repo's own install mid-branch.

`review-publisher` is tagged `version: 2.0.0` — major: `--cache-dir` removed, cache location moved, `state.json` schema changed.

## Review notes

Two agent review passes ran over this branch. Everything raised is fixed except these, kept knowingly:

- `source` and `installed_at` in the manifest have no reader — human breadcrumbs, labelled as such.
- `fingerprint` covers names and bytes, not mode bits or empty directories: a `chmod -x` on an installed script still reads `✓`. Documented in the docstring.
- Two agents reviewing the same commit concurrently share a cache dir, and the second `crawl` would wipe the first's adjudications. Rare enough to accept; the alternative re-introduces per-session keys and loses cross-session resume.
