### PR TITLE
fix(parser): strip only url-terminating commas when parsing srcset

### DIFF
--- a/src/fundus/parser/utility.py
+++ b/src/fundus/parser/utility.py
@@ -659,7 +659,10 @@ def image_author_parsing(authors: Union[str, List[str]]) -> List[str]:
 
 
 # https://regex101.com/r/MplUXL/2
-_srcset_pattern = re.compile(r"(?P<url>\S+)\s*(?P<descriptor>[0-9.]+[wx])?(,?\s*)")
+# candidates are separated by a comma that may sit flush against the preceding url, e.g.
+# 'a.jpg, b.jpg 2x'. only strip commas terminating a url, so that urls carrying commas of
+# their own - CDN transformations like '.../w_300,h_200/img.jpg' - survive intact.
+_srcset_pattern = re.compile(r"(?P<url>\S+?),*(?=\s|$)\s*(?P<descriptor>[0-9.]+[wx])?\s*,?\s*")
 
 
 def parse_srcset(srcset: str) -> Dict[str, str]:

--- a/tests/resources/parser/test_data/au/NineNews.json
+++ b/tests/resources/parser/test_data/au/NineNews.json
@@ -545,7 +545,7 @@
       {
         "versions": [
           {
-            "url": "https://static.ffx.io/images/$zoom_0.1562%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/80d526e3807bcd9a241a378b7911ff10c3698a32,",
+            "url": "https://static.ffx.io/images/$zoom_0.1562%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/80d526e3807bcd9a241a378b7911ff10c3698a32",
             "query_width": null,
             "size": null,
             "type": null
@@ -563,7 +563,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.1562%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/80d526e3807bcd9a241a378b7911ff10c3698a32,",
+            "url": "https://static.ffx.io/images/$zoom_0.1562%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/80d526e3807bcd9a241a378b7911ff10c3698a32",
             "query_width": "min-width:1124",
             "size": null,
             "type": null
@@ -575,7 +575,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.1562%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/80d526e3807bcd9a241a378b7911ff10c3698a32,",
+            "url": "https://static.ffx.io/images/$zoom_0.1562%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/80d526e3807bcd9a241a378b7911ff10c3698a32",
             "query_width": "min-width:768",
             "size": null,
             "type": null
@@ -592,7 +592,7 @@
       {
         "versions": [
           {
-            "url": "https://static.ffx.io/images/$zoom_0.6421%2C$multiply_2%2C$ratio_1.5%2C$width_756%2C$x_70%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/384dcf01c047879b04a345aad6c85391884350a1,",
+            "url": "https://static.ffx.io/images/$zoom_0.6421%2C$multiply_2%2C$ratio_1.5%2C$width_756%2C$x_70%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/384dcf01c047879b04a345aad6c85391884350a1",
             "query_width": null,
             "size": null,
             "type": null
@@ -610,7 +610,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.6421%2C$multiply_2%2C$ratio_1.5%2C$width_756%2C$x_70%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/384dcf01c047879b04a345aad6c85391884350a1,",
+            "url": "https://static.ffx.io/images/$zoom_0.6421%2C$multiply_2%2C$ratio_1.5%2C$width_756%2C$x_70%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/384dcf01c047879b04a345aad6c85391884350a1",
             "query_width": "min-width:1124",
             "size": null,
             "type": null
@@ -622,7 +622,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.6421%2C$multiply_2%2C$ratio_1.5%2C$width_756%2C$x_70%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/384dcf01c047879b04a345aad6c85391884350a1,",
+            "url": "https://static.ffx.io/images/$zoom_0.6421%2C$multiply_2%2C$ratio_1.5%2C$width_756%2C$x_70%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/384dcf01c047879b04a345aad6c85391884350a1",
             "query_width": "min-width:768",
             "size": null,
             "type": null
@@ -639,7 +639,7 @@
       {
         "versions": [
           {
-            "url": "https://static.ffx.io/images/$zoom_0.1638%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_31%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/9f8be2faa63f7949971b73cd8d47a8adf6bb56c9,",
+            "url": "https://static.ffx.io/images/$zoom_0.1638%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_31%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/9f8be2faa63f7949971b73cd8d47a8adf6bb56c9",
             "query_width": null,
             "size": null,
             "type": null
@@ -657,7 +657,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.1638%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_31%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/9f8be2faa63f7949971b73cd8d47a8adf6bb56c9,",
+            "url": "https://static.ffx.io/images/$zoom_0.1638%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_31%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/9f8be2faa63f7949971b73cd8d47a8adf6bb56c9",
             "query_width": "min-width:1124",
             "size": null,
             "type": null
@@ -669,7 +669,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.1638%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_31%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/9f8be2faa63f7949971b73cd8d47a8adf6bb56c9,",
+            "url": "https://static.ffx.io/images/$zoom_0.1638%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_31%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/9f8be2faa63f7949971b73cd8d47a8adf6bb56c9",
             "query_width": "min-width:768",
             "size": null,
             "type": null
@@ -687,7 +687,7 @@
       {
         "versions": [
           {
-            "url": "https://static.ffx.io/images/$zoom_0.149%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/484c2c8d6dc66d8dde5be17bb9daf8f7bc4f344f,",
+            "url": "https://static.ffx.io/images/$zoom_0.149%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_382%2Cq_88%2Cf_auto/484c2c8d6dc66d8dde5be17bb9daf8f7bc4f344f",
             "query_width": null,
             "size": null,
             "type": null
@@ -705,7 +705,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.149%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/484c2c8d6dc66d8dde5be17bb9daf8f7bc4f344f,",
+            "url": "https://static.ffx.io/images/$zoom_0.149%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_620%2Cq_88%2Cf_auto/484c2c8d6dc66d8dde5be17bb9daf8f7bc4f344f",
             "query_width": "min-width:1124",
             "size": null,
             "type": null
@@ -717,7 +717,7 @@
             "type": null
           },
           {
-            "url": "https://static.ffx.io/images/$zoom_0.149%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/484c2c8d6dc66d8dde5be17bb9daf8f7bc4f344f,",
+            "url": "https://static.ffx.io/images/$zoom_0.149%2C$multiply_4%2C$ratio_1.5%2C$width_756%2C$x_0%2C$y_0/t_crop_custom/c_scale%2Cw_696%2Cq_88%2Cf_auto/484c2c8d6dc66d8dde5be17bb9daf8f7bc4f344f",
             "query_width": "min-width:768",
             "size": null,
             "type": null

--- a/tests/resources/parser/test_data/ca/CanadaCom.json
+++ b/tests/resources/parser/test_data/ca/CanadaCom.json
@@ -63,7 +63,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=fa_HIGnR-PCeW3IWM-iOXA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=fa_HIGnR-PCeW3IWM-iOXA",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -81,7 +81,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=bxlOv7DKlNztkYkEm9CyQw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=bxlOv7DKlNztkYkEm9CyQw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -93,13 +93,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=CSOBswfLnd3ypL-YhLTTCw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=CSOBswfLnd3ypL-YhLTTCw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=GnA_9JMgTIx5HMDDdTINdA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=GnA_9JMgTIx5HMDDdTINdA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -111,7 +111,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=301G3rmovdqumtdQEyn1pg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=301G3rmovdqumtdQEyn1pg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -123,7 +123,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=288&h=216&sig=KwK4SbYdQFkgFlAIp0nDHw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL_Summer-Hero_2026-1-1.jpg?quality=90&strip=all&w=288&h=216&sig=KwK4SbYdQFkgFlAIp0nDHw",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -152,7 +152,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=288&type=webp&sig=GmP1XdjhUgxSc6s2oOwpKQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=288&type=webp&sig=GmP1XdjhUgxSc6s2oOwpKQ",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -170,7 +170,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=564&type=jpg&sig=59OvNlFnQ5ialDuWjwnIpw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=564&type=jpg&sig=59OvNlFnQ5ialDuWjwnIpw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -182,13 +182,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=564&type=webp&sig=OiC0MvlmjHWPCOXGBr-ApQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=564&type=webp&sig=OiC0MvlmjHWPCOXGBr-ApQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=472&type=jpg&sig=AuiAAFumOyhEV2-tF4fKDQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=472&type=jpg&sig=AuiAAFumOyhEV2-tF4fKDQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -200,7 +200,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=472&type=webp&sig=MY7t1i8dBqBSmfkyPQ4TcQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=472&type=webp&sig=MY7t1i8dBqBSmfkyPQ4TcQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -212,7 +212,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=288&sig=h_b5eHdWjGGwzFWvl7SJyQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/JPL-LOBBY-2026-17-1-sm.jpg?quality=90&strip=all&w=288&sig=h_b5eHdWjGGwzFWvl7SJyQ",
             "query_width": null,
             "size": {
               "width": 1500,
@@ -241,7 +241,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=288&type=webp&sig=0dTOklrfR2TmJF7gg2Uk0g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=288&type=webp&sig=0dTOklrfR2TmJF7gg2Uk0g",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -259,7 +259,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=564&type=jpg&sig=tIzRPoKRRsP3StzxTR0SXw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=564&type=jpg&sig=tIzRPoKRRsP3StzxTR0SXw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -271,13 +271,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=564&type=webp&sig=cN2YRhFOZzFlIsy9QWYGEA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=564&type=webp&sig=cN2YRhFOZzFlIsy9QWYGEA",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=472&type=jpg&sig=T8j6lAuuprfgViTqPY5S1w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=472&type=jpg&sig=T8j6lAuuprfgViTqPY5S1w",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -289,7 +289,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=472&type=webp&sig=Zhe5rkZXyNae5bsDQR8KEw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=472&type=webp&sig=Zhe5rkZXyNae5bsDQR8KEw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -301,7 +301,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=288&sig=XWtO3-jbhojNPkwbAKCvGA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Patio-sm-1.jpg?quality=90&strip=all&w=288&sig=XWtO3-jbhojNPkwbAKCvGA",
             "query_width": null,
             "size": {
               "width": 1500,
@@ -330,7 +330,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=288&type=webp&sig=vYRNDFwzut3pUbxcMc6L5Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=288&type=webp&sig=vYRNDFwzut3pUbxcMc6L5Q",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -348,7 +348,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=564&type=jpg&sig=blou4pzaAs0knrN2u0RWnw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=564&type=jpg&sig=blou4pzaAs0knrN2u0RWnw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -360,13 +360,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=564&type=webp&sig=JHecnh-BQoSmNIG86nQ1PQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=564&type=webp&sig=JHecnh-BQoSmNIG86nQ1PQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=472&type=jpg&sig=zvRdKH1f552rvQjX8jTHgA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=472&type=jpg&sig=zvRdKH1f552rvQjX8jTHgA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -378,7 +378,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=472&type=webp&sig=qG_Mlq0kgsUH6DSVCBIUnQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=472&type=webp&sig=qG_Mlq0kgsUH6DSVCBIUnQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -390,7 +390,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=288&sig=FpqdXWW76lnd2v37W18_EQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/DSCF3709.jpg?quality=90&strip=all&w=288&sig=FpqdXWW76lnd2v37W18_EQ",
             "query_width": null,
             "size": {
               "width": 2000,
@@ -419,7 +419,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=288&type=webp&sig=BQMzUZNj9XWNn9E4qaLNog,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=288&type=webp&sig=BQMzUZNj9XWNn9E4qaLNog",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -437,7 +437,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=564&type=jpg&sig=pOmmwQvLJ1zD-poxYpMsRQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=564&type=jpg&sig=pOmmwQvLJ1zD-poxYpMsRQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -449,13 +449,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=564&type=webp&sig=QnHY6zETDRSJ8LAexZ4_Ow,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=564&type=webp&sig=QnHY6zETDRSJ8LAexZ4_Ow",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=472&type=jpg&sig=1B6sIagQOj4SeKbQHpkQSQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=472&type=jpg&sig=1B6sIagQOj4SeKbQHpkQSQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -467,7 +467,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=472&type=webp&sig=S5UrXQL5G51EVSj4M8uYmQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=472&type=webp&sig=S5UrXQL5G51EVSj4M8uYmQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -479,7 +479,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=288&sig=Sbaoo-ShBVpWJ0ZK4KGtNg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ocanada/wp-content/uploads/2026/06/Fairmont-Jasper-Park-Lodge-is-now-open-after-undergoing-a-major-restoration-project_photo-credit-Fairmont-Jasper-Park-Lodge-sm.jpg?quality=90&strip=all&w=288&sig=Sbaoo-ShBVpWJ0ZK4KGtNg",
             "query_width": null,
             "size": {
               "width": 1500,

--- a/tests/resources/parser/test_data/ca/FinancialPost.json
+++ b/tests/resources/parser/test_data/ca/FinancialPost.json
@@ -103,7 +103,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=zhTlcbiRE5JaP4YHa5DYxw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=zhTlcbiRE5JaP4YHa5DYxw",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -121,7 +121,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=Cqxo72qHpQg0FVp4tlMVcw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=Cqxo72qHpQg0FVp4tlMVcw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -133,13 +133,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=wgSQAFSAOOk-RPVi93lJ7w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=wgSQAFSAOOk-RPVi93lJ7w",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=BWtcurMeuEblOcdwJU_4bg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=BWtcurMeuEblOcdwJU_4bg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -151,7 +151,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=YAfm4T1vqD-znDKoE9aYbg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=YAfm4T1vqD-znDKoE9aYbg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -163,7 +163,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=288&h=216&sig=a4VeUlSTXHXLaWdXHN8b-Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/financialpost/wp-content/uploads/2026/06/0606-mg-bank-of-canada-2.jpg?quality=90&strip=all&w=288&h=216&sig=a4VeUlSTXHXLaWdXHN8b-Q",
             "query_width": null,
             "size": {
               "width": 1200,

--- a/tests/resources/parser/test_data/ca/NationalPost.json
+++ b/tests/resources/parser/test_data/ca/NationalPost.json
@@ -76,7 +76,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=Zq8w7OQBop96U-IkO4Wr4g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=Zq8w7OQBop96U-IkO4Wr4g",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -94,7 +94,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=alHwy-JaVMJpAkzZfmF-1w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=alHwy-JaVMJpAkzZfmF-1w",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -106,13 +106,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=tjU1vhPSQI8zy3tLPltvAQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=tjU1vhPSQI8zy3tLPltvAQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=xAkT0AqbUK8rRbVXS6kKFw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=xAkT0AqbUK8rRbVXS6kKFw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -124,7 +124,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=4WF1KUMMZAmGP3FtaHxxMg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=4WF1KUMMZAmGP3FtaHxxMg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -136,7 +136,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=288&h=216&sig=Ljg4qX5ZA5CJ_zgkeUwCGg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-1.jpg?quality=90&strip=all&w=288&h=216&sig=Ljg4qX5ZA5CJ_zgkeUwCGg",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -165,7 +165,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=288&type=webp&sig=NnBkH3fs58Dm6P8xBrKJ5g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=288&type=webp&sig=NnBkH3fs58Dm6P8xBrKJ5g",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -183,7 +183,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=564&type=jpg&sig=kWtRmpC43RiTDa1IHPK6BA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=564&type=jpg&sig=kWtRmpC43RiTDa1IHPK6BA",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -195,13 +195,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=564&type=webp&sig=5NYrqJxhwP2DuUNLEqM0qQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=564&type=webp&sig=5NYrqJxhwP2DuUNLEqM0qQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=472&type=jpg&sig=r61-h97I64LEsQQiWLi9Fw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=472&type=jpg&sig=r61-h97I64LEsQQiWLi9Fw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -213,7 +213,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=472&type=webp&sig=yVgL6kzTXG6kHHf7o5azZw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=472&type=webp&sig=yVgL6kzTXG6kHHf7o5azZw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -225,7 +225,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=288&sig=OCI8kk7ttdb6U7lfUnsBbg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2024/08/Kamala-Harris-2.jpg?quality=90&strip=all&w=288&sig=OCI8kk7ttdb6U7lfUnsBbg",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -631,7 +631,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=KzSaTubTyq5FEbZVcFUmBg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=KzSaTubTyq5FEbZVcFUmBg",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -649,7 +649,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=D8f2qRtnXOEEMv066uwoNg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=D8f2qRtnXOEEMv066uwoNg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -661,13 +661,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=G-6G_XUBb0Nvr_YEDiwXnw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=G-6G_XUBb0Nvr_YEDiwXnw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=1rwZyZcFbV0uhqoZRaKlxg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=1rwZyZcFbV0uhqoZRaKlxg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -679,7 +679,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=etTk0I2InT6-v6WJb8kKVw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=etTk0I2InT6-v6WJb8kKVw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -691,7 +691,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=288&h=216&sig=OXjy_cdFhRXFlZkksP4fng,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250354_295413440.jpg?quality=90&strip=all&w=288&h=216&sig=OXjy_cdFhRXFlZkksP4fng",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -721,7 +721,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=288&type=webp&sig=ZyiOpHGSYJbGWbiPAdNMGw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=288&type=webp&sig=ZyiOpHGSYJbGWbiPAdNMGw",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -739,7 +739,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=564&type=jpg&sig=noLhqA5Sx3_7fCdh0IOAbQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=564&type=jpg&sig=noLhqA5Sx3_7fCdh0IOAbQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -751,13 +751,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=564&type=webp&sig=vCdKHa9Ux1kGDwbuAyT9NQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=564&type=webp&sig=vCdKHa9Ux1kGDwbuAyT9NQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=472&type=jpg&sig=Z4hH4_xHo0m_bzwH7wBUOg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=472&type=jpg&sig=Z4hH4_xHo0m_bzwH7wBUOg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -769,7 +769,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=472&type=webp&sig=Y3YyZWpKG9JCNt8-1X-mgw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=472&type=webp&sig=Y3YyZWpKG9JCNt8-1X-mgw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -781,7 +781,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=288&sig=3jUAhppdBcfUZvq8_UVzwg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/embed-map-india-pakistan_295404548.jpg?quality=90&strip=all&w=288&sig=3jUAhppdBcfUZvq8_UVzwg",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -811,7 +811,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=288&type=webp&sig=iuUo0O1W0JJW_WvcUwumGA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=288&type=webp&sig=iuUo0O1W0JJW_WvcUwumGA",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -829,7 +829,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=564&type=jpg&sig=rEATcvnwtR4GWm9FPCL3zg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=564&type=jpg&sig=rEATcvnwtR4GWm9FPCL3zg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -841,13 +841,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=564&type=webp&sig=M8UhuszOJnjvTXMr6cYX2g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=564&type=webp&sig=M8UhuszOJnjvTXMr6cYX2g",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=472&type=jpg&sig=BNBz9u_gG5s7-w4OrPgK8w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=472&type=jpg&sig=BNBz9u_gG5s7-w4OrPgK8w",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -859,7 +859,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=472&type=webp&sig=HoRhq9GSVy6EW6fywHeCaw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=472&type=webp&sig=HoRhq9GSVy6EW6fywHeCaw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -871,7 +871,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=288&sig=7aFImgpYcfi4RGc99AUVEw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213241500_295411236.jpg?quality=90&strip=all&w=288&sig=7aFImgpYcfi4RGc99AUVEw",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -901,7 +901,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=288&type=webp&sig=bfEQkGKBlq870S4huSae8g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=288&type=webp&sig=bfEQkGKBlq870S4huSae8g",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -919,7 +919,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=564&type=jpg&sig=tPbGMFMuVhV5r-glKLX08Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=564&type=jpg&sig=tPbGMFMuVhV5r-glKLX08Q",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -931,13 +931,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=564&type=webp&sig=eKDQkyuLYaNZld_hii-l1Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=564&type=webp&sig=eKDQkyuLYaNZld_hii-l1Q",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=472&type=jpg&sig=7ju-TKXBVjbSr6rUCfJh6g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=472&type=jpg&sig=7ju-TKXBVjbSr6rUCfJh6g",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -949,7 +949,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=472&type=webp&sig=88yTfYlRT-WXRGXPYgoiww,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=472&type=webp&sig=88yTfYlRT-WXRGXPYgoiww",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -961,7 +961,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=288&sig=dYjeEDOPv93m_a07j3Hg_w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213231552_295409708.jpg?quality=90&strip=all&w=288&sig=dYjeEDOPv93m_a07j3Hg_w",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -991,7 +991,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=288&type=webp&sig=tWgmWjxkSVq0NHEb-idVZQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=288&type=webp&sig=tWgmWjxkSVq0NHEb-idVZQ",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1009,7 +1009,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=564&type=jpg&sig=qEhS8Z_Ct_MrduJ4Uk8rsw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=564&type=jpg&sig=qEhS8Z_Ct_MrduJ4Uk8rsw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1021,13 +1021,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=564&type=webp&sig=gOBfHTbXLVoUe_co1kBpdA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=564&type=webp&sig=gOBfHTbXLVoUe_co1kBpdA",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=472&type=jpg&sig=_HhLF04zeGMOHlcGoa3lTA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=472&type=jpg&sig=_HhLF04zeGMOHlcGoa3lTA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1039,7 +1039,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=472&type=webp&sig=5Fhy6ipPbUJkJcdSWr6cDw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=472&type=webp&sig=5Fhy6ipPbUJkJcdSWr6cDw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1051,7 +1051,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=288&sig=qhZMYEkYtmx-ulPOzErUsg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213249426_295413398.jpg?quality=90&strip=all&w=288&sig=qhZMYEkYtmx-ulPOzErUsg",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1081,7 +1081,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=288&type=webp&sig=fGmg-lxd26XswKKfW0w_Lw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=288&type=webp&sig=fGmg-lxd26XswKKfW0w_Lw",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1099,7 +1099,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=564&type=jpg&sig=De6B1ln0UJwKhxd2LWXnqw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=564&type=jpg&sig=De6B1ln0UJwKhxd2LWXnqw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1111,13 +1111,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=564&type=webp&sig=s1-25fs6wpv-bom6onNIjQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=564&type=webp&sig=s1-25fs6wpv-bom6onNIjQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=472&type=jpg&sig=3JhWH-B9tnDFGpLEM3994g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=472&type=jpg&sig=3JhWH-B9tnDFGpLEM3994g",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1129,7 +1129,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=472&type=webp&sig=ZKiSZlW_wqhzZEyJ6kMnLw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=472&type=webp&sig=ZKiSZlW_wqhzZEyJ6kMnLw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1141,7 +1141,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=288&sig=m7UJjjSUDIsI0bXwpJmpSw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213238034_295410150.jpg?quality=90&strip=all&w=288&sig=m7UJjjSUDIsI0bXwpJmpSw",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1171,7 +1171,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=288&type=webp&sig=zbPcc7a583XYOxHTDTCtvA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=288&type=webp&sig=zbPcc7a583XYOxHTDTCtvA",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1189,7 +1189,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=564&type=jpg&sig=AuMnR-Nos_ZmEUWPR9ulTw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=564&type=jpg&sig=AuMnR-Nos_ZmEUWPR9ulTw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1201,13 +1201,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=564&type=webp&sig=jSZSOGr9V3l0dmW89dKwbg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=564&type=webp&sig=jSZSOGr9V3l0dmW89dKwbg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=472&type=jpg&sig=WQy8hcwOShmcYf54acKVdg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=472&type=jpg&sig=WQy8hcwOShmcYf54acKVdg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1219,7 +1219,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=472&type=webp&sig=T9nL6D2IbwRiwipBCI2n2w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=472&type=webp&sig=T9nL6D2IbwRiwipBCI2n2w",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1231,7 +1231,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=288&sig=P5-rqJ4F15AX8AMEXy3scg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250342_295413640.jpg?quality=90&strip=all&w=288&sig=P5-rqJ4F15AX8AMEXy3scg",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1261,7 +1261,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=288&type=webp&sig=sJxJlz-lZb6ycYyvHnrC6Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=288&type=webp&sig=sJxJlz-lZb6ycYyvHnrC6Q",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1279,7 +1279,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=564&type=jpg&sig=UbPe2MwkTEZ9sa0V-gLR9g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=564&type=jpg&sig=UbPe2MwkTEZ9sa0V-gLR9g",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1291,13 +1291,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=564&type=webp&sig=yGoMiyVoQ4a5bas8x_Z4wQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=564&type=webp&sig=yGoMiyVoQ4a5bas8x_Z4wQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=472&type=jpg&sig=gXLDsfbvFt6idhf1denrzA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=472&type=jpg&sig=gXLDsfbvFt6idhf1denrzA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1309,7 +1309,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=472&type=webp&sig=kWmSnOL6Ks2vB1QIfzz3ag,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=472&type=webp&sig=kWmSnOL6Ks2vB1QIfzz3ag",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1321,7 +1321,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=288&sig=Mws9tJ7k5g8-6nD3iiNzmQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213248993_295412982.jpg?quality=90&strip=all&w=288&sig=Mws9tJ7k5g8-6nD3iiNzmQ",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1351,7 +1351,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=288&type=webp&sig=LB6k1GwFFAov2H1Sl8Og3A,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=288&type=webp&sig=LB6k1GwFFAov2H1Sl8Og3A",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1369,7 +1369,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=564&type=jpg&sig=dTGnr1lxY6zTsQ80C77juA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=564&type=jpg&sig=dTGnr1lxY6zTsQ80C77juA",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1381,13 +1381,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=564&type=webp&sig=AQDixxc1Zr-LlMY8a5iAKQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=564&type=webp&sig=AQDixxc1Zr-LlMY8a5iAKQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=472&type=jpg&sig=4VK0rv5h3siIS7fU9QMxTg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=472&type=jpg&sig=4VK0rv5h3siIS7fU9QMxTg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1399,7 +1399,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=472&type=webp&sig=-er_wY4GBS5-HflUADkrxA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=472&type=webp&sig=-er_wY4GBS5-HflUADkrxA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1411,7 +1411,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=288&sig=5pau3olMuTmGlEU8-ykClg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213243843_295411974.jpg?quality=90&strip=all&w=288&sig=5pau3olMuTmGlEU8-ykClg",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1441,7 +1441,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&type=webp&sig=A98wTV8CXbEFUYm6u5VAUg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&type=webp&sig=A98wTV8CXbEFUYm6u5VAUg",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1459,7 +1459,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=jpg&sig=RaAzkWPWF5HRgFlZHjYCkg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=jpg&sig=RaAzkWPWF5HRgFlZHjYCkg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1471,13 +1471,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=webp&sig=u5jpbtgm_qfjrRdUeclMbg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=webp&sig=u5jpbtgm_qfjrRdUeclMbg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=jpg&sig=Unk0ZiaeUvG-ozqYBdzlkw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=jpg&sig=Unk0ZiaeUvG-ozqYBdzlkw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1489,7 +1489,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=webp&sig=hoTtcqnsQhJNcl6NpsHgGQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=webp&sig=hoTtcqnsQhJNcl6NpsHgGQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1501,7 +1501,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&sig=i_1lssVml9VhsyF0zfVgKA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&sig=i_1lssVml9VhsyF0zfVgKA",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1531,7 +1531,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=288&type=webp&sig=vJ2_arsHU8Qq2zOioMTGEQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=288&type=webp&sig=vJ2_arsHU8Qq2zOioMTGEQ",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1549,7 +1549,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=564&type=jpg&sig=qQhW39bV62PlNeGxLh3aPw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=564&type=jpg&sig=qQhW39bV62PlNeGxLh3aPw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1561,13 +1561,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=564&type=webp&sig=A70d_BwEKOppWNoKW6Pbeg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=564&type=webp&sig=A70d_BwEKOppWNoKW6Pbeg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=472&type=jpg&sig=orsswdfq-LiozS4wYSHLBA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=472&type=jpg&sig=orsswdfq-LiozS4wYSHLBA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1579,7 +1579,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=472&type=webp&sig=eACF0E3Bu660xmRghYDypg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=472&type=webp&sig=eACF0E3Bu660xmRghYDypg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1591,7 +1591,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=288&sig=NcLkS10x9emq6ZZNOwKpEQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213250491_295413650.jpg?quality=90&strip=all&w=288&sig=NcLkS10x9emq6ZZNOwKpEQ",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1621,7 +1621,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&type=webp&sig=A98wTV8CXbEFUYm6u5VAUg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&type=webp&sig=A98wTV8CXbEFUYm6u5VAUg",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1639,7 +1639,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=jpg&sig=RaAzkWPWF5HRgFlZHjYCkg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=jpg&sig=RaAzkWPWF5HRgFlZHjYCkg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1651,13 +1651,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=webp&sig=u5jpbtgm_qfjrRdUeclMbg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=564&type=webp&sig=u5jpbtgm_qfjrRdUeclMbg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=jpg&sig=Unk0ZiaeUvG-ozqYBdzlkw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=jpg&sig=Unk0ZiaeUvG-ozqYBdzlkw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1669,7 +1669,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=webp&sig=hoTtcqnsQhJNcl6NpsHgGQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=472&type=webp&sig=hoTtcqnsQhJNcl6NpsHgGQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1681,7 +1681,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&sig=i_1lssVml9VhsyF0zfVgKA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213245162_295412240.jpg?quality=90&strip=all&w=288&sig=i_1lssVml9VhsyF0zfVgKA",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1711,7 +1711,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=288&type=webp&sig=7B41b7_PV5NZh2A4M3-Udw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=288&type=webp&sig=7B41b7_PV5NZh2A4M3-Udw",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1729,7 +1729,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=564&type=jpg&sig=oo2qUk9ZHihPEUDVCClKNA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=564&type=jpg&sig=oo2qUk9ZHihPEUDVCClKNA",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1741,13 +1741,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=564&type=webp&sig=cZW7TNlQXEkhAoxQuKmGbg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=564&type=webp&sig=cZW7TNlQXEkhAoxQuKmGbg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=472&type=jpg&sig=QB4kSoL0vh281_An4fUZfQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=472&type=jpg&sig=QB4kSoL0vh281_An4fUZfQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1759,7 +1759,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=472&type=webp&sig=IrqJv2ERyGOpGTCThNtgWA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=472&type=webp&sig=IrqJv2ERyGOpGTCThNtgWA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1771,7 +1771,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=288&sig=99CeuQO66JdSnLWGDOAEDA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/2213211184_295405314.jpg?quality=90&strip=all&w=288&sig=99CeuQO66JdSnLWGDOAEDA",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1801,7 +1801,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=288&type=webp&sig=tp9696jIuHfhjTj1K9aaVQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=288&type=webp&sig=tp9696jIuHfhjTj1K9aaVQ",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1819,7 +1819,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=564&type=jpg&sig=9LGPusijfNSZiJogiICUyQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=564&type=jpg&sig=9LGPusijfNSZiJogiICUyQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1831,13 +1831,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=564&type=webp&sig=PeLjslsb03Cu54h_PP29Sg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=564&type=webp&sig=PeLjslsb03Cu54h_PP29Sg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=472&type=jpg&sig=Zty_r0OFyw78ZxFMIS8IpA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=472&type=jpg&sig=Zty_r0OFyw78ZxFMIS8IpA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1849,7 +1849,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=472&type=webp&sig=CK_U_ZuAYGGuvWZSgD_bjQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=472&type=webp&sig=CK_U_ZuAYGGuvWZSgD_bjQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1861,7 +1861,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=288&sig=VPlD2Lb9z0nGMuBz0RQYQQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295409116.jpg?quality=90&strip=all&w=288&sig=VPlD2Lb9z0nGMuBz0RQYQQ",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1891,7 +1891,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=288&type=webp&sig=d6Ms61AuEX8pmjccqq_5zw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=288&type=webp&sig=d6Ms61AuEX8pmjccqq_5zw",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1909,7 +1909,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=564&type=jpg&sig=V1guXnZDVOsqUlZAHOY5wg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=564&type=jpg&sig=V1guXnZDVOsqUlZAHOY5wg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -1921,13 +1921,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=564&type=webp&sig=mYZbsELDnPZjvX_w6CfW1Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=564&type=webp&sig=mYZbsELDnPZjvX_w6CfW1Q",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=472&type=jpg&sig=DP9jDdFm0imUY8zXTW4w9g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=472&type=jpg&sig=DP9jDdFm0imUY8zXTW4w9g",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -1939,7 +1939,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=472&type=webp&sig=djwyUUb2PPKya43xH9i4XQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=472&type=webp&sig=djwyUUb2PPKya43xH9i4XQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -1951,7 +1951,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=288&sig=ITvKCCUe_PbTma5z7Pq2tA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/pakistan-india_295411658.jpg?quality=90&strip=all&w=288&sig=ITvKCCUe_PbTma5z7Pq2tA",
             "query_width": null,
             "size": {
               "width": 1000,
@@ -1981,7 +1981,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=288&type=webp&sig=zMKYRkDvO5Yy-oJNBxXHBQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=288&type=webp&sig=zMKYRkDvO5Yy-oJNBxXHBQ",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -1999,7 +1999,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=564&type=jpg&sig=5U3hR2SkJkxxaNv8U3Gwrw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=564&type=jpg&sig=5U3hR2SkJkxxaNv8U3Gwrw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -2011,13 +2011,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=564&type=webp&sig=ZOSlVcdDWSCjSqId_iLVJA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=564&type=webp&sig=ZOSlVcdDWSCjSqId_iLVJA",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=472&type=jpg&sig=0D90j8APlvphX4HK0_y82g,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=472&type=jpg&sig=0D90j8APlvphX4HK0_y82g",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -2029,7 +2029,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=472&type=webp&sig=V4WX5tclUVmRo74b_yKYEw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=472&type=webp&sig=V4WX5tclUVmRo74b_yKYEw",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -2041,7 +2041,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=288&sig=jcIvC2NJ_DYJEFQhgY_YRw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/nationalpost/wp-content/uploads/2025/05/india-pakistan_295411630.jpg?quality=90&strip=all&w=288&sig=jcIvC2NJ_DYJEFQhgY_YRw",
             "query_width": null,
             "size": {
               "width": 1000,

--- a/tests/resources/parser/test_data/ca/OttawaCitizen.json
+++ b/tests/resources/parser/test_data/ca/OttawaCitizen.json
@@ -58,7 +58,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=YhbnYzVWatAK9c7uZMNx0Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=YhbnYzVWatAK9c7uZMNx0Q",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -76,7 +76,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=zWsinTpMKcBBWlgM-65tZQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=zWsinTpMKcBBWlgM-65tZQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -88,13 +88,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=Tm00p50SFYXoUhlpeZHszg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=Tm00p50SFYXoUhlpeZHszg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=pf5PZkGhgQk6kO356VeJPQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=pf5PZkGhgQk6kO356VeJPQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -106,7 +106,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=6q2l7gZZ58JaENluH465qQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=6q2l7gZZ58JaENluH465qQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -118,7 +118,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=288&h=216&sig=uvGhtpHAm5qdypXRp8Wttg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/132727_75423266-1.jpg?quality=90&strip=all&w=288&h=216&sig=uvGhtpHAm5qdypXRp8Wttg",
             "query_width": null,
             "size": {
               "width": 1200,
@@ -148,7 +148,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=288&type=webp&sig=9TkFG4Js2DDBJJoI2gXHCg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=288&type=webp&sig=9TkFG4Js2DDBJJoI2gXHCg",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -166,7 +166,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=564&type=jpg&sig=ELHn4fYC-q8wZm9xbKZbuQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=564&type=jpg&sig=ELHn4fYC-q8wZm9xbKZbuQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -178,13 +178,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=564&type=webp&sig=jMnlbL5Oh-XePxhcN7Jbng,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=564&type=webp&sig=jMnlbL5Oh-XePxhcN7Jbng",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=472&type=jpg&sig=FXUcjoie7Afx4Oi1XhyIww,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=472&type=jpg&sig=FXUcjoie7Afx4Oi1XhyIww",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -196,7 +196,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=472&type=webp&sig=5qHReHKzw4q6U1qrWmHYKg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=472&type=webp&sig=5qHReHKzw4q6U1qrWmHYKg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -208,7 +208,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=288&sig=GXMOxEBgBvOvHnosLBUbPg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/ottawacitizen/wp-content/uploads/2026/05/building-large-tear_303285778-1.png?quality=90&strip=all&w=288&sig=GXMOxEBgBvOvHnosLBUbPg",
             "query_width": null,
             "size": {
               "width": 1200,

--- a/tests/resources/parser/test_data/ca/TheProvince.json
+++ b/tests/resources/parser/test_data/ca/TheProvince.json
@@ -55,7 +55,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=izOdREqlPqZuW5NC2IM-Nw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=288&h=216&type=webp&sig=izOdREqlPqZuW5NC2IM-Nw",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -73,7 +73,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=oxDqzGbmGtyyChgUJwam2w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=564&h=423&type=jpg&sig=oxDqzGbmGtyyChgUJwam2w",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -85,13 +85,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=n76AqSbKWx2bN9_rX6PjZQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=564&h=423&type=webp&sig=n76AqSbKWx2bN9_rX6PjZQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=rB4LzmVqadr5Xy6JU31YCA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=472&h=354&type=jpg&sig=rB4LzmVqadr5Xy6JU31YCA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -103,7 +103,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=LTFqe6TF2TH9hCByQIYE3Q,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=472&h=354&type=webp&sig=LTFqe6TF2TH9hCByQIYE3Q",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -115,7 +115,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=288&h=216&sig=MkYkvgwf9E12UHmLZ2fJow,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/gettyimages-905866588_280442772.jpg?quality=90&strip=all&w=288&h=216&sig=MkYkvgwf9E12UHmLZ2fJow",
             "query_width": null,
             "size": {
               "width": 1200,
@@ -145,7 +145,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=288&type=webp&sig=GzuNcvN_Rd4ytA4lw_MorA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=288&type=webp&sig=GzuNcvN_Rd4ytA4lw_MorA",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -163,7 +163,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=564&type=jpg&sig=jVEyhIqpvMM2V-wTQ5hVKg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=564&type=jpg&sig=jVEyhIqpvMM2V-wTQ5hVKg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -175,13 +175,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=564&type=webp&sig=h5Tq2DZWfK_Jk4Xr-A76Rg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=564&type=webp&sig=h5Tq2DZWfK_Jk4Xr-A76Rg",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=472&type=jpg&sig=LRsKRlszQIWbT9-OArpvlA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=472&type=jpg&sig=LRsKRlszQIWbT9-OArpvlA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -193,7 +193,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=472&type=webp&sig=0HOdZ3uzr8OFxvjvklUqqA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=472&type=webp&sig=0HOdZ3uzr8OFxvjvklUqqA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -205,7 +205,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=288&sig=F2dsXo2HOTLQdbNSDreG4A,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/lavieilleferme_rose_303414085.jpg?quality=90&strip=all&w=288&sig=F2dsXo2HOTLQdbNSDreG4A",
             "query_width": null,
             "size": {
               "width": 508,
@@ -232,7 +232,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=288&type=webp&sig=JK_6UxkkssWTbLdAPYQPkA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=288&type=webp&sig=JK_6UxkkssWTbLdAPYQPkA",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -250,7 +250,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=564&type=jpg&sig=rb7XLZ_jaZpbhf8FG2NfKw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=564&type=jpg&sig=rb7XLZ_jaZpbhf8FG2NfKw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -262,13 +262,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=564&type=webp&sig=m6O3gY4bp0Rj5ETCptiMpQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=564&type=webp&sig=m6O3gY4bp0Rj5ETCptiMpQ",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=472&type=jpg&sig=uqaJRQTVjVtrDkRzDW22rA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=472&type=jpg&sig=uqaJRQTVjVtrDkRzDW22rA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -280,7 +280,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=472&type=webp&sig=XEuJe-KnPJM4T3InOUrlZQ,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=472&type=webp&sig=XEuJe-KnPJM4T3InOUrlZQ",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -292,7 +292,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=288&sig=XUqAGhoN5dZ_fgF7m-yLew,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/nocompromise_orangecarricante_303414081.jpg?quality=90&strip=all&w=288&sig=XUqAGhoN5dZ_fgF7m-yLew",
             "query_width": null,
             "size": {
               "width": 537,
@@ -319,7 +319,7 @@
       {
         "versions": [
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=288&type=webp&sig=pylJQj8j2nh_KrL7HSV1Ew,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=288&type=webp&sig=pylJQj8j2nh_KrL7HSV1Ew",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/webp"
@@ -337,7 +337,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=564&type=jpg&sig=ARMzSIJipLOmwithgK5DWw,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=564&type=jpg&sig=ARMzSIJipLOmwithgK5DWw",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/jpeg"
@@ -349,13 +349,13 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=564&type=webp&sig=8PcQdmDcOscztOsrcJXH_w,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=564&type=webp&sig=8PcQdmDcOscztOsrcJXH_w",
             "query_width": "min-width:1200",
             "size": null,
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=472&type=jpg&sig=IlDHtilnB3uE9_iCCK-EHg,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=472&type=jpg&sig=IlDHtilnB3uE9_iCCK-EHg",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/jpeg"
@@ -367,7 +367,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=472&type=webp&sig=La665T4nO_wWMRuw2TyCiA,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=472&type=webp&sig=La665T4nO_wWMRuw2TyCiA",
             "query_width": "min-width:768",
             "size": null,
             "type": "image/webp"
@@ -379,7 +379,7 @@
             "type": "image/webp"
           },
           {
-            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=288&sig=4Et-oSu48z4n6LVzgWuC4A,",
+            "url": "https://smartcdn.gprod.postmedia.digital/theprovince/wp-content/uploads/2026/05/dillons_whitecranberrycosmopolitan_303414083.jpg?quality=90&strip=all&w=288&sig=4Et-oSu48z4n6LVzgWuC4A",
             "query_width": null,
             "size": {
               "width": 700,

--- a/tests/resources/parser/test_data/de/DieZeit.json
+++ b/tests/resources/parser/test_data/de/DieZeit.json
@@ -30,7 +30,7 @@
       {
         "versions": [
           {
-            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__360x202__mobile,",
+            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__360x202__mobile",
             "query_width": "max-width:360",
             "size": {
               "width": 360,
@@ -39,7 +39,7 @@
             "type": null
           },
           {
-            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__480x270__mobile,",
+            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__480x270__mobile",
             "query_width": "max-width:480",
             "size": {
               "width": 480,
@@ -48,7 +48,7 @@
             "type": null
           },
           {
-            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__660x371__mobile,",
+            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__660x371__mobile",
             "query_width": "max-width:660",
             "size": {
               "width": 660,
@@ -66,7 +66,7 @@
             "type": null
           },
           {
-            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__767x431__mobile,",
+            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__767x431__mobile",
             "query_width": "max-width:767",
             "size": {
               "width": 767,
@@ -75,7 +75,7 @@
             "type": null
           },
           {
-            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__900x506__desktop,",
+            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__900x506__desktop",
             "query_width": "max-width:900",
             "size": {
               "width": 900,
@@ -102,7 +102,7 @@
             "type": null
           },
           {
-            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__1000x562__desktop,",
+            "url": "https://img.zeit.de/news/2023-04/28/nach-massenschlaegerei-real-star-llull-entschuldigt-sich-image-group/wide__1000x562__desktop",
             "query_width": "min-width:900",
             "size": {
               "width": 1000,

--- a/tests/resources/parser/test_data/us/FoxNews.json
+++ b/tests/resources/parser/test_data/us/FoxNews.json
@@ -46,7 +46,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/672/378/CCPv2.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/672/378/CCPv2.jpg?ve=1&tl=1",
             "query_width": "max-width:1023",
             "size": null,
             "type": "image/jpeg"
@@ -58,13 +58,13 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/931/523/CCPv2.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/931/523/CCPv2.jpg?ve=1&tl=1",
             "query_width": "max-width:1279",
             "size": null,
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/343/192/CCPv2.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/343/192/CCPv2.jpg?ve=1&tl=1",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/jpeg"
@@ -82,7 +82,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/720/405/CCPv2.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/04/720/405/CCPv2.jpg?ve=1&tl=1",
             "query_width": "min-width:1280",
             "size": null,
             "type": "image/jpeg"
@@ -112,7 +112,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/672/378/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/672/378/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1",
             "query_width": "max-width:1023",
             "size": null,
             "type": "image/jpeg"
@@ -124,13 +124,13 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/931/523/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/931/523/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1",
             "query_width": "max-width:1279",
             "size": null,
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/343/192/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/343/192/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/jpeg"
@@ -148,7 +148,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/720/405/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/01/720/405/FBI-Director-Christopher-Wray-Tyre-Nichols-Case.jpg?ve=1&tl=1",
             "query_width": "min-width:1280",
             "size": null,
             "type": "image/jpeg"
@@ -177,7 +177,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/672/378/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/672/378/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1",
             "query_width": "max-width:1023",
             "size": null,
             "type": "image/jpeg"
@@ -189,13 +189,13 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/931/523/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/931/523/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1",
             "query_width": "max-width:1279",
             "size": null,
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/343/192/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/343/192/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1",
             "query_width": "max-width:767",
             "size": null,
             "type": "image/jpeg"
@@ -213,7 +213,7 @@
             "type": "image/jpeg"
           },
           {
-            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/720/405/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1,",
+            "url": "https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2023/03/720/405/Chinese-President-Xi-Jinping-1.jpg?ve=1&tl=1",
             "query_width": "min-width:1280",
             "size": null,
             "type": "image/jpeg"


### PR DESCRIPTION
`parse_srcset` matched a candidate's url as `\S+`, so a candidate written without a descriptor swallowed the comma that separates it from the next one:

```
srcset="a-320x214.jpg, a-640x428.jpg 2x"   ->   1x: "a-320x214.jpg,"
```

The url then 404s, and `ImageVersion._parse_type` reads the extension as `jpg,` and yields `type: null`.

The naive fix (`[^\s,]+`) would truncate urls carrying commas of their own — CDN transformations like `.../w_300,h_200/img.jpg`, which this repo already crawls (Nine News, NZZ). The pattern now strips only commas that *terminate* a url, matching the HTML srcset grammar. Two extras fall out: repeated separators (`a.jpg,, b.jpg 2x`) and whitespace ahead of the comma (`a.jpg 1x , b.jpg 2x`, previously yielding a bogus url of just `","`).

210 urls across 8 fixtures were storing the broken value; regenerated with `python -m scripts.generate_parser_test_files -oj`, every change a pure trailing-comma strip. Found while reviewing #978, whose new `RuhrNachrichten` fixture hits the same bug — it needs the same `-oj` regeneration once this lands.