### PR TITLE
fix(parser): filter image credit keywords per author in `image_author_parsing`

### DIFF
--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -633,7 +633,11 @@ def image_author_parsing(authors: Union[str, List[str]]) -> List[str]:
         "quellen?",
         "bild(rechte)?",
         "sources?",
-        r"(((f|ph)oto(graph)?s?|image|illustrations?|cartoons?|pictures?)\s*)+(by|:|courtesy)",
+        "collagen?",
+        "montagen?",
+        "screenshots?",
+        "grafiken?",
+        "wasserzeichen",
         "©",
         "– alle rechte vorbehalten",
         "copyright",
@@ -641,12 +645,18 @@ def image_author_parsing(authors: Union[str, List[str]]) -> List[str]:
         "courtesy of",
         "＝",
     ]
-    author_filter = re.compile(r"(?is)^(" + r"|".join(credit_keywords) + r"):?\s*")
+    media_keywords = r"(((f|ph)oto(graph)?s?|image|illustrations?|cartoons?|pictures?)\s*)+"
+    credit_prefix = r"(?is)^(?:" + r"|".join(credit_keywords) + r"|" + media_keywords + r"(by|:|courtesy))"
+    author_filter = re.compile(credit_prefix + r":?\s*")
+    # within a credit line a keyword only introduces another author if it is followed by a colon or forms the
+    # entire author, so that credits reading like a sentence, e.g. "Bild erstellt mit KI", keep their wording
+    nested_credit_prefix = r"(?is)^(?:" + r"|".join(credit_keywords) + r"|" + media_keywords + r")"
+    nested_author_filter = re.compile(nested_credit_prefix + r"\s*(?::\s*|$)")
 
-    def clean(author: str):
+    def clean(author: str, credit_filter: Pattern[str] = author_filter) -> str:
         author = re.sub(r"^\((.*)\)$", r"\1", author).strip()
         # filtering credit keywords
-        author = re.sub(author_filter, "", author, count=1)
+        author = re.sub(credit_filter, "", author, count=1)
         # filtering bloat follwing the author
         author = re.sub(r"(?i)/?copyright.*", "", author)
         return author.strip()
@@ -655,7 +665,10 @@ def image_author_parsing(authors: Union[str, List[str]]) -> List[str]:
         authors = [clean(author) for author in authors]
     else:
         authors = clean(authors)
-    return generic_author_parsing(authors)
+
+    # a caption can credit several sources at once, e.g. "Collage: Ivo Mayr / CORRECTIV, Fotos: picture alliance",
+    # so credits are filtered again after being split into single authors
+    return [cleaned for author in generic_author_parsing(authors) if (cleaned := clean(author, nested_author_filter))]
 
 
 # https://regex101.com/r/MplUXL/2

--- a/tests/resources/parser/test_data/at/DerStandard.json
+++ b/tests/resources/parser/test_data/at/DerStandard.json
@@ -147,7 +147,7 @@
         "description": null,
         "caption": "Der Ex-Rapper Brado (links) hörte aus religiösen Gründen mit der Musik auf. Jetzt wirbt er für radikale Islamisten. Kopf von \"Muslim Interaktiv\" ist Raheem Boateng (rechts). In der Mitte: ein Beitrag der \"Generation Islam\".",
         "authors": [
-          "Screenshots Instagram/TikTok"
+          "Instagram/TikTok"
         ],
         "position": 184
       }

--- a/tests/resources/parser/test_data/at/SalzburgerNachrichten.json
+++ b/tests/resources/parser/test_data/at/SalzburgerNachrichten.json
@@ -239,7 +239,7 @@
         "description": "Der Bürgermeister von Crans Montana räumte öffentlich Versäumnisse ein",
         "caption": "Der Bürgermeister von Crans Montana räumte öffentlich Versäumnisse ein",
         "authors": [
-          "Bild: SN/APA/KEYSTONE/CYRIL ZINGARO"
+          "SN/APA/KEYSTONE/CYRIL ZINGARO"
         ],
         "position": 573
       },

--- a/tests/resources/parser/test_data/de/FrankfurterRundschau.json
+++ b/tests/resources/parser/test_data/de/FrankfurterRundschau.json
@@ -97,9 +97,7 @@
         "is_cover": false,
         "description": "Mann mit schlimmem Heuschnupfen.",
         "caption": "Ambrosia kommt eigentlich aus Nordamerika und ist für Europäer gefährlich - besonders bei Allergikern.",
-        "authors": [
-          "Montage"
-        ],
+        "authors": [],
         "position": 260
       },
       {


### PR DESCRIPTION
Stacked on #968, targeting `fix-correctiv`. Needs its own review pass, since it touches shared parser code and three unrelated fixtures.

## Problem

`image_author_parsing` filters credit keywords from the whole credit string once, **before** `generic_author_parsing` splits it into single authors. Captions that credit several sources at once therefore keep the keyword on every author but the first:

```
"Collage: Ivo Mayr / CORRECTIV, Fotos: picture alliance"
  -> ["Ivo Mayr / CORRECTIV", "Fotos: picture alliance"]
```

CORRECTIV uses this caption shape on most of its cover images, but the helper is publisher independent and so is the defect.

## Change

- Filter credit keywords again after the credits have been split into single authors.
- Within a credit line a keyword only counts when it is followed by a colon or forms the entire author. Without that restriction credits that read like a sentence lose a word, e.g. Heise's `"Bild erstellt mit KI in Bing Designer durch heise online / dmk"` or Bild's `"BILD 15.05.2023"`, where `BILD` is the credit itself.
- Add `collage`, `montage`, `screenshot`, `grafik` and `wasserzeichen` to the keyword list. The list already carried the Russian and Ukrainian words for collage, but not the German or English ones.

Result for the example above:

```
"Collage: Ivo Mayr / CORRECTIV, Fotos: picture alliance"
  -> ["Ivo Mayr / CORRECTIV", "picture alliance"]
```

## Effect on existing test data

Three fixtures change, each because a keyword is now recognised. All three look like improvements to me, but they are the part worth a close look:

| Publisher | before | after |
| --- | --- | --- |
| Der Standard | `["Screenshots Instagram/TikTok"]` | `["Instagram/TikTok"]` |
| Salzburger Nachrichten | `["Bild: SN/APA/KEYSTONE/CYRIL ZINGARO"]` | `["SN/APA/KEYSTONE/CYRIL ZINGARO"]` |
| Frankfurter Rundschau | `["Montage"]` | `[]` |

## Verification

- Full test suite passes, 863 tests.
- Checked against 136 captions collected from CORRECTIV fixtures, the articles cited in the #968 review and 70 further live articles. No author keeps a credit keyword any more, and no caption text is lost.
- Verified that Heise, Bild and Aftonbladet, whose credits contain a keyword without a colon, are unchanged.
