### PR TITLE
fix(publisher): replace `TaipeiTimes` sources with RSS feed

### DIFF
--- a/src/fundus/publishers/tw/__init__.py
+++ b/src/fundus/publishers/tw/__init__.py
@@ -1,6 +1,6 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.publishers.tw.taipei_times import TaipeiTimesParser
-from fundus.scraping.url import NewsMap, Sitemap, RSSFeed
+from fundus.scraping.url import RSSFeed
 
 
 class TW(metaclass=PublisherGroup):

--- a/src/fundus/publishers/tw/__init__.py
+++ b/src/fundus/publishers/tw/__init__.py
@@ -1,6 +1,6 @@
 from fundus.publishers.base_objects import Publisher, PublisherGroup
 from fundus.publishers.tw.taipei_times import TaipeiTimesParser
-from fundus.scraping.url import NewsMap, Sitemap
+from fundus.scraping.url import NewsMap, Sitemap, RSSFeed
 
 
 class TW(metaclass=PublisherGroup):
@@ -11,7 +11,6 @@ class TW(metaclass=PublisherGroup):
         domain="https://www.taipeitimes.com/",
         parser=TaipeiTimesParser,
         sources=[
-            Sitemap("https://www.taipeitimes.com/sitemapIndex.xml", languages={"en"}),
-            NewsMap("https://www.taipeitimes.com/sitemap/sitemap.xml", languages={"en"}),
+            RSSFeed("https://www.taipeitimes.com/xml/index.rss", languages={"en"}),
         ],
     )


### PR DESCRIPTION
The Newsmap and SiteMap objects are no longer accessible